### PR TITLE
PDX-391: Updated nuts for testoutputLevel and pluginOutputLevel that is added in boilerPlate 

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "postpack": "shx rm -f oclif.manifest.json",
     "prepack": "sf-prepack",
     "test": "wireit",
-    "test:nuts": "nyc mocha \"**/*setup.nut.ts\" \"**/*generate.nut.ts\" \"**/*permission.nut.ts\" \"**/*load.nut.ts\" \"**/*validate.nut.ts\" \"**/*get.nut.ts\" --slow 4500 --timeout 600000 --reporter mochawesome",
+    "test:nuts": "nyc mocha  \"**/*generate.nut.ts\" \"**/*permission.nut.ts\" \"**/*load.nut.ts\" \"**/*validate.nut.ts\" \"**/*set.nut.ts\" \"**/*get.nut.ts\" --slow 4500 --timeout 600000 --reporter mochawesome",
     "test:only": "wireit",
     "version": "oclif readme"
   },

--- a/test/assertion/loadConstants.ts
+++ b/test/assertion/loadConstants.ts
@@ -7,7 +7,7 @@
 
 export const loadSuccessMessage = 'The properties file was loaded successfully.\n';
 export const multipleErrors =
-  "Error (1): [MISSING_PROPERTY] The property 'projectPath' is missing. [INVALID_VALUES] The properties 'resultsPathDisposition', 'stopOnError', 'metadata.metadataLevel', 'environment.webBrowser' values are not valid.\n\n";
+  "Error (1): [MISSING_PROPERTY] The property 'projectPath' is missing. [INVALID_VALUES] The properties 'resultsPathDisposition', 'testOutputLevel', 'pluginOutputlevel', 'stopOnError', 'metadata.metadataLevel', 'environment.webBrowser' values are not valid.\n\n";
 
 export const invalidValuesError =
   "Error (1): [INVALID_VALUES] The properties 'provarHome', 'projectPath', 'resultsPath', 'metadata.metadataLevel', 'metadata.cachePath', 'environment.webBrowser', 'environment.webBrowserConfig', 'environment.webBrowserProviderName', 'environment.webBrowserDeviceName' values are not valid.\n\n";
@@ -46,7 +46,7 @@ export const multipleJsonErrors = {
       {
         code: 'INVALID_VALUES',
         message:
-          "The properties 'resultsPathDisposition', 'stopOnError', 'metadata.metadataLevel', 'environment.webBrowser' values are not valid.",
+          "The properties 'resultsPathDisposition', 'testOutputLevel', 'pluginOutputlevel', 'stopOnError', 'metadata.metadataLevel', 'environment.webBrowser' values are not valid.",
       },
     ],
   },

--- a/test/assertion/validateConstants.ts
+++ b/test/assertion/validateConstants.ts
@@ -16,10 +16,10 @@ export const invalidValueError =
   "Error (1): [INVALID_VALUE] The property 'resultsPathDisposition' value is not valid.\n\n";
 
 export const invalidValuesError =
-  "Error (1): [INVALID_VALUES] The properties 'resultsPathDisposition', 'stopOnError', 'metadata.metadataLevel', 'environment.webBrowser' values are not valid.\n\n";
+  "Error (1): [INVALID_VALUES] The properties 'resultsPathDisposition', 'testOutputLevel', 'pluginOutputlevel', 'stopOnError', 'metadata.metadataLevel', 'environment.webBrowser' values are not valid.\n\n";
 
 export const multipleErrors =
-  "Error (1): [MISSING_PROPERTY] The property 'provarHome' is missing. [INVALID_VALUES] The properties 'resultsPathDisposition', 'stopOnError', 'metadata.metadataLevel', 'environment.webBrowser' values are not valid.\n\n";
+  "Error (1): [MISSING_PROPERTY] The property 'provarHome' is missing. [INVALID_VALUES] The properties 'resultsPathDisposition', 'testOutputLevel', 'pluginOutputlevel', 'stopOnError', 'metadata.metadataLevel', 'environment.webBrowser' values are not valid.\n\n";
 
 export const validateSuccessJson = {
   status: 0,
@@ -108,7 +108,7 @@ export const invalidValuesJsonError = {
       {
         code: 'INVALID_VALUES',
         message:
-          "The properties 'resultsPathDisposition', 'stopOnError', 'metadata.metadataLevel', 'environment.webBrowser' values are not valid.",
+          "The properties 'resultsPathDisposition', 'testOutputLevel', 'pluginOutputlevel', 'stopOnError', 'metadata.metadataLevel', 'environment.webBrowser' values are not valid.",
       },
     ],
   },
@@ -127,7 +127,7 @@ export const multipleJsonErrors = {
       {
         code: 'INVALID_VALUES',
         message:
-          "The properties 'resultsPathDisposition', 'stopOnError', 'metadata.metadataLevel', 'environment.webBrowser' values are not valid.",
+          "The properties 'resultsPathDisposition', 'testOutputLevel', 'pluginOutputlevel', 'stopOnError', 'metadata.metadataLevel', 'environment.webBrowser' values are not valid.",
       },
     ],
   },

--- a/test/commands/provar/automation/config/get.nut.ts
+++ b/test/commands/provar/automation/config/get.nut.ts
@@ -151,6 +151,19 @@ describe('sf provar config get NUTs', () => {
     ).shellOutput;
     expect(getOutput.stdout).to.deep.equal('\n');
   });
+  it('value should be returned for testOutputLevel property', () => {
+    const getOutput = execCmd<SfProvarCommandResult>(
+      `${commandConstants.SF_PROVAR_AUTOMATION_CONFIG_GET_COMMAND} testOutputLevel`
+    ).shellOutput;
+    expect(getOutput.stdout).to.deep.equal('BASIC\n');
+  });
+
+  it('value should be returned for pluginOutputlevel property', () => {
+    const getOutput = execCmd<SfProvarCommandResult>(
+      `${commandConstants.SF_PROVAR_AUTOMATION_CONFIG_GET_COMMAND} pluginOutputlevel`
+    ).shellOutput;
+    expect(getOutput.stdout).to.deep.equal('WARNING\n');
+  });
 
   it('value should be returned for resultsPathDisposition property in json format', () => {
     const getOutput = execCmd<SfProvarCommandResult>(
@@ -158,6 +171,14 @@ describe('sf provar config get NUTs', () => {
     ).jsonOutput;
     expect(getOutput?.result.success).to.deep.equal(true);
     expect(getOutput?.result.value).to.deep.equal('Increment');
+  });
+
+  it('value should be returned for lightningMode property in json format', () => {
+    const getOutput = execCmd<SfProvarCommandResult>(
+      `${commandConstants.SF_PROVAR_AUTOMATION_CONFIG_GET_COMMAND} lightningMode --json`
+    ).jsonOutput;
+    expect(getOutput?.result.success).to.deep.equal(true);
+    expect(getOutput?.result.value).to.deep.equal(true);
   });
 
   it('Value should be returned successfully for metdata object', () => {
@@ -204,6 +225,13 @@ describe('sf provar config get NUTs', () => {
       `${commandConstants.SF_PROVAR_AUTOMATION_CONFIG_GET_COMMAND} testprojectSecrets`
     ).shellOutput;
     expect(getOutput.stdout).to.deep.equal('${PROVAR_TEST_PROJECT_SECRETS}\n');
+  });
+
+  it('Value should be returned successfully for connectionRefreshType property', () => {
+    const getOutput = execCmd<SfProvarCommandResult>(
+      `${commandConstants.SF_PROVAR_AUTOMATION_CONFIG_GET_COMMAND} connectionRefreshType`
+    ).shellOutput;
+    expect(getOutput.stdout).to.deep.equal('Reload\n');
   });
 
   it('value should be returned for new added property', () => {


### PR DESCRIPTION
PDX-391: Updated nuts for testoutputLevel and pluginOutputLevel that is added in boilerplate 
RCA: testoutputLevel and pluginOutputLevel are added in boilerplate 
Fix: NUTs are update and added checks for testoutputLevel and pluginOutputLeve