### PR TITLE
PDX-453: make 4 space from 3 while editing the json files in any case

### DIFF
--- a/src/commands/provar/automation/config/set.ts
+++ b/src/commands/provar/automation/config/set.ts
@@ -68,7 +68,7 @@ export default class SfProvarConfigSet extends SfCommand<SfProvarCommandResult> 
         }
       }
       if (this.errorHandler.getErrors().length == 0) {
-        fileSystem.writeFileSync(propertiesFilePath, JSON.stringify(propertyFileContent, null, 3));
+        fileSystem.writeFileSync(propertiesFilePath, JSON.stringify(propertyFileContent, null, 4));
       }
     } catch (err: any) {
       if (err.name === 'InvalidArgumentFormatError') {

--- a/src/commands/provar/config/set.ts
+++ b/src/commands/provar/config/set.ts
@@ -81,7 +81,7 @@ export default class SfProvarConfigSet extends SfCommand<SfProvarCommandResult> 
         }
       }
       if (this.errorHandler.getErrors().length == 0) {
-        fileSystem.writeFileSync(propertiesFilePath, JSON.stringify(propertyFileContent, null, 3));
+        fileSystem.writeFileSync(propertiesFilePath, JSON.stringify(propertyFileContent, null, 4));
       }
     } catch (err: any) {
       if (err.name === 'InvalidArgumentFormatError') {


### PR DESCRIPTION
make 4 space from 3 while editing the json files in any case after setting the required attribute for set commands.
No changes in NUTs required as we are only getting the set values and asserting the values in NUTs and not validating the whole JSON