### PR TITLE
PDX-328: release issues 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "name": "@provartesting/provardx-cli",
   "description": "A plugin for the Salesforce CLI to orchestrate testing activities and report quality metrics to Provar Manager",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "license": "BSD-3-Clause",
+  "plugins": [
+    "@provartesting/provardx-plugins-automation",
+    "@provartesting/provardx-plugins-manager"
+  ],
   "dependencies": {
     "@oclif/core": "^3.26.2",
     "@salesforce/core": "^6.5.1",
@@ -94,7 +98,6 @@
     "docs": "sf-docs",
     "format": "wireit",
     "lint": "wireit",
-    "postinstall": "node ./scripts/postInstall.js",
     "postpack": "shx rm -f oclif.manifest.json",
     "prepack": "sf-prepack",
     "test": "wireit",

--- a/scripts/postInstall.js
+++ b/scripts/postInstall.js
@@ -7,14 +7,16 @@ console.log('starting postInstall');
 
 execSync(commandToInstallAutomationPlugin, (error) => {
   if (error) {
-    console.error(`Error: ${error.message}`);
+    const errormessage = error.message ? error.message.toString('utf-8') : 'Unknown error';
+    console.error(`Error: ${errormessage}`);
     return;
   }
 });
 
 execSync(commandToInstallManagerPlugin, (error) => {
   if (error) {
-    console.error(`Error: ${error.message}`);
+    const errormessage = error.message ? error.message.toString('utf-8') : 'Unknown error';
+    console.error(`Error: ${errormessage}`);
     return;
   }
 });


### PR DESCRIPTION
adding plugins attribute inside package.json to auto install plugins along with the parent one
as done here in SF cli
https://github.com/salesforcecli/cli/blob/main/package.json#L48
have not removed postinstall.js , because we are not sure about this