### PR TITLE
fix: MCP review items 11-16 (version, dedup, shell, regex, freshness, deps)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^5.0.2",
-    "yarn": "^1.22.22",
     "@salesforce/cli-plugins-testkit": "^5.1.7",
     "@salesforce/dev-scripts": "^8.3.0",
     "@types/sinon": "^21.0.0",

--- a/scripts/mcp-smoke.cjs
+++ b/scripts/mcp-smoke.cjs
@@ -27,7 +27,7 @@ const INCLUDE_SETUP = process.env['SMOKE_INCLUDE_SETUP'] === '1';
 // ----------------------------------------------------------------------------
 const server = spawn('sf', ['provar', 'mcp', 'start', '--allowed-paths', TMP], {
   stdio: ['pipe', 'pipe', 'inherit'],
-  shell: true,
+  shell: process.platform === 'win32',
   env: {
     ...process.env,
     PROVAR_DEV_WHITELIST_KEYS: process.env.PROVAR_DEV_WHITELIST_KEYS || '',

--- a/src/mcp/licensing/licenseValidator.ts
+++ b/src/mcp/licensing/licenseValidator.ts
@@ -111,6 +111,14 @@ function validateViaIdeDetection(): LicenseValidationResult {
     );
   }
 
+  // Warn when the IDE's own ALGAS check is stale (> 7 days) — the IDE may not have been
+  // opened recently enough to refresh the activation status from the licensing server.
+  const IDE_FRESHNESS_WARN_MS = 7 * 24 * 60 * 60 * 1000;
+  if (ideState.lastOnlineCheckMs > 0 && Date.now() - ideState.lastOnlineCheckMs > IDE_FRESHNESS_WARN_MS) {
+    const ageDays = Math.round((Date.now() - ideState.lastOnlineCheckMs) / (24 * 60 * 60 * 1000));
+    log('warn', 'licenseValidator: IDE license online check is stale — open Provar IDE to refresh', { ageDays });
+  }
+
   // 3. Valid — write to MCP cache so next start within 2h skips this read
   const entry: CacheEntry = {
     keyHash,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,9 +10,8 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { log } from './logging/logger.js';
 
-const _require = createRequire(import.meta.url);
-const _pkg = _require('../../package.json') as { version: string };
-const SERVER_VERSION: string = _pkg.version;
+const requireJson = createRequire(import.meta.url);
+const SERVER_VERSION: string = (requireJson('../../package.json') as { version: string }).version;
 import { registerProjectInspect } from './tools/projectInspect.js';
 import { registerPageObjectGenerate } from './tools/pageObjectGenerate.js';
 import { registerPageObjectValidate } from './tools/pageObjectValidate.js';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -5,9 +5,14 @@
  * For full license text, see LICENSE.md file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { createRequire } from 'node:module';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { log } from './logging/logger.js';
+
+const _require = createRequire(import.meta.url);
+const _pkg = _require('../../package.json') as { version: string };
+const SERVER_VERSION: string = _pkg.version;
 import { registerProjectInspect } from './tools/projectInspect.js';
 import { registerPageObjectGenerate } from './tools/pageObjectGenerate.js';
 import { registerPageObjectValidate } from './tools/pageObjectValidate.js';
@@ -33,7 +38,7 @@ export function createProvarMcpServer(config: ServerConfig): McpServer {
 
   const server = new McpServer({
     name: 'provar-mcp',
-    version: '1.0.0',
+    version: SERVER_VERSION,
   });
 
   // ── Sanity-check tool ────────────────────────────────────────────────────────
@@ -44,7 +49,7 @@ export function createProvarMcpServer(config: ServerConfig): McpServer {
       message: z.string().optional().default('ping').describe('Optional message to echo back'),
     },
     ({ message }) => {
-      const result = { pong: message, ts: new Date().toISOString(), server: 'provar-mcp@1.0.0' };
+      const result = { pong: message, ts: new Date().toISOString(), server: `provar-mcp@${SERVER_VERSION}` };
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(result) }],
         structuredContent: result,

--- a/src/mcp/tools/automationTools.ts
+++ b/src/mcp/tools/automationTools.ts
@@ -15,7 +15,7 @@ import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
 import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
-import { sfSpawnHelper } from './sfSpawn.js';
+import { sfSpawnHelper, SfNotFoundError } from './sfSpawn.js';
 
 // ── SF CLI discovery ──────────────────────────────────────────────────────────
 
@@ -89,20 +89,6 @@ function resolveSfExecutable(): string | null {
   return null;
 }
 
-class SfNotFoundError extends Error {
-  public readonly code = 'SF_NOT_FOUND';
-  public constructor(sfPath?: string) {
-    const where = sfPath
-      ? `at explicit path "${sfPath}"`
-      : 'in PATH or common npm/nvm install locations';
-    super(
-      `sf CLI not found ${where}. ` +
-      'Install Salesforce CLI (npm install -g @salesforce/cli) and ensure the install directory is in your PATH, ' +
-      'or pass sf_path pointing to the sf executable directly ' +
-      '(e.g. "~/.nvm/versions/node/v22.0.0/bin/sf").'
-    );
-  }
-}
 
 function runSfCommand(args: string[], sfPath?: string): SpawnResult {
   // Use explicit path if provided; otherwise use cached probe result

--- a/src/mcp/tools/qualityHubTools.ts
+++ b/src/mcp/tools/qualityHubTools.ts
@@ -143,7 +143,13 @@ export function registerQualityHubTestRunReport(server: McpServer): void {
           return { isError: true as const, content: [{ type: 'text' as const, text: JSON.stringify(makeError('QH_REPORT_FAILED', result.stderr || result.stdout, requestId)) }] };
         }
 
-        const hasFailures = /fail/i.test(result.stdout);
+        let hasFailures = false;
+        try {
+          const parsed = JSON.parse(result.stdout) as { result?: { status?: string } };
+          hasFailures = /fail/i.test(parsed.result?.status ?? '');
+        } catch {
+          hasFailures = /\bFAILED?\b/i.test(result.stdout);
+        }
         const suggestion = hasFailures
           ? 'Failures detected. Use provar.qualityhub.defect.create with run_id and target_org to automatically create Defect__c records for each failure (syncs to Jira/ADO if configured).'
           : '';

--- a/src/mcp/tools/qualityHubTools.ts
+++ b/src/mcp/tools/qualityHubTools.ts
@@ -143,12 +143,16 @@ export function registerQualityHubTestRunReport(server: McpServer): void {
           return { isError: true as const, content: [{ type: 'text' as const, text: JSON.stringify(makeError('QH_REPORT_FAILED', result.stderr || result.stdout, requestId)) }] };
         }
 
+        const failureStatuses = new Set(['FAIL', 'FAILED']);
         let hasFailures = false;
         try {
           const parsed = JSON.parse(result.stdout) as { result?: { status?: string } };
-          hasFailures = /fail/i.test(parsed.result?.status ?? '');
+          const normalizedStatus = parsed.result?.status?.trim().toUpperCase();
+          hasFailures = normalizedStatus !== undefined && failureStatuses.has(normalizedStatus);
         } catch {
-          hasFailures = /\bFAILED?\b/i.test(result.stdout);
+          const statusMatch = result.stdout.match(/"status"\s*:\s*"([^"]+)"/i);
+          const normalizedStatus = statusMatch?.[1]?.trim().toUpperCase();
+          hasFailures = normalizedStatus !== undefined && failureStatuses.has(normalizedStatus);
         }
         const suggestion = hasFailures
           ? 'Failures detected. Use provar.qualityhub.defect.create with run_id and target_org to automatically create Defect__c records for each failure (syncs to Jira/ADO if configured).'

--- a/src/mcp/tools/sfSpawn.ts
+++ b/src/mcp/tools/sfSpawn.ts
@@ -19,9 +19,15 @@ export const sfSpawnHelper = {
 
 export class SfNotFoundError extends Error {
   public readonly code = 'SF_NOT_FOUND';
-  public constructor() {
+  public constructor(sfPath?: string) {
+    const where = sfPath
+      ? `at explicit path "${sfPath}"`
+      : 'in PATH or common npm/nvm/volta install locations';
     super(
-      'sf CLI not found in PATH. Install Salesforce CLI (`npm install -g @salesforce/cli`) and ensure it is in your PATH.'
+      `sf CLI not found ${where}. ` +
+      'Install Salesforce CLI (npm install -g @salesforce/cli) and ensure the install directory is in your PATH, ' +
+      'or pass sf_path pointing to the sf executable directly ' +
+      '(e.g. "~/.nvm/versions/node/v22.0.0/bin/sf").'
     );
     this.name = 'SfNotFoundError';
   }


### PR DESCRIPTION
## Summary

Addresses the six deferred items from the pre-merge security review of #107, following the pt1 fixes in #109.

### Changes

**Item 11 — hardcoded version string**
- `server.ts`: read `version` from `package.json` at runtime via `createRequire`; was hardcoded as `'1.0.0'` in both the `McpServer` constructor and the `provardx.ping` response

**Item 12 — duplicate `SfNotFoundError`**
- `sfSpawn.ts`: updated `SfNotFoundError` to accept optional `sfPath` with a richer diagnostic message ("at explicit path X" vs "in PATH or common npm/nvm/volta install locations")
- `automationTools.ts`: removed the private duplicate class; now imports `SfNotFoundError` from `sfSpawn.ts`

**Item 13 — `shell: true` in smoke test**
- `scripts/mcp-smoke.cjs`: replaced `shell: true` with `shell: process.platform === 'win32'`; Linux/macOS CI no longer spawns an unnecessary shell wrapper

**Item 14 — broad `/fail/i` regex**
- `qualityHubTools.ts`: replaced raw stdout scan with a JSON parse of `result.status` for precise match; falls back to `/\bFAILED?\b/i` word-boundary regex if the output is not JSON

**Item 15 — license freshness check**
- `licenseValidator.ts`: added a `warn` log when the IDE's `lastOnlineCheckMs` is more than 7 days old, alerting users whose IDE hasn't synced with ALGAS recently

**Item 16 — `yarn` devDependency**
- `package.json`: removed `"yarn": "^1.22.22"` from `devDependencies`; yarn is a package manager and should not be an npm package dependency — GitHub Actions runners provide it via system/corepack

## Test plan
- [x] CI passes on ubuntu-latest and macos-latest
- [x] `provardx.ping` response includes the correct `1.5.0-beta` version string
- [x] MCP smoke test passes with smoke test using `shell: false` on Linux/macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)