### PR TITLE
fix: improve oclif topic descriptions and fix malformed subtopics nes…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@modelcontextprotocol/sdk": "^1.8.0",
     "@oclif/core": "^3.26.2",
     "@provartesting/provardx-plugins-automation": "1.2.2-dev.0",
-    "@provartesting/provardx-plugins-manager": "1.3.2-dev.0",
+    "@provartesting/provardx-plugins-manager": "1.3.2-dev.1",
     "@provartesting/provardx-plugins-utils": "1.3.2-dev.0",
     "@salesforce/core": "^6.5.1",
     "@salesforce/kit": "^3.0.15",
@@ -70,11 +70,22 @@
           "mcp": {
             "description": "Commands to start and manage the Provar MCP server."
           },
+          "config": {
+            "description": "Commands to manage ProvarDX property configuration files."
+          },
+          "manager": {
+            "description": "Commands to connect and interact with Provar Quality Hub."
+          },
           "quality-hub": {
             "description": "Commands to connect and interact with Provar Quality Hub.",
             "subtopics": {
               "test": {
-                "description": "Operations related to Quality Hub test runs."
+                "description": "Operations related to Quality Hub test runs.",
+                "subtopics": {
+                  "run": {
+                    "description": "Commands to launch, monitor, abort, and report on Quality Hub test runs."
+                  }
+                }
               },
               "testcase": {
                 "description": "Operations related to Quality Hub test cases."
@@ -82,21 +93,19 @@
             }
           },
           "automation": {
-            "description": "These commands are used to interact with Provar Automation.",
+            "description": "Commands to interact with Provar Automation.",
             "subtopics": {
               "config": {
-                "description": "commands to generate and manipulate provardx-properties file."
+                "description": "Commands to generate and manage the provardx-properties configuration file."
               },
-              "subtopics": {
-                "metadata": {
-                  "description": "commands to download metadata for required connections."
-                }
+              "metadata": {
+                "description": "Commands to download required metadata for Salesforce connections."
               },
               "test": {
-                "description": "Operations related to test run."
+                "description": "Commands to execute and manage Provar Automation test runs."
               },
               "project": {
-                "description": "Compile the project."
+                "description": "Commands to compile and manage Provar Automation projects."
               }
             }
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,10 +1859,10 @@
     axios "^1.13.5"
     xml-js "^1.6.11"
 
-"@provartesting/provardx-plugins-manager@1.3.2-dev.0":
-  version "1.3.2-dev.0"
-  resolved "https://registry.yarnpkg.com/@provartesting/provardx-plugins-manager/-/provardx-plugins-manager-1.3.2-dev.0.tgz#43044169f03afe5cd2f206dfe969ef46083ee498"
-  integrity sha512-Wg1icRKHqz/5CbNRl6SwrQGV4YCfc478JsKjWvkAd5yH3jq95YQwCOiaplzBaQvakXTlxgqjxVRQ38BxY7q4UA==
+"@provartesting/provardx-plugins-manager@1.3.2-dev.1":
+  version "1.3.2-dev.1"
+  resolved "https://registry.yarnpkg.com/@provartesting/provardx-plugins-manager/-/provardx-plugins-manager-1.3.2-dev.1.tgz#f41edadb9d3fac2ef40becbbd3a9174d420386b1"
+  integrity sha512-kooH2Cd+NFT7XB6iWL7AP21K1oT2BF4uwjMSRxq+4p9kLOIUEfPvlTVTBJfh/lxDt124SJQl5hvRKy8ANp35qw==
   dependencies:
     "@oclif/core" "^3.26.2"
     "@provartesting/provardx-plugins-utils" "1.3.1"


### PR DESCRIPTION
…ting

- Add config and manager subtopic overrides with proper descriptions
- Fix automation.subtopics.subtopics.metadata nesting bug (was buried one level too deep)
- Update automation topic descriptions to be consistent and capitalized
- Improve quality-hub.test.run subtopic description to cover abort/report
- Override provar config and provar manager topic descriptions which previously showed command-level descriptions