### PR TITLE
feat(mcp): add provar.loop.db prompt and fix database step reference

### DIFF
--- a/docs/PROVAR_TEST_STEP_REFERENCE.md
+++ b/docs/PROVAR_TEST_STEP_REFERENCE.md
@@ -1125,6 +1125,12 @@ Variable-to-variable or variable-to-literal comparison. For UI field assertions 
 
 ## Database Steps
 
+> **Critical constraints — read before generating any Database step XML:**
+>
+> 1. **`connectionId` must use `valueClass="id"`** — not `"string"`. Using `"string"` causes a runtime type error.
+> 2. **`DbConnect.resultName` must exactly equal `SqlQuery.dbConnectionName`** — these two values are the coupling point between the steps. A mismatch causes "connection not found" at runtime.
+> 3. **Never use `{Count(Var)}` or `{Var[0].Field}` string expressions in SetValues/AssertValues** — these are stored verbatim and never evaluated. Use `<value class="funcCall">` for Count and the structured `<value class="variable"><path>` form for indexed field access. See the examples below.
+
 ### DbConnect
 
 ```xml
@@ -1136,12 +1142,14 @@ Variable-to-variable or variable-to-literal comparison. For UI field assertions 
       <value class="value" valueClass="string">MyDatabase</value>
     </argument>
     <argument id="connectionId">
-      <value class="value" valueClass="string">database-connection-id</value>
+      <!-- MUST be valueClass="id" — not "string" -->
+      <value class="value" valueClass="id">database-connection-uuid</value>
     </argument>
     <argument id="autoCommit">
       <value class="value" valueClass="boolean">true</value>
     </argument>
     <argument id="resultName">
+      <!-- This value must exactly match dbConnectionName on every SqlQuery that uses this connection -->
       <value class="value" valueClass="string">DbConnection</value>
     </argument>
     <argument id="resultScope">
@@ -1159,13 +1167,98 @@ Variable-to-variable or variable-to-literal comparison. For UI field assertions 
          title="SQL Query: DbConnection=&gt;DbResults">
   <arguments>
     <argument id="dbConnectionName">
+      <!-- Must exactly equal the resultName on the DbConnect step above -->
       <value class="value" valueClass="string">DbConnection</value>
     </argument>
     <argument id="query">
-      <value class="value" valueClass="string">SELECT * FROM Users WHERE Status = 'Active'</value>
+      <value class="value" valueClass="string">SELECT Id, Name, Status FROM Users WHERE Status = 'Active'</value>
     </argument>
     <argument id="resultName">
       <value class="value" valueClass="string">DbResults</value>
+    </argument>
+    <argument id="resultScope">
+      <value class="value" valueClass="string">Test</value>
+    </argument>
+  </arguments>
+</apiCall>
+```
+
+### Accessing Database Results — funcCall and structured variable paths
+
+After `SqlQuery`, the result variable (e.g. `DbResults`) is a list of rows. To use the results in `SetValues` or `AssertValues`, you must use structured XML — not `{...}` string expressions.
+
+#### Count the result rows (funcCall)
+
+```xml
+<!-- ✅ CORRECT — funcCall element evaluates at runtime -->
+<argument id="value">
+  <value class="funcCall" id="Count">
+    <argument id="value">
+      <value class="variable">
+        <path element="DbResults"/>
+      </value>
+    </argument>
+  </value>
+</argument>
+
+<!-- ❌ WRONG — string expression stored verbatim, never evaluated -->
+<argument id="value">
+  <value class="value" valueClass="string">{Count(DbResults)}</value>
+</argument>
+```
+
+#### Access a field from a specific row (structured variable path)
+
+```xml
+<!-- ✅ CORRECT — structured path with index filter (0-based) -->
+<argument id="value">
+  <value class="variable">
+    <path element="DbResults">
+      <filter class="index">
+        <index valueClass="decimal">0</index>
+      </filter>
+    </path>
+    <path element="Status"/>
+  </value>
+</argument>
+
+<!-- ❌ WRONG — string expression stored verbatim, never evaluated -->
+<argument id="value">
+  <value class="value" valueClass="string">{DbResults[0].Status}</value>
+</argument>
+```
+
+#### Full SetValues example — extract row count and first-row field
+
+```xml
+<apiCall apiId="com.provar.plugins.bundled.apis.control.SetValues"
+         name="SetValues" testItemId="3"
+         title="Extract DB result values">
+  <arguments>
+    <argument id="values">
+      <value class="list">
+        <!-- Row count into RowCount variable -->
+        <value class="namedValue" name="RowCount">
+          <value class="funcCall" id="Count">
+            <argument id="value">
+              <value class="variable">
+                <path element="DbResults"/>
+              </value>
+            </argument>
+          </value>
+        </value>
+        <!-- First row Status field into FirstStatus variable -->
+        <value class="namedValue" name="FirstStatus">
+          <value class="variable">
+            <path element="DbResults">
+              <filter class="index">
+                <index valueClass="decimal">0</index>
+              </filter>
+            </path>
+            <path element="Status"/>
+          </value>
+        </value>
+      </value>
     </argument>
     <argument id="resultScope">
       <value class="value" valueClass="string">Test</value>

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -67,6 +67,7 @@ The Provar DX CLI ships with a built-in **Model Context Protocol (MCP) server** 
     - [provar.loop.fix](#provarloopfix)
     - [provar.loop.review](#provarloopreview)
     - [provar.loop.coverage](#provarloopcoverage)
+    - [provar.loop.db](#provarloopdb)
 - [MCP Resources](#mcp-resources)
   - [provar://docs/step-reference](#provardocsstep-reference)
 - [AI loop pattern](#ai-loop-pattern)
@@ -1682,6 +1683,28 @@ Analyse coverage gaps for a Salesforce object or feature area. Inspects the proj
 | `objectName`  | string | yes      | Primary Salesforce object to check coverage for (e.g. `"Opportunity"`, `"Lead"`).                                                                                                          |
 | `projectPath` | string | yes      | Absolute path to the Provar project root.                                                                                                                                                  |
 | `targetOrg`   | string | no       | Salesforce org alias or username. When provided, existing Quality Hub test cases for this object are retrieved via `provar.qualityhub.testcase.retrieve` before the coverage gap analysis. |
+
+---
+
+#### `provar.loop.db`
+
+Generate a Provar XML test case that connects to an **external database** (SQL Server, Oracle, MySQL, PostgreSQL, etc.) and verifies query results. This prompt is distinct from the Salesforce/SOQL loop — it targets `DbConnect` + `SqlQuery` steps and enforces the correct patterns for `funcCall` row counts and structured variable paths for field access, which are the most common source of errors in database test generation.
+
+**Arguments**
+
+| Parameter          | Type   | Required | Description                                                                                                                                                                                        |
+| ------------------ | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `story`            | string | yes      | Description of what the database test should verify. Include the database type, table name, query intent, and what values should be asserted.                                                      |
+| `projectPath`      | string | no       | Absolute path to the Provar project root. Used to locate the `tests/` directory when writing the output file.                                                                                      |
+| `testName`         | string | no       | Optional file name for the test case (without extension). Inferred from the story if omitted.                                                                                                      |
+| `dbConnectionName` | string | no       | The name of the database connection as configured in Provar Connection Manager. Used as the `connectionName` argument on `DbConnect`. If omitted, the story should describe the connection to use. |
+
+**What the prompt enforces:**
+
+- `DbConnect.connectionId` must use `valueClass="id"` — not `"string"`
+- `DbConnect.resultName` must exactly equal `SqlQuery.dbConnectionName` (the coupling point)
+- Row counts use `<value class="funcCall" id="Count">` — not `{Count(Var)}` string expressions
+- Indexed field access uses a structured `<value class="variable"><path><filter class="index">` — not `{Var[0].Field}` string expressions
 
 ---
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1692,12 +1692,12 @@ Generate a Provar XML test case that connects to an **external database** (SQL S
 
 **Arguments**
 
-| Parameter          | Type   | Required | Description                                                                                                                                                                                        |
-| ------------------ | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `story`            | string | yes      | Description of what the database test should verify. Include the database type, table name, query intent, and what values should be asserted.                                                      |
-| `projectPath`      | string | no       | Absolute path to the Provar project root. Used to locate the `tests/` directory when writing the output file.                                                                                      |
-| `testName`         | string | no       | Optional file name for the test case (without extension). Inferred from the story if omitted.                                                                                                      |
-| `dbConnectionName` | string | no       | The name of the database connection as configured in Provar Connection Manager. Used as the `connectionName` argument on `DbConnect`. If omitted, the story should describe the connection to use. |
+| Parameter        | Type   | Required | Description                                                                                                                                                                          |
+| ---------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `story`          | string | yes      | Description of what the database test should verify. Include the database type, table name, query intent, and what values should be asserted.                                        |
+| `projectPath`    | string | no       | Absolute path to the Provar project root. Used to locate the `tests/` directory when writing the output file.                                                                        |
+| `testName`       | string | no       | Optional file name for the test case (without extension). Inferred from the story if omitted.                                                                                        |
+| `connectionName` | string | no       | The Provar Connection Manager database connection name (`DbConnect.connectionName`). Identifies which connection entry to use. If omitted, the story should describe the connection. |
 
 **What the prompt enforces:**
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provartesting/provardx-cli",
   "description": "A plugin for the Salesforce CLI to orchestrate testing activities and report quality metrics to Provar Quality Hub",
-  "version": "1.5.0-beta.8",
+  "version": "1.5.0-beta.9",
   "mcpName": "io.github.provartesting/provar",
   "license": "BSD-3-Clause",
   "plugins": [

--- a/scripts/mcp-smoke.cjs
+++ b/scripts/mcp-smoke.cjs
@@ -350,6 +350,12 @@ async function runTests() {
     arguments: { objectName: 'Opportunity', projectPath: '/tmp/provar-project' },
   });
 
+  // ── 48. provar.loop.db prompt ─────────────────────────────────────────────
+  await rpc('provar.loop.db (prompt)', 'prompts/get', {
+    name: 'provar.loop.db',
+    arguments: { story: 'Verify Users table has at least one Active record after Salesforce flow runs' },
+  });
+
   server.stdin.end();
 }
 
@@ -358,8 +364,8 @@ async function runTests() {
 // ----------------------------------------------------------------------------
 server.on('close', () => {
   clearTimeout(overallTimer);
-  // initialize + tools/list + 37 tools + prompts/list + 7 prompts/get (setup excluded from default count)
-  const TOTAL_EXPECTED = 47 + (INCLUDE_SETUP ? 1 : 0);
+  // initialize + tools/list + 37 tools + prompts/list + 8 prompts/get (setup excluded from default count)
+  const TOTAL_EXPECTED = 48 + (INCLUDE_SETUP ? 1 : 0);
   let passed = 0;
   let failed = 0;
 

--- a/src/mcp/prompts/index.ts
+++ b/src/mcp/prompts/index.ts
@@ -16,6 +16,7 @@ import {
   registerLoopFixPrompt,
   registerLoopReviewPrompt,
   registerLoopCoveragePrompt,
+  registerLoopDbPrompt,
 } from './loopPrompts.js';
 
 export function registerAllPrompts(server: McpServer): void {
@@ -26,4 +27,5 @@ export function registerAllPrompts(server: McpServer): void {
   registerLoopFixPrompt(server);
   registerLoopReviewPrompt(server);
   registerLoopCoveragePrompt(server);
+  registerLoopDbPrompt(server);
 }

--- a/src/mcp/prompts/loopPrompts.ts
+++ b/src/mcp/prompts/loopPrompts.ts
@@ -394,3 +394,106 @@ Begin with step 1: list the .testcase files in ${projectPath}/tests/ and search 
     })
   );
 }
+
+// ── Prompt: provar.loop.db ────────────────────────────────────────────────────
+
+export function registerLoopDbPrompt(server: McpServer): void {
+  server.prompt(
+    'provar.loop.db',
+    'Generate a Provar XML test case that connects to an external database (SQL Server, Oracle, MySQL, etc.) and verifies query results. Distinct from Salesforce/SOQL flows — this targets DbConnect + SqlQuery steps. Retrieves corpus examples for grounding, enforces correct funcCall/variable-path patterns, generates the test, then validates.',
+    {
+      story: z
+        .string()
+        .describe(
+          'Description of what the database test should verify. Include the database type (e.g. "SQL Server"), table name, query intent, and what values should be asserted (e.g. "Verify that the Users table contains an active user record with Status=Active after a Salesforce flow runs").'
+        ),
+      projectPath: z
+        .string()
+        .optional()
+        .describe('Absolute path to the Provar project root. Used to locate the tests/ directory.'),
+      testName: z
+        .string()
+        .optional()
+        .describe('Optional file name for the test case (without extension). Inferred from the story if omitted.'),
+      dbConnectionName: z
+        .string()
+        .optional()
+        .describe(
+          'The name of the database connection as configured in Provar Connection Manager. Used as the connectionName argument on DbConnect. If omitted, the story should describe it.'
+        ),
+    },
+    ({ story, projectPath, testName, dbConnectionName }) => ({
+      messages: [
+        {
+          role: 'user' as const,
+          content: {
+            type: 'text' as const,
+            text: `You are a Provar test automation expert. Generate a Provar XML test case that validates database state using DbConnect and SqlQuery steps.
+
+This is a **database test**, NOT a Salesforce UI or Apex test. Do not use UiConnect, UiWithScreen, ApexConnect, or ApexCreateObject — use the database step types: DbConnect, SqlQuery, SetValues, AssertValues.
+
+## Workflow
+
+Follow these steps in order:
+
+1. **Get corpus examples** — call \`provar.qualityhub.examples.retrieve\` with a query that includes "database DbConnect SqlQuery" plus keywords from the story (e.g. "database SQL Server verify record count"). Use the returned XML examples as the reference for correct step structure.
+   If the response has \`"count": 0\` with a \`"warning"\` field (API unavailable or not configured), fall back: read the \`provar://docs/step-reference\` MCP resource — specifically the Database Steps section — for the correct attribute schema, then continue.
+
+2. **Generate the test case** — produce valid Provar XML. Apply these database-specific rules:
+
+   **DbConnect rules:**
+   - \`connectionId\` argument MUST use \`valueClass="id"\` — NOT \`"string"\`. Using \`"string"\` causes a runtime type error.
+   - \`resultName\` sets the connection handle name (e.g. \`"DbConnection"\`).
+   - This name must be reused exactly as \`dbConnectionName\` on every SqlQuery step that uses this connection.
+${dbConnectionName ? `   - Use connection name: ${dbConnectionName}` : ''}
+
+   **SqlQuery rules:**
+   - \`dbConnectionName\` must exactly equal the \`resultName\` from the DbConnect step above.
+   - \`resultName\` names the variable that will hold the query result rows (e.g. \`"DbResults"\`).
+
+   **Accessing results in SetValues/AssertValues — critical:**
+   - To count result rows: use \`<value class="funcCall" id="Count">\` — NEVER use \`{Count(Var)}\` string expressions.
+   - To access a field from row N (0-based): use the structured variable path with a \`<filter class="index">\` — NEVER use \`{Var[0].Field}\` string expressions.
+   - String \`{...}\` expressions are stored verbatim and never evaluated. They will always produce wrong results.
+
+   **Pattern for extracting values from results:**
+   \`\`\`xml
+   <!-- Count rows -->
+   <value class="funcCall" id="Count">
+     <argument id="value">
+       <value class="variable"><path element="DbResults"/></value>
+     </argument>
+   </value>
+
+   <!-- Access field from row 0 -->
+   <value class="variable">
+     <path element="DbResults">
+       <filter class="index"><index valueClass="decimal">0</index></filter>
+     </path>
+     <path element="FieldName"/>
+   </value>
+   \`\`\`
+
+3. **Write the file** — save the XML to the tests/ directory in the Provar project.
+   ${projectHint(projectPath)}
+   ${testName ? `Target file name: ${testName}.testcase` : 'Infer the file name from the story (snake_case).'}
+
+4. **Validate** — call \`provar.testcase.validate\` on the saved file. If it reports errors, fix them and re-validate until the file passes clean.
+
+5. **Report** — summarise:
+   - Which query/assertion was implemented
+   - The DbConnect resultName and SqlQuery dbConnectionName used (confirm they match)
+   - Any validation warnings
+   - Any aspects of the story that could not be automated (add \`<!-- TODO: manual verification — <reason> -->\` in the XML)
+
+## Database Test Story
+
+${story}
+
+Begin with step 1: call provar.qualityhub.examples.retrieve with "database DbConnect SqlQuery" plus keywords from the story above.`,
+          },
+        },
+      ],
+    })
+  );
+}

--- a/src/mcp/prompts/loopPrompts.ts
+++ b/src/mcp/prompts/loopPrompts.ts
@@ -415,14 +415,14 @@ export function registerLoopDbPrompt(server: McpServer): void {
         .string()
         .optional()
         .describe('Optional file name for the test case (without extension). Inferred from the story if omitted.'),
-      dbConnectionName: z
+      connectionName: z
         .string()
         .optional()
         .describe(
-          'The name of the database connection as configured in Provar Connection Manager. Used as the connectionName argument on DbConnect. If omitted, the story should describe it.'
+          'The Provar Connection Manager database connection name (DbConnect.connectionName). This identifies which connection entry to use. If omitted, the story should describe the connection to use.'
         ),
     },
-    ({ story, projectPath, testName, dbConnectionName }) => ({
+    ({ story, projectPath, testName, connectionName }) => ({
       messages: [
         {
           role: 'user' as const,
@@ -442,10 +442,12 @@ Follow these steps in order:
 2. **Generate the test case** — produce valid Provar XML. Apply these database-specific rules:
 
    **DbConnect rules:**
+   - \`connectionName\` argument identifies the Connection Manager entry (e.g. \`"MyDatabase"\`).${
+     connectionName ? `\n   - Use connection name: ${connectionName}` : ''
+   }
    - \`connectionId\` argument MUST use \`valueClass="id"\` — NOT \`"string"\`. Using \`"string"\` causes a runtime type error.
-   - \`resultName\` sets the connection handle name (e.g. \`"DbConnection"\`).
-   - This name must be reused exactly as \`dbConnectionName\` on every SqlQuery step that uses this connection.
-${dbConnectionName ? `   - Use connection name: ${dbConnectionName}` : ''}
+   - \`resultName\` sets the **connection handle** — the variable name used to refer to this open connection (e.g. \`"DbConnection"\`). Choose any valid identifier.
+   - This handle must be reused exactly as \`dbConnectionName\` on every SqlQuery step that uses this connection.
 
    **SqlQuery rules:**
    - \`dbConnectionName\` must exactly equal the \`resultName\` from the DbConnect step above.

--- a/src/mcp/tools/qualityHubApiTools.ts
+++ b/src/mcp/tools/qualityHubApiTools.ts
@@ -49,8 +49,8 @@ export function registerCorpusExamplesRetrieve(server: McpServer): void {
     'provar.qualityhub.examples.retrieve',
     [
       'Retrieve N similar Provar test case examples from the Quality Hub corpus (1000+ tests in Bedrock KB).',
-      'Use this BEFORE calling provar.testcase.generate to get few-shot grounding examples.',
-      'Pass a user story, requirement, or source test file content as the query.',
+      'Use this BEFORE writing any Provar .testcase XML — whether via provar.testcase.generate, Write, or Edit.',
+      'Pass a user story, requirement, source test file content, or step type keywords as the query.',
       'Returns up to N example Provar XML test cases ordered by similarity score.',
       'If retrieval fails (no auth, network error, rate limit), returns empty examples with a warning — the',
       'generation workflow can still continue without grounding. Never hard-errors on API failure.',

--- a/src/mcp/tools/testCaseGenerate.ts
+++ b/src/mcp/tools/testCaseGenerate.ts
@@ -22,25 +22,25 @@ import { validateTestCase } from './testCaseValidate.js';
 // and expanded automatically before writing XML.
 
 const SHORTHAND_TO_FQID: Record<string, string> = {
-  UiConnect:          'com.provar.plugins.forcedotcom.core.ui.UiConnect',
-  UiDoAction:         'com.provar.plugins.forcedotcom.core.ui.UiDoAction',
-  UiWithScreen:       'com.provar.plugins.forcedotcom.core.ui.UiWithScreen',
-  UiAssert:           'com.provar.plugins.forcedotcom.core.ui.UiAssert',
-  UiNavigate:         'com.provar.plugins.forcedotcom.core.ui.UiNavigate',
-  UiWithRow:          'com.provar.plugins.forcedotcom.core.ui.UiWithRow',
-  UiScrollToElement:  'com.provar.plugins.forcedotcom.core.ui.UiScrollToElement',
-  ApexConnect:        'com.provar.plugins.forcedotcom.core.testapis.ApexConnect',
-  ApexSoqlQuery:      'com.provar.plugins.forcedotcom.core.testapis.ApexSoqlQuery',
-  ApexCreateObject:   'com.provar.plugins.forcedotcom.core.testapis.ApexCreateObject',
-  ApexReadObject:     'com.provar.plugins.forcedotcom.core.testapis.ApexReadObject',
-  ApexUpdateObject:   'com.provar.plugins.forcedotcom.core.testapis.ApexUpdateObject',
-  ApexDeleteObject:   'com.provar.plugins.forcedotcom.core.testapis.ApexDeleteObject',
-  SetValues:          'com.provar.plugins.bundled.apis.control.SetValues',
-  AssertValues:       'com.provar.plugins.bundled.apis.AssertValues',
-  StepGroup:          'com.provar.plugins.bundled.apis.control.StepGroup',
-  Sleep:              'com.provar.plugins.bundled.apis.control.Sleep',
-  ForEach:            'com.provar.plugins.bundled.apis.control.ForEach',
-  CaseCall:           'com.provar.plugins.bundled.apis.control.CaseCall',
+  UiConnect: 'com.provar.plugins.forcedotcom.core.ui.UiConnect',
+  UiDoAction: 'com.provar.plugins.forcedotcom.core.ui.UiDoAction',
+  UiWithScreen: 'com.provar.plugins.forcedotcom.core.ui.UiWithScreen',
+  UiAssert: 'com.provar.plugins.forcedotcom.core.ui.UiAssert',
+  UiNavigate: 'com.provar.plugins.forcedotcom.core.ui.UiNavigate',
+  UiWithRow: 'com.provar.plugins.forcedotcom.core.ui.UiWithRow',
+  UiScrollToElement: 'com.provar.plugins.forcedotcom.core.ui.UiScrollToElement',
+  ApexConnect: 'com.provar.plugins.forcedotcom.core.testapis.ApexConnect',
+  ApexSoqlQuery: 'com.provar.plugins.forcedotcom.core.testapis.ApexSoqlQuery',
+  ApexCreateObject: 'com.provar.plugins.forcedotcom.core.testapis.ApexCreateObject',
+  ApexReadObject: 'com.provar.plugins.forcedotcom.core.testapis.ApexReadObject',
+  ApexUpdateObject: 'com.provar.plugins.forcedotcom.core.testapis.ApexUpdateObject',
+  ApexDeleteObject: 'com.provar.plugins.forcedotcom.core.testapis.ApexDeleteObject',
+  SetValues: 'com.provar.plugins.bundled.apis.control.SetValues',
+  AssertValues: 'com.provar.plugins.bundled.apis.AssertValues',
+  StepGroup: 'com.provar.plugins.bundled.apis.control.StepGroup',
+  Sleep: 'com.provar.plugins.bundled.apis.control.Sleep',
+  ForEach: 'com.provar.plugins.bundled.apis.control.ForEach',
+  CaseCall: 'com.provar.plugins.bundled.apis.control.CaseCall',
 };
 
 function resolveApiId(apiId: string): string {
@@ -56,16 +56,16 @@ function buildStepWarnings(steps: Array<{ api_id: string }>): string[] {
   if (resolvedIds.includes(SHORTHAND_TO_FQID['ApexReadObject'] ?? '')) {
     warnings.push(
       'ApexReadObject: You must specify field names in the attributes (e.g. fieldList); ' +
-      'if none are provided Provar generates "SELECT  FROM ..." which throws MALFORMED_QUERY. ' +
-      'Prefer ApexSoqlQuery for full control over the SELECT clause and result binding.'
+        'if none are provided Provar generates "SELECT  FROM ..." which throws MALFORMED_QUERY. ' +
+        'Prefer ApexSoqlQuery for full control over the SELECT clause and result binding.'
     );
   }
 
   if (resolvedIds.includes(SHORTHAND_TO_FQID['AssertValues'] ?? '')) {
     warnings.push(
       'AssertValues: Direct index paths like "ResultList[0].FieldName" are NOT supported for ApexSoqlQuery results. ' +
-      'To assert SOQL results use either: (a) a ForEach loop over the result list with AssertValues inside, ' +
-      'or (b) a SetValues step to extract a specific field into a named variable, then assert that variable.'
+        'To assert SOQL results use either: (a) a ForEach loop over the result list with AssertValues inside, ' +
+        'or (b) a SetValues step to extract a specific field into a named variable, then assert that variable.'
     );
   }
 
@@ -79,10 +79,10 @@ const StepSchema = z.object({
     .string()
     .describe(
       'Provar step API ID. Shorthand forms are accepted and auto-expanded to fully-qualified IDs: ' +
-      'UiConnect, UiDoAction, UiWithScreen, UiAssert, UiNavigate, UiWithRow, ' +
-      'ApexConnect, ApexSoqlQuery, ApexCreateObject, ApexReadObject, ApexUpdateObject, ApexDeleteObject, ' +
-      'SetValues, AssertValues, StepGroup, Sleep, ForEach, CaseCall. ' +
-      'Or pass the fully-qualified ID directly (com.provar.plugins.*).'
+        'UiConnect, UiDoAction, UiWithScreen, UiAssert, UiNavigate, UiWithRow, ' +
+        'ApexConnect, ApexSoqlQuery, ApexCreateObject, ApexReadObject, ApexUpdateObject, ApexDeleteObject, ' +
+        'SetValues, AssertValues, StepGroup, Sleep, ForEach, CaseCall. ' +
+        'Or pass the fully-qualified ID directly (com.provar.plugins.*).'
     ),
   name: z.string().describe('Human-readable step name'),
   attributes: z
@@ -90,9 +90,9 @@ const StepSchema = z.object({
     .default({})
     .describe(
       'Step argument values as key/value pairs. Written as <arguments><argument id="key"><value .../></argument></arguments> ' +
-      'inside the <apiCall> element — the format Provar runtime requires. ' +
-      'Do NOT rely on XML attributes on <apiCall>; the runtime silently ignores them. ' +
-      'Example: { "connectionName": "MyOrg", "objectApiName": "Opportunity" }'
+        'inside the <apiCall> element — the format Provar runtime requires. ' +
+        'Do NOT rely on XML attributes on <apiCall>; the runtime silently ignores them. ' +
+        'Example: { "connectionName": "MyOrg", "objectApiName": "Opportunity" }'
     ),
 });
 
@@ -109,6 +109,7 @@ const TOOL_DESCRIPTION = [
   'AssertValues on SOQL results: index paths like "ResultList[0].Field" are not supported.',
   'Use ForEach to iterate the result list, or SetValues to extract a field into a variable first.',
   'Validation: the response always includes a validation field with is_valid, validity_score, quality_score, and any structural issues — check this before attempting to run the test case.',
+  'Grounding: call provar.qualityhub.examples.retrieve before generating to get corpus examples for the scenario — correct XML structure for the step types you need.',
 ].join(' ');
 
 export function registerTestCaseGenerate(server: McpServer, config: ServerConfig): void {
@@ -117,24 +118,12 @@ export function registerTestCaseGenerate(server: McpServer, config: ServerConfig
     TOOL_DESCRIPTION,
     {
       test_case_name: z.string().describe('Test case name (human-readable label)'),
-      test_case_id: z
-        .string()
-        .optional()
-        .describe('Explicit test case id; auto-generated UUID v4 if omitted'),
+      test_case_id: z.string().optional().describe('Explicit test case id; auto-generated UUID v4 if omitted'),
       steps: z.array(StepSchema).default([]).describe('Ordered list of test steps'),
-      output_path: z
-        .string()
-        .optional()
-        .describe('Suggested file path for the .xml file (returned in response)'),
+      output_path: z.string().optional().describe('Suggested file path for the .xml file (returned in response)'),
       overwrite: z.boolean().default(false).describe('Overwrite if output_path file already exists'),
-      dry_run: z
-        .boolean()
-        .default(true)
-        .describe('true = return XML only (default); false = write to output_path'),
-      idempotency_key: z
-        .string()
-        .optional()
-        .describe('Caller-provided key echoed back for deduplication tracking'),
+      dry_run: z.boolean().default(true).describe('true = return XML only (default); false = write to output_path'),
+      idempotency_key: z.string().optional().describe('Caller-provided key echoed back for deduplication tracking'),
     },
     (input) => {
       const requestId = makeRequestId();
@@ -146,9 +135,7 @@ export function registerTestCaseGenerate(server: McpServer, config: ServerConfig
 
       try {
         const xmlContent = buildTestCaseXml(input);
-        const filePath: string | undefined = input.output_path
-          ? path.resolve(input.output_path)
-          : undefined;
+        const filePath: string | undefined = input.output_path ? path.resolve(input.output_path) : undefined;
         let written = false;
 
         if (filePath && !input.dry_run) {
@@ -197,7 +184,7 @@ export function registerTestCaseGenerate(server: McpServer, config: ServerConfig
       } catch (err: unknown) {
         const error = err as Error & { code?: string };
         const errResult = makeError(
-          error instanceof PathPolicyError ? error.code : (error.code ?? 'GENERATE_ERROR'),
+          error instanceof PathPolicyError ? error.code : error.code ?? 'GENERATE_ERROR',
           error.message,
           requestId,
           false
@@ -215,10 +202,11 @@ function buildArgumentsXml(attributes: Record<string, string>): string {
   const entries = Object.entries(attributes);
   if (entries.length === 0) return '';
   const argLines = entries
-    .map(([k, v]) =>
-      `      <argument id="${escapeXmlAttr(k)}">\n` +
-      `        <value class="value" valueClass="String">${escapeXmlContent(v)}</value>\n` +
-      '      </argument>'
+    .map(
+      ([k, v]) =>
+        `      <argument id="${escapeXmlAttr(k)}">\n` +
+        `        <value class="value" valueClass="String">${escapeXmlContent(v)}</value>\n` +
+        '      </argument>'
     )
     .join('\n');
   return `\n      <arguments>\n${argLines}\n      </arguments>\n    `;
@@ -264,16 +252,9 @@ function buildTestCaseXml(input: {
 }
 
 function escapeXmlAttr(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 function escapeXmlContent(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }

--- a/src/mcp/tools/testCaseGenerate.ts
+++ b/src/mcp/tools/testCaseGenerate.ts
@@ -205,7 +205,7 @@ function buildArgumentsXml(attributes: Record<string, string>): string {
     .map(
       ([k, v]) =>
         `      <argument id="${escapeXmlAttr(k)}">\n` +
-        `        <value class="value" valueClass="String">${escapeXmlContent(v)}</value>\n` +
+        `        <value class="value" valueClass="string">${escapeXmlContent(v)}</value>\n` +
         '      </argument>'
     )
     .join('\n');

--- a/test/unit/mcp/loopPrompts.test.ts
+++ b/test/unit/mcp/loopPrompts.test.ts
@@ -12,6 +12,7 @@ import {
   registerLoopFixPrompt,
   registerLoopReviewPrompt,
   registerLoopCoveragePrompt,
+  registerLoopDbPrompt,
 } from '../../../src/mcp/prompts/loopPrompts.js';
 
 // ── Minimal McpServer mock ─────────────────────────────────────────────────────
@@ -59,11 +60,12 @@ beforeEach(() => {
   registerLoopFixPrompt(server as never);
   registerLoopReviewPrompt(server as never);
   registerLoopCoveragePrompt(server as never);
+  registerLoopDbPrompt(server as never);
 });
 
 describe('loopPrompts — registration', () => {
-  it('registers all 4 loop prompts', () => {
-    assert.equal(server.registrations.length, 4);
+  it('registers all 5 loop prompts', () => {
+    assert.equal(server.registrations.length, 5);
   });
 
   it('registers provar.loop.generate', () => {
@@ -259,5 +261,95 @@ describe('loopPrompts — provar.loop.coverage', () => {
     const text = getMessageText(result);
     // When no targetOrg, the step 2 should be corpus retrieval, not QH testcase retrieve
     assert.ok(text.includes('provar.qualityhub.examples.retrieve'), 'should still include corpus retrieval');
+  });
+});
+
+describe('loopPrompts — provar.loop.db', () => {
+  it('registers provar.loop.db', () => {
+    const reg = server.registrations.find((r) => r.name === 'provar.loop.db');
+    assert.ok(reg, 'provar.loop.db should be registered');
+    assert.ok(reg.description.toLowerCase().includes('database'), 'description should mention database');
+  });
+
+  it('includes story text in message', () => {
+    const story = 'Verify Users table has Active records after SF flow runs';
+    const result = server.call('provar.loop.db', { story });
+    const text = getMessageText(result);
+    assert.ok(text.includes(story), 'message should contain the story text');
+  });
+
+  it('includes corpus retrieval and validate in workflow', () => {
+    const result = server.call('provar.loop.db', { story: 'any db test' });
+    const text = getMessageText(result);
+    assert.ok(text.includes('provar.qualityhub.examples.retrieve'), 'should reference corpus tool');
+    assert.ok(text.includes('provar.testcase.validate'), 'should reference validator tool');
+  });
+
+  it('references DbConnect and SqlQuery step types', () => {
+    const result = server.call('provar.loop.db', { story: 'any db test' });
+    const text = getMessageText(result);
+    assert.ok(text.includes('DbConnect'), 'should reference DbConnect step type');
+    assert.ok(text.includes('SqlQuery'), 'should reference SqlQuery step type');
+  });
+
+  it('warns about funcCall vs string expressions', () => {
+    const result = server.call('provar.loop.db', { story: 'any db test' });
+    const text = getMessageText(result);
+    assert.ok(text.includes('funcCall'), 'should mention funcCall for count');
+    assert.ok(text.includes('valueClass="id"'), 'should warn about connectionId valueClass="id"');
+  });
+
+  it('warns about resultName / dbConnectionName coupling', () => {
+    const result = server.call('provar.loop.db', { story: 'any db test' });
+    const text = getMessageText(result);
+    assert.ok(
+      text.includes('resultName') && text.includes('dbConnectionName'),
+      'should mention the resultName / dbConnectionName coupling'
+    );
+  });
+
+  it('includes dbConnectionName in message when provided', () => {
+    const result = server.call('provar.loop.db', {
+      story: 'any db test',
+      dbConnectionName: 'MyDB',
+    });
+    const text = getMessageText(result);
+    assert.ok(text.includes('MyDB'), 'message should include provided dbConnectionName');
+  });
+
+  it('includes projectPath when provided', () => {
+    const result = server.call('provar.loop.db', {
+      story: 'any db test',
+      projectPath: '/provar/project',
+    });
+    const text = getMessageText(result);
+    assert.ok(text.includes('/provar/project'), 'message should include project path');
+  });
+
+  it('includes testName when provided', () => {
+    const result = server.call('provar.loop.db', {
+      story: 'any db test',
+      testName: 'VerifyUsersTable',
+    });
+    const text = getMessageText(result);
+    assert.ok(text.includes('VerifyUsersTable'), 'message should include target test name');
+  });
+
+  it('explicitly forbids Salesforce UI and Apex steps', () => {
+    const result = server.call('provar.loop.db', { story: 'any db test' });
+    const text = getMessageText(result);
+    // The prompt names these steps to explicitly forbid them — verify that context
+    assert.ok(
+      text.includes('Do not use') || text.includes('do not use'),
+      'should explicitly forbid Salesforce/Apex steps'
+    );
+    assert.ok(text.includes('UiConnect'), 'should name UiConnect in the forbidden list');
+    assert.ok(text.includes('ApexConnect'), 'should name ApexConnect in the forbidden list');
+  });
+
+  it('includes step-reference fallback instruction', () => {
+    const result = server.call('provar.loop.db', { story: 'any db test' });
+    const text = getMessageText(result);
+    assert.ok(text.includes('provar://docs/step-reference'), 'should include step-reference fallback');
   });
 });

--- a/test/unit/mcp/loopPrompts.test.ts
+++ b/test/unit/mcp/loopPrompts.test.ts
@@ -308,13 +308,13 @@ describe('loopPrompts — provar.loop.db', () => {
     );
   });
 
-  it('includes dbConnectionName in message when provided', () => {
+  it('includes connectionName in message when provided', () => {
     const result = server.call('provar.loop.db', {
       story: 'any db test',
-      dbConnectionName: 'MyDB',
+      connectionName: 'MyDB',
     });
     const text = getMessageText(result);
-    assert.ok(text.includes('MyDB'), 'message should include provided dbConnectionName');
+    assert.ok(text.includes('MyDB'), 'message should include provided connectionName');
   });
 
   it('includes projectPath when provided', () => {

--- a/test/unit/mcp/testCaseGenerate.test.ts
+++ b/test/unit/mcp/testCaseGenerate.test.ts
@@ -156,9 +156,9 @@ describe('provar.testcase.generate', () => {
       const result = server.call('provar.testcase.generate', {
         test_case_name: 'Multi Step',
         steps: [
-          { api_id: 'UiConnect',  name: 'Connect',  attributes: {} },
+          { api_id: 'UiConnect', name: 'Connect', attributes: {} },
           { api_id: 'UiNavigate', name: 'Navigate', attributes: {} },
-          { api_id: 'UiDoAction', name: 'Click',    attributes: {} },
+          { api_id: 'UiDoAction', name: 'Click', attributes: {} },
         ],
         dry_run: true,
         overwrite: false,
@@ -177,7 +177,7 @@ describe('provar.testcase.generate', () => {
       const result = server.call('provar.testcase.generate', {
         test_case_name: 'Count Test',
         steps: [
-          { api_id: 'UiConnect',  name: 'Step 1', attributes: {} },
+          { api_id: 'UiConnect', name: 'Step 1', attributes: {} },
           { api_id: 'UiNavigate', name: 'Step 2', attributes: {} },
         ],
         dry_run: true,
@@ -202,7 +202,10 @@ describe('provar.testcase.generate', () => {
       assert.equal(typeof validation['validity_score'], 'number');
       assert.equal(typeof validation['quality_score'], 'number');
       assert.equal(validation['is_valid'], true, 'Well-formed generated XML should be valid');
-      assert.ok(!('best_practices_violations' in validation), 'best_practices_violations should be omitted from slim response');
+      assert.ok(
+        !('best_practices_violations' in validation),
+        'best_practices_violations should be omitted from slim response'
+      );
     });
 
     it('emits a TODO comment when no steps are provided', () => {
@@ -366,6 +369,27 @@ describe('provar.testcase.generate', () => {
       });
 
       assert.equal(parseText(result)['idempotency_key'], 'dedup-key-abc');
+    });
+  });
+
+  describe('XML argument valueClass casing', () => {
+    it('emits lowercase valueClass="string" not uppercase "String"', () => {
+      const result = server.call('provar.testcase.generate', {
+        test_case_name: 'ValueClass Test',
+        steps: [
+          {
+            api_id: 'UiConnect',
+            name: 'Connect',
+            attributes: { connectionName: 'MyOrg' },
+          },
+        ],
+        dry_run: true,
+        overwrite: false,
+      });
+
+      const xml = parseText(result)['xml_content'] as string;
+      assert.ok(xml.includes('valueClass="string"'), 'Expected lowercase valueClass="string"');
+      assert.ok(!xml.includes('valueClass="String"'), 'Must not emit uppercase valueClass="String"');
     });
   });
 });


### PR DESCRIPTION
## Summary

- **`provar.loop.db` prompt** — new MCP prompt for external database test generation (SQL Server, Oracle, MySQL, PostgreSQL). Distinct from Salesforce/SOQL flows. Enforces the three patterns that caused ~6-iteration failures in a real session.
- **PROVAR_TEST_STEP_REFERENCE.md Database section** — critical constraints box, corrected `connectionId` to `valueClass="id"`, full counter-examples for `funcCall` vs `{Count(Var)}` and structured variable paths vs `{Var[0].Field}` anti-patterns.
- **`examples.retrieve` trigger broadened** — description changed from "before testcase.generate" to "before writing any Provar .testcase XML — whether via generate, Write, or Edit." Closes the most common organic workflow gap.
- **Bidirectional grounding note** added to `testcase.generate` description.
- **Smoke test count** updated to 48; full unit test coverage for `provar.loop.db`.

## Root cause addressed

A real database test generation session required ~6 iterations to pass. Every failure was a format/schema error, not a logic error. Three bugs repeated across all test cases:

1. `{Count(ResultVar)}` string expression used in SetValues instead of `<value class="funcCall" id="Count">` — stored verbatim, never evaluated.
2. `{ResultVar[0].FieldName}` string expression used instead of the structured `<value class="variable"><path><filter class="index">` form.
3. `DbConnect.resultName` not matching `SqlQuery.dbConnectionName`, plus `connectionId` with `valueClass="string"` instead of `"id"`.

## What this PR does NOT address (deferred to follow-up)

- Auth-aware routing in `provar_automation_testrun` (P2)
- Nudge to call `provar_testcase_validate` after raw Write (P2)
- Making `examples.retrieve` non-deferred (needs architectural decision)

## Test plan

- [x] Unit tests: `test/unit/mcp/loopPrompts.test.ts` — 45 tests pass including 11 new `provar.loop.db` tests
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] Lint clean (wireit/eslint hook passed)
- [x] Smoke test count updated to 48

🤖 Generated with [Claude Code](https://claude.com/claude-code)