### PR TITLE
fix: MCP security hardening (items 1-10)

### DIFF
--- a/.github/workflows/CI_Execution.yml
+++ b/.github/workflows/CI_Execution.yml
@@ -22,7 +22,7 @@ jobs:
   provardx-ci-execution:
     strategy:
       matrix:
-        os: ${{ fromJSON(inputs.OS && format('[{0}]', inputs.OS) || '["ubuntu-latest"]') }}
+        os: ${{ fromJSON(inputs.OS && format('[{0}]', inputs.OS) || '["ubuntu-latest", "macos-latest"]') }}
         nodeversion: [20]
     runs-on: ${{ matrix.os }}
     steps:
@@ -102,7 +102,6 @@ jobs:
       - name: MCP smoke test
         timeout-minutes: 5
         env:
-          NODE_ENV: test
           PROVAR_DEV_WHITELIST_KEYS: ${{ secrets.PROVAR_DEV_WHITELIST_KEYS }}
         run: node scripts/mcp-smoke.cjs
       - name: Check out Regression repo

--- a/scripts/mcp-smoke.cjs
+++ b/scripts/mcp-smoke.cjs
@@ -30,7 +30,7 @@ const server = spawn('sf', ['provar', 'mcp', 'start', '--allowed-paths', TMP], {
   shell: true,
   env: {
     ...process.env,
-    PROVAR_DEV_WHITELIST_KEYS: process.env.PROVAR_DEV_WHITELIST_KEYS || 'true',
+    PROVAR_DEV_WHITELIST_KEYS: process.env.PROVAR_DEV_WHITELIST_KEYS || '',
   },
 });
 

--- a/src/mcp/licensing/algasClient.ts
+++ b/src/mcp/licensing/algasClient.ts
@@ -127,14 +127,22 @@ export async function validateKeyWithAlgas(licenseKey: string): Promise<AlgasRes
 
     // 401 means the Cognito token was rotated mid-session — clear the module-level cache
     // and retry exactly once with a fresh token before surfacing an error.
+    // A new AbortController is created for the retry: the original controller's timer
+    // may have partially elapsed during the first request, leaving insufficient time.
     if (res.status === 401) {
       cachedToken = null;
       tokenExpiresAt = 0;
-      const refreshedToken = await getCognitoToken();
-      res = await fetch(`${TAG_BASE_URL}/${encodeURIComponent(licenseKey)}`, {
-        headers: { Authorization: `Bearer ${refreshedToken}` },
-        signal: controller.signal,
-      });
+      const retryController = new AbortController();
+      const retryTimeout = setTimeout(() => retryController.abort(), TIMEOUT_MS);
+      try {
+        const refreshedToken = await getCognitoToken();
+        res = await fetch(`${TAG_BASE_URL}/${encodeURIComponent(licenseKey)}`, {
+          headers: { Authorization: `Bearer ${refreshedToken}` },
+          signal: retryController.signal,
+        });
+      } finally {
+        clearTimeout(retryTimeout);
+      }
     }
 
     if (res.status === 404) {

--- a/src/mcp/licensing/ideDetection.ts
+++ b/src/mcp/licensing/ideDetection.ts
@@ -14,35 +14,12 @@
  * - licenseStatus — Activated | NotActivated | Expired | Invalid | QuotaReached
  * - licenseType — Fixed Seat | Floating | Trial | None
  * - lastOnlineAvailabilityCheckUtc — epoch ms of last ALGAS check by the IDE
- * - licenseKey — AES-128-ECB encrypted with key "provarautomation", Base64-encoded
- *
- * The licenseKey field is AES-128-ECB encrypted (LicenseSupport.KEY = "provarautomation").
- * We decrypt it to allow cross-referencing an explicitly supplied --license-key against
- * the IDE's already-validated license state without re-calling the licensing API.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { createDecipheriv } from 'node:crypto';
 import type { LicenseType } from './licenseCache.js';
-
-/** AES-128-ECB key used by Provar IDE to encrypt the licenseKey field. */
-const AES_KEY = Buffer.from('provarautomation'); // 16 bytes ASCII
-
-/**
- * Decrypt an AES-128-ECB + PKCS5 encrypted, Base64-encoded licenseKey field.
- * Returns the plaintext string, or null if decryption fails (wrong key / corrupt).
- */
-function decryptLicenseKeyField(encryptedBase64: string): string | null {
-  try {
-    const decipher = createDecipheriv('aes-128-ecb', AES_KEY, null);
-    const buf = Buffer.from(encryptedBase64, 'base64');
-    return Buffer.concat([decipher.update(buf), decipher.final()]).toString('utf-8');
-  } catch {
-    return null;
-  }
-}
 
 /** Mirrors License4J's DEFAULT_LICENSE_FOLDER_PATH + PROVAR_USER_HOME. */
 function provarLicensesDir(): string {
@@ -142,53 +119,3 @@ export function findActivatedIdeLicense(): IdeLicenseState | null {
   return activated.sort((a, b) => b.lastOnlineCheckMs - a.lastOnlineCheckMs)[0];
 }
 
-/**
- * Search all IDE .properties files for one whose decrypted licenseKey matches
- * the supplied raw key string.
- *
- * Used to cross-reference an explicit --license-key against the IDE's already-
- * validated activation state without making a fresh API call.
- *
- * Returns the matching IdeLicenseState (which may have activated=false if the
- * IDE recorded the key but it isn't currently activated), or null when no file
- * decrypts to the given key.
- */
-export function findLicenseByDecryptedKey(rawKey: string): IdeLicenseState | null {
-  const dir = provarLicensesDir();
-  if (!fs.existsSync(dir)) return null;
-
-  let entries: fs.Dirent[];
-  try {
-    entries = fs.readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return null;
-  }
-
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith('.properties')) continue;
-    try {
-      const content = fs.readFileSync(path.join(dir, entry.name), 'utf-8');
-      const props = parseProperties(content);
-
-      const encryptedKey = props.get('licenseKey');
-      if (!encryptedKey) continue;
-
-      const decrypted = decryptLicenseKeyField(encryptedKey);
-      if (decrypted !== rawKey) continue;
-
-      const licenseStatus = props.get('licenseStatus') ?? '';
-      const licenseType = parseLicenseType(props.get('licenseType') ?? '');
-      const lastCheck = parseInt(props.get('lastOnlineAvailabilityCheckUtc') ?? '0', 10);
-
-      return {
-        name: entry.name.slice(0, -'.properties'.length),
-        licenseType,
-        activated: licenseStatus === 'Activated',
-        lastOnlineCheckMs: isNaN(lastCheck) ? 0 : lastCheck,
-      };
-    } catch {
-      // Unreadable or corrupt file — skip
-    }
-  }
-  return null;
-}

--- a/src/mcp/licensing/licenseCache.ts
+++ b/src/mcp/licensing/licenseCache.ts
@@ -78,7 +78,7 @@ export function writeCacheEntry(entry: CacheEntry): void {
       }
     }
     cache[entry.keyHash] = entry;
-    fs.writeFileSync(file, JSON.stringify(cache, null, 2), 'utf-8');
+    fs.writeFileSync(file, JSON.stringify(cache, null, 2), { encoding: 'utf-8', mode: 0o600 });
   } catch {
     // Cache write failure is non-fatal; validation result still returned to caller.
   }

--- a/src/mcp/licensing/licenseCache.ts
+++ b/src/mcp/licensing/licenseCache.ts
@@ -79,6 +79,11 @@ export function writeCacheEntry(entry: CacheEntry): void {
     }
     cache[entry.keyHash] = entry;
     fs.writeFileSync(file, JSON.stringify(cache, null, 2), { encoding: 'utf-8', mode: 0o600 });
+    try {
+      fs.chmodSync(file, 0o600);
+    } catch {
+      // Best-effort permission hardening; cache write itself already succeeded.
+    }
   } catch {
     // Cache write failure is non-fatal; validation result still returned to caller.
   }

--- a/src/mcp/security/pathPolicy.ts
+++ b/src/mcp/security/pathPolicy.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.md file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import fs from 'node:fs';
 import path from 'node:path';
 
 export class PathPolicyError extends Error {
@@ -24,6 +25,11 @@ export class PathPolicyError extends Error {
  * - PATH_NOT_ALLOWED — resolved path is outside all allowed roots
  *
  * When allowedPaths is empty, all paths are permitted (unrestricted mode).
+ *
+ * Symlinks are resolved via fs.realpathSync so that a symlink inside an allowed
+ * directory pointing to a location outside it cannot bypass containment.
+ * If the path does not yet exist (e.g. an output file to be created), the parent
+ * directory is resolved instead and the basename re-attached.
  */
 export function assertPathAllowed(filePath: string, allowedPaths: string[]): void {
   // Check the original path for `..` segments before any normalization resolves them away
@@ -31,8 +37,30 @@ export function assertPathAllowed(filePath: string, allowedPaths: string[]): voi
   if (rawSegments.some((s) => s === '..')) {
     throw new PathPolicyError('PATH_TRAVERSAL', `Path traversal detected: ${filePath}`);
   }
-  const resolved = path.resolve(filePath);
-  const resolvedAllowed = allowedPaths.map((p) => path.resolve(path.normalize(p)));
+
+  // Resolve symlinks so a symlink inside an allowed dir that points outside cannot bypass
+  // the containment check. Fall back to lexical resolution when the path doesn't exist yet.
+  let resolved: string;
+  try {
+    resolved = fs.realpathSync(filePath);
+  } catch {
+    // Path doesn't exist — resolve the parent (which should exist) to catch symlinks there
+    const parent = path.dirname(path.resolve(filePath));
+    try {
+      resolved = path.join(fs.realpathSync(parent), path.basename(filePath));
+    } catch {
+      resolved = path.resolve(filePath);
+    }
+  }
+
+  const resolvedAllowed = allowedPaths.map((p) => {
+    try {
+      return fs.realpathSync(p);
+    } catch {
+      return path.resolve(path.normalize(p));
+    }
+  });
+
   if (
     resolvedAllowed.length > 0 &&
     !resolvedAllowed.some((base) => resolved === base || resolved.startsWith(base + path.sep))

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -63,7 +63,7 @@ export function createProvarMcpServer(config: ServerConfig): McpServer {
   registerProjectValidateFromPath(server, config);
   registerAllPropertiesTools(server, config);
   registerAllQualityHubTools(server);
-  registerAllAutomationTools(server);
+  registerAllAutomationTools(server, config);
   registerAllDefectTools(server);
   registerAllAntTools(server, config);
   registerAllRcaTools(server);

--- a/src/mcp/tools/antTools.ts
+++ b/src/mcp/tools/antTools.ts
@@ -251,6 +251,15 @@ export function registerAntGenerate(server: McpServer, config: ServerConfig): vo
       });
 
       try {
+        // Validate all path inputs before writing anything — these get embedded in the
+        // generated ANT build.xml and would be accessed by ANT at execution time.
+        assertPathAllowed(input.provar_home, config.allowedPaths);
+        assertPathAllowed(input.project_path, config.allowedPaths);
+        assertPathAllowed(input.results_path, config.allowedPaths);
+        if (input.license_path) assertPathAllowed(input.license_path, config.allowedPaths);
+        if (input.smtp_path) assertPathAllowed(input.smtp_path, config.allowedPaths);
+        if (input.project_cache_path) assertPathAllowed(input.project_cache_path, config.allowedPaths);
+
         const xmlContent = buildAntXml(input);
         const filePath = input.output_path ? path.resolve(input.output_path) : undefined;
         let written = false;
@@ -559,6 +568,7 @@ function escapeXmlAttr(value: string): string {
   return value
     .replace(/&/g, '&amp;')
     .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 }

--- a/src/mcp/tools/automationTools.ts
+++ b/src/mcp/tools/automationTools.ts
@@ -14,6 +14,8 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
 import { sfSpawnHelper } from './sfSpawn.js';
+import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
+import type { ServerConfig } from '../server.js';
 
 // ── SF CLI discovery ──────────────────────────────────────────────────────────
 
@@ -135,7 +137,7 @@ function handleSpawnError(err: unknown, requestId: string, toolName: string): { 
 
 // ── Tool: provar.automation.config.load ──────────────────────────────────────
 
-export function registerAutomationConfigLoad(server: McpServer): void {
+export function registerAutomationConfigLoad(server: McpServer, config: ServerConfig): void {
   server.tool(
     'provar.automation.config.load',
     [
@@ -153,6 +155,7 @@ export function registerAutomationConfigLoad(server: McpServer): void {
       log('info', 'provar.automation.config.load', { requestId, properties_path });
 
       try {
+        assertPathAllowed(properties_path, config.allowedPaths);
         const result = runSfCommand(['provar', 'automation', 'config', 'load', '--properties-file', properties_path], sf_path);
         const response = { requestId, exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr, properties_path };
 
@@ -162,6 +165,9 @@ export function registerAutomationConfigLoad(server: McpServer): void {
 
         return { content: [{ type: 'text' as const, text: JSON.stringify(response) }], structuredContent: response };
       } catch (err) {
+        if (err instanceof PathPolicyError) {
+          return { isError: true as const, content: [{ type: 'text' as const, text: JSON.stringify(makeError(err.code, err.message, requestId, false)) }] };
+        }
         return handleSpawnError(err, requestId, 'provar.automation.config.load');
       }
     }
@@ -458,9 +464,9 @@ export function registerAutomationSetup(server: McpServer): void {
 
 // ── Bulk registration ─────────────────────────────────────────────────────────
 
-export function registerAllAutomationTools(server: McpServer): void {
+export function registerAllAutomationTools(server: McpServer, config: ServerConfig): void {
   registerAutomationSetup(server);
-  registerAutomationConfigLoad(server);
+  registerAutomationConfigLoad(server, config);
   registerAutomationTestRun(server);
   registerAutomationCompile(server);
   registerAutomationMetadataDownload(server);

--- a/src/mcp/tools/automationTools.ts
+++ b/src/mcp/tools/automationTools.ts
@@ -13,9 +13,9 @@ import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
-import { sfSpawnHelper } from './sfSpawn.js';
-import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import type { ServerConfig } from '../server.js';
+import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
+import { sfSpawnHelper } from './sfSpawn.js';
 
 // ── SF CLI discovery ──────────────────────────────────────────────────────────
 

--- a/test/unit/mcp/automationTools.test.ts
+++ b/test/unit/mcp/automationTools.test.ts
@@ -66,7 +66,8 @@ describe('automationTools', () => {
 
     const { registerAllAutomationTools, setSfPathCacheForTesting } = await import('../../../src/mcp/tools/automationTools.js');
     setSfPathCacheForTesting('sf'); // bypass probe spawn; tests control spawnStub directly
-    registerAllAutomationTools(server as unknown as McpServer);
+    // allowedPaths: [] means unrestricted — existing tests use arbitrary paths
+    registerAllAutomationTools(server as unknown as McpServer, { allowedPaths: [] });
   });
 
   afterEach(() => {
@@ -460,6 +461,45 @@ describe('automationTools', () => {
       server.call('provar.automation.config.load', { properties_path: '/proj/props.json', sf_path: '/custom/bin/sf' });
       const [cmd] = spawnStub.firstCall.args as [string, string[]];
       assert.equal(cmd, '/custom/bin/sf');
+    });
+
+    describe('path policy enforcement', () => {
+      let restrictedServer: MockMcpServer;
+      const allowedDir = os.tmpdir();
+
+      beforeEach(async () => {
+        restrictedServer = new MockMcpServer();
+        const { registerAutomationConfigLoad, setSfPathCacheForTesting } = await import('../../../src/mcp/tools/automationTools.js');
+        setSfPathCacheForTesting('sf');
+        registerAutomationConfigLoad(restrictedServer as unknown as McpServer, { allowedPaths: [allowedDir] });
+      });
+
+      it('rejects properties_path outside allowed paths', () => {
+        const result = restrictedServer.call('provar.automation.config.load', {
+          properties_path: '/etc/passwd',
+        });
+        assert.ok(isError(result));
+        assert.equal(parseBody(result).error_code, 'PATH_NOT_ALLOWED');
+        assert.ok(!spawnStub.called, 'sf should not be spawned for a rejected path');
+      });
+
+      it('rejects properties_path with .. traversal', () => {
+        const result = restrictedServer.call('provar.automation.config.load', {
+          properties_path: path.join(allowedDir, '..', 'etc', 'passwd'),
+        });
+        assert.ok(isError(result));
+        assert.equal(parseBody(result).error_code, 'PATH_TRAVERSAL');
+        assert.ok(!spawnStub.called, 'sf should not be spawned for a path traversal');
+      });
+
+      it('allows properties_path within allowed paths', () => {
+        spawnStub.returns(makeSpawnResult('', '', 0));
+        const allowed = path.join(allowedDir, 'provardx-properties.json');
+        const result = restrictedServer.call('provar.automation.config.load', {
+          properties_path: allowed,
+        });
+        assert.ok(!isError(result));
+      });
     });
   });
 

--- a/test/unit/mcp/licensing/licenseValidator.test.ts
+++ b/test/unit/mcp/licensing/licenseValidator.test.ts
@@ -1,7 +1,6 @@
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
-import { createCipheriv } from 'node:crypto';
 import { strict as assert } from 'node:assert';
 import { describe, it, beforeEach, afterEach } from 'mocha';
 import { LicenseError } from '../../../../src/mcp/licensing/licenseError.js';
@@ -18,14 +17,7 @@ import { validateLicense } from '../../../../src/mcp/licensing/licenseValidator.
 import {
   readIdeLicenses,
   findActivatedIdeLicense,
-  findLicenseByDecryptedKey,
 } from '../../../../src/mcp/licensing/ideDetection.js';
-
-/** Encrypt a raw license key with AES-128-ECB + PKCS5 to mimic IDE storage. */
-function encryptKey(rawKey: string): string {
-  const cipher = createCipheriv('aes-128-ecb', Buffer.from('provarautomation'), null);
-  return Buffer.concat([cipher.update(Buffer.from(rawKey, 'utf-8')), cipher.final()]).toString('base64');
-}
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -301,74 +293,6 @@ describe('ideDetection', () => {
     assert.equal(best?.name, 'Recent');
   });
 
-  it('findLicenseByDecryptedKey returns null when no .licenses folder', () => {
-    assert.equal(findLicenseByDecryptedKey('any-key'), null);
-  });
-
-  it('findLicenseByDecryptedKey returns null when no file matches the key', () => {
-    writeLicenseFile('LicA', {
-      licenseKey: encryptKey('OTHER-KEY-111'),
-      licenseStatus: 'Activated',
-      licenseType: 'Floating',
-      lastOnlineAvailabilityCheckUtc: String(Date.now()),
-    });
-    assert.equal(findLicenseByDecryptedKey('AAAAA-BBBBB-CCCCC-DDDDD-EEEEE'), null);
-  });
-
-  it('findLicenseByDecryptedKey returns matching state when key decrypts correctly', () => {
-    const rawKey = 'AAAAA-BBBBB-CCCCC-DDDDD-EEEEE';
-    writeLicenseFile('FloatingLic', {
-      licenseKey: encryptKey(rawKey),
-      licenseStatus: 'Activated',
-      licenseType: 'Floating',
-      lastOnlineAvailabilityCheckUtc: String(Date.now()),
-    });
-    const state = findLicenseByDecryptedKey(rawKey);
-    assert.ok(state !== null);
-    assert.equal(state?.name, 'FloatingLic');
-    assert.equal(state?.licenseType, 'Floating');
-    assert.equal(state?.activated, true);
-  });
-
-  it('findLicenseByDecryptedKey returns state even when not Activated', () => {
-    const rawKey = 'SOME-KEY-NOT-ACTIVE';
-    writeLicenseFile('NotActive', {
-      licenseKey: encryptKey(rawKey),
-      licenseStatus: 'NotActivated',
-      licenseType: 'FixedSeat',
-      lastOnlineAvailabilityCheckUtc: String(Date.now()),
-    });
-    const state = findLicenseByDecryptedKey(rawKey);
-    assert.ok(state !== null);
-    assert.equal(state?.activated, false);
-  });
-
-  it('findLicenseByDecryptedKey returns null when licenseKey field is absent', () => {
-    writeLicenseFile('NoKey', {
-      licenseStatus: 'Activated',
-      licenseType: 'FixedSeat',
-      lastOnlineAvailabilityCheckUtc: String(Date.now()),
-    });
-    assert.equal(findLicenseByDecryptedKey('any'), null);
-  });
-
-  it('findLicenseByDecryptedKey matches across multiple files', () => {
-    const rawKey = 'MULTI-FILE-MATCH-KEY';
-    writeLicenseFile('Unrelated', {
-      licenseKey: encryptKey('DIFFERENT-KEY'),
-      licenseStatus: 'Activated',
-      licenseType: 'Trial',
-      lastOnlineAvailabilityCheckUtc: String(Date.now()),
-    });
-    writeLicenseFile('Target', {
-      licenseKey: encryptKey(rawKey),
-      licenseStatus: 'Activated',
-      licenseType: 'Floating',
-      lastOnlineAvailabilityCheckUtc: String(Date.now()),
-    });
-    const state = findLicenseByDecryptedKey(rawKey);
-    assert.equal(state?.name, 'Target');
-  });
 });
 
 // ── E. licenseValidator — IDE auto-detection (non-test env) ──────────────────

--- a/test/unit/mcp/pathPolicy.test.ts
+++ b/test/unit/mcp/pathPolicy.test.ts
@@ -59,7 +59,7 @@ describe('pathPolicy', () => {
   });
 
   describe('symlink containment', () => {
-    let symlinkDir: string;
+    let symlinkDir: string | undefined;
 
     afterEach(() => {
       if (symlinkDir) {

--- a/test/unit/mcp/pathPolicy.test.ts
+++ b/test/unit/mcp/pathPolicy.test.ts
@@ -1,7 +1,8 @@
 import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { describe, it } from 'mocha';
+import { describe, it, afterEach } from 'mocha';
 import { assertPathAllowed, PathPolicyError } from '../../../src/mcp/security/pathPolicy.js';
 
 const tmp = os.tmpdir();
@@ -55,5 +56,45 @@ describe('pathPolicy', () => {
       assert.ok(e instanceof PathPolicyError, 'Expected PathPolicyError');
       assert.equal(e.code, 'PATH_NOT_ALLOWED');
     }
+  });
+
+  describe('symlink containment', () => {
+    let symlinkDir: string;
+
+    afterEach(() => {
+      if (symlinkDir) {
+        try { fs.rmSync(symlinkDir, { recursive: true, force: true }); } catch { /* ignore */ }
+      }
+    });
+
+    it('rejects a symlink inside an allowed dir that points outside it', function () {
+      if (process.platform === 'win32') {
+        // Symlink creation on Windows requires elevated privileges in most CI environments
+        this.skip();
+        return;
+      }
+      symlinkDir = fs.mkdtempSync(path.join(tmp, 'pathpolicy-sym-'));
+      const target = path.join(tmp, 'outside-secret.txt');
+      fs.writeFileSync(target, 'secret');
+      const link = path.join(symlinkDir, 'evil-link');
+      fs.symlinkSync(target, link);
+
+      try {
+        assertPathAllowed(link, [symlinkDir]);
+        assert.fail('Expected PathPolicyError to be thrown');
+      } catch (e) {
+        assert.ok(e instanceof PathPolicyError, 'Expected PathPolicyError');
+        assert.equal(e.code, 'PATH_NOT_ALLOWED');
+      } finally {
+        fs.unlinkSync(target);
+      }
+    });
+
+    it('allows a real path inside an allowed dir (not a symlink)', () => {
+      symlinkDir = fs.mkdtempSync(path.join(tmp, 'pathpolicy-real-'));
+      const real = path.join(symlinkDir, 'real-file.txt');
+      fs.writeFileSync(real, 'content');
+      assert.doesNotThrow(() => assertPathAllowed(real, [symlinkDir]));
+    });
   });
 });


### PR DESCRIPTION
## Summary

Security and correctness fixes for Provar MCP V1, identified during pre-merge review of #107.

### Changes

**Path containment (symlink hardening)**
- `pathPolicy.ts`: Replace `path.resolve()` with `fs.realpathSync()` to prevent symlink traversal attacks; both the input path and allowed paths are resolved through the real filesystem
- `automationTools.ts`: Thread `ServerConfig` through `registerAllAutomationTools` → `registerAutomationConfigLoad` and add `assertPathAllowed` check for `properties_path`
- `antTools.ts`: Add `assertPathAllowed` for all 6 path inputs (`provar_home`, `project_path`, `results_path`, `license_path`, `smtp_path`, `project_cache_path`)
- `server.ts`: Pass `config` to `registerAllAutomationTools`

**XML injection**
- `antTools.ts`: Add `'` → `&apos;` escape in `escapeXmlAttr`

**Dead code / credential exposure**
- `ideDetection.ts`: Remove AES-128-ECB decrypt function with hardcoded key `'provarautomation'` (unused dead code, key was committed to public npm package)

**License bypass removal**
- `scripts/mcp-smoke.cjs`: Remove `|| 'true'` fallback on `PROVAR_DEV_WHITELIST_KEYS` (was bypassing license validation when secret not set)
- `.github/workflows/CI_Execution.yml`: Remove `NODE_ENV: test` from smoke test step (was bypassing license validation in CI)

**HTTP retry safety**
- `algasClient.ts`: Create fresh `AbortController` for the 401-retry fetch instead of reusing the elapsed one

**File permissions**
- `licenseCache.ts`: Write cache file with `0o600` mode (owner read/write only)

**CI coverage**
- `.github/workflows/CI_Execution.yml`: Restore `macos-latest` to default CI matrix

### Tests updated
- `pathPolicy.test.ts`: Added symlink containment tests (skipped on Windows, runs on Linux/macOS CI)
- `automationTools.test.ts`: Updated for `ServerConfig` param + path policy enforcement tests
- `licenseValidator.test.ts`: Removed `findLicenseByDecryptedKey` tests (function removed)

### Deferred (items 11-16)
Hardcoded version string, duplicate `SfNotFoundError`, `shell:true` in smoke test, `/fail/i` regex in qualityHubTools, license freshness check, and yarn devDependency — addressed after this PR is tested.

## Test plan
- [x] CI passes on ubuntu-latest and macos-latest
- [x] MCP smoke test passes with `PROVAR_DEV_WHITELIST_KEYS` secret set
- [x] MCP smoke test fails (or skips correctly) when secret not set
- [x] Path policy unit tests pass (symlink test runs on Linux/macOS)
- [x] Automation tools path policy tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)