### PR TITLE
fix(auth): trim and validate stored api key in resolveApiKey

### DIFF
--- a/src/services/auth/credentials.ts
+++ b/src/services/auth/credentials.ts
@@ -82,6 +82,7 @@ export function clearCredentials(): void {
 export function resolveApiKey(): string | null {
   const envKey = process.env.PROVAR_API_KEY?.trim();
   if (envKey?.startsWith(KEY_PREFIX)) return envKey;
-  const stored = readStoredCredentials();
-  return stored?.api_key ?? null;
+  const storedKey = readStoredCredentials()?.api_key.trim() ?? null;
+  if (storedKey?.startsWith(KEY_PREFIX)) return storedKey;
+  return null;
 }

--- a/src/services/auth/credentials.ts
+++ b/src/services/auth/credentials.ts
@@ -82,7 +82,8 @@ export function clearCredentials(): void {
 export function resolveApiKey(): string | null {
   const envKey = process.env.PROVAR_API_KEY?.trim();
   if (envKey?.startsWith(KEY_PREFIX)) return envKey;
-  const storedKey = readStoredCredentials()?.api_key.trim() ?? null;
+  const creds = readStoredCredentials();
+  const storedKey = typeof creds?.api_key === 'string' ? creds.api_key.trim() : null;
   if (storedKey?.startsWith(KEY_PREFIX)) return storedKey;
   return null;
 }

--- a/test/unit/services/auth/credentials.test.ts
+++ b/test/unit/services/auth/credentials.test.ts
@@ -190,4 +190,34 @@ describe('resolveApiKey', () => {
     fs.writeFileSync(p, 'not-json');
     assert.equal(resolveApiKey(), null);
   });
+
+  it('trims whitespace from the stored key before returning it', () => {
+    // Manually written credentials.json with surrounding whitespace on the key
+    // (e.g. edited in a text editor or written by a buggy tool) must not reach the API as-is.
+    const p = getCredentialsPath();
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    const data: StoredCredentials = {
+      api_key: '  pv_k_trimme  \n',
+      prefix: 'pv_k_trimme',
+      set_at: '2026-01-01T00:00:00.000Z',
+      source: 'manual',
+    };
+    fs.writeFileSync(p, JSON.stringify(data));
+    assert.equal(resolveApiKey(), 'pv_k_trimme');
+  });
+
+  it('returns null when stored key does not start with pv_k_ prefix', () => {
+    // A credentials.json that pre-dates the pv_k_ format or was written by hand
+    // with the wrong format should not be sent to the API.
+    const p = getCredentialsPath();
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    const data: StoredCredentials = {
+      api_key: 'old-format-key-12345',
+      prefix: 'old-format',
+      set_at: '2026-01-01T00:00:00.000Z',
+      source: 'manual',
+    };
+    fs.writeFileSync(p, JSON.stringify(data));
+    assert.equal(resolveApiKey(), null);
+  });
 });

--- a/test/unit/services/auth/credentials.test.ts
+++ b/test/unit/services/auth/credentials.test.ts
@@ -220,4 +220,25 @@ describe('resolveApiKey', () => {
     fs.writeFileSync(p, JSON.stringify(data));
     assert.equal(resolveApiKey(), null);
   });
+
+  it('returns null when stored credentials are missing the api_key field', () => {
+    // Manually edited or corrupt file that lacks api_key entirely must not throw.
+    const p = getCredentialsPath();
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify({ prefix: 'pv_k_', set_at: '2026-01-01T00:00:00.000Z', source: 'manual' }));
+    assert.doesNotThrow(() => resolveApiKey());
+    assert.equal(resolveApiKey(), null);
+  });
+
+  it('returns null when stored api_key is a non-string type', () => {
+    // A file where api_key was set to a number or boolean (e.g. from a bad script) must not throw.
+    const p = getCredentialsPath();
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(
+      p,
+      JSON.stringify({ api_key: 12_345, prefix: 'pv_k_', set_at: '2026-01-01T00:00:00.000Z', source: 'manual' })
+    );
+    assert.doesNotThrow(() => resolveApiKey());
+    assert.equal(resolveApiKey(), null);
+  });
 });


### PR DESCRIPTION
The stored key was returned as-is with no trim() or prefix check, unlike the env var path which had both. A key with trailing whitespace (e.g. from manual editing) or a pre-pv_k_ format key would be sent to the Quality Hub API unchanged, causing a 401 and triggering local_fallback even when a valid key exists. Tests added for both cases.