### PR TITLE
feat(mcp): Wave 1 inner-loop improvements — divergence warning, JUnit steps, validateTestCaseXml export

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -817,9 +817,9 @@ If the file you read differs on critical fields (`provarHome`, `projectPath`, `r
 | ----------- | ------ | -------- | ------------------------------------------- |
 | `file_path` | string | yes      | Path to the `provardx-properties.json` file |
 
-**Output** — `{ file_path, content[, details.warning] }` where `content` is the parsed JSON object. `details.warning` is present when the file diverges from the active sf config.
+**Output** — `{ requestId, file_path, content[, details.warning] }` where `content` is the parsed JSON object. `details.warning` is present when the file diverges from the active sf config.
 
-**Error codes:** `PROPERTIES_FILE_NOT_FOUND`, `MALFORMED_JSON`, `PATH_NOT_ALLOWED`
+**Error codes:** `PROPERTIES_FILE_NOT_FOUND`, `MALFORMED_JSON`, `PATH_NOT_ALLOWED`, `PATH_TRAVERSAL`
 
 ---
 
@@ -855,7 +855,7 @@ Updates one or more fields in a `provardx-properties.json` file. Only the suppli
 
 **Output** — `{ file_path, updated_fields, content }`
 
-**Error codes:** `FILE_NOT_FOUND`, `MALFORMED_JSON`, `PATH_NOT_ALLOWED`
+**Error codes:** `PROPERTIES_FILE_NOT_FOUND`, `MALFORMED_JSON`, `PATH_NOT_ALLOWED`
 
 ---
 
@@ -879,7 +879,7 @@ Validates a `provardx-properties.json` file against the ProvarDX schema. Checks 
 | `warning_count` | Number of warnings (e.g. unfilled placeholders) |
 | `issues`        | Array of `{ field, severity, message }`         |
 
-**Error codes:** `MISSING_INPUT`, `FILE_NOT_FOUND`, `MALFORMED_JSON`, `PATH_NOT_ALLOWED`
+**Error codes:** `MISSING_INPUT`, `PROPERTIES_FILE_NOT_FOUND`, `MALFORMED_JSON`, `PATH_NOT_ALLOWED`
 
 ---
 
@@ -1150,7 +1150,7 @@ Triggers a Provar Automation test run using the currently loaded properties file
 
 The `stdout` field is filtered before returning: Java schema-validator lines (`com.networknt.schema.*`) and stale logger-lock `SEVERE` warnings are stripped. If any lines were suppressed, `output_lines_suppressed` contains the count.
 
-After each run, the tool scans the results directory for `JUnit.xml` and adds a `steps` array when results are found:
+After each run, the tool scans the results directory for JUnit XML files and adds a `steps` array when results are found:
 
 ```json
 "steps": [

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -807,7 +807,9 @@ Generates a `provardx-properties.json` file from the standard template. Placehol
 
 ### `provar.properties.read`
 
-Reads and parses a `provardx-properties.json` file. Use this to inspect the current configuration before making changes with `provar.properties.set`.
+Reads and parses a `provardx-properties.json` file directly from disk. Use this to inspect the current configuration before making changes with `provar.properties.set`.
+
+If the file you read differs on critical fields (`provarHome`, `projectPath`, `resultsPath`) from the file currently registered via `provar.automation.config.load`, the response will include a `details.warning` listing the divergent keys. This catches the common case where the agent reads one file but test runs use another.
 
 **Input**
 
@@ -815,9 +817,9 @@ Reads and parses a `provardx-properties.json` file. Use this to inspect the curr
 | ----------- | ------ | -------- | ------------------------------------------- |
 | `file_path` | string | yes      | Path to the `provardx-properties.json` file |
 
-**Output** — `{ file_path, content }` where `content` is the parsed JSON object.
+**Output** — `{ file_path, content[, details.warning] }` where `content` is the parsed JSON object. `details.warning` is present when the file diverges from the active sf config.
 
-**Error codes:** `FILE_NOT_FOUND`, `MALFORMED_JSON`, `PATH_NOT_ALLOWED`
+**Error codes:** `PROPERTIES_FILE_NOT_FOUND`, `MALFORMED_JSON`, `PATH_NOT_ALLOWED`
 
 ---
 
@@ -1144,9 +1146,20 @@ Triggers a Provar Automation test run using the currently loaded properties file
 | --------- | -------- | -------- | ------------------------------------------------------------------------ |
 | `flags`   | string[] | no       | Raw CLI flags to forward (e.g. `["--project-path", "/path/to/project"]`) |
 
-**Output** — `{ requestId, exitCode, stdout, stderr[, output_lines_suppressed] }`
+**Output** — `{ requestId, exitCode, stdout, stderr[, output_lines_suppressed][, steps][, details.warning] }`
 
-The `stdout` field is filtered before returning: Java schema-validator lines (`com.networknt.schema.*`) and stale logger-lock `SEVERE` warnings are stripped. If any lines were suppressed, `output_lines_suppressed` contains the count and a note is appended to `stdout`. Use `provar.testrun.rca` to inspect the full raw JUnit output.
+The `stdout` field is filtered before returning: Java schema-validator lines (`com.networknt.schema.*`) and stale logger-lock `SEVERE` warnings are stripped. If any lines were suppressed, `output_lines_suppressed` contains the count.
+
+After each run, the tool scans the results directory for `JUnit.xml` and adds a `steps` array when results are found:
+
+```json
+"steps": [
+  { "testItemId": "1", "title": "TC-Login-001-LoginAndVerify.testcase", "status": "pass" },
+  { "testItemId": "2", "title": "TC-Login-002-ForgotPassword.testcase", "status": "fail", "errorMessage": "Execution failed: Element not found" }
+]
+```
+
+Each entry represents one test case. `status` is `"pass"`, `"fail"`, or `"skip"`. If the results directory cannot be located or contains no JUnit XML, `details.warning` explains why and `steps` is absent.
 
 **Error codes:** `AUTOMATION_TESTRUN_FAILED`, `SF_NOT_FOUND`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provartesting/provardx-cli",
   "description": "A plugin for the Salesforce CLI to orchestrate testing activities and report quality metrics to Provar Quality Hub",
-  "version": "1.5.0-beta.9",
+  "version": "1.5.0-beta.10",
   "mcpName": "io.github.provartesting/provar",
   "license": "BSD-3-Clause",
   "plugins": [

--- a/server.json
+++ b/server.json
@@ -14,12 +14,12 @@
     "url": "https://github.com/ProvarTesting/provardx-cli",
     "source": "github"
   },
-  "version": "1.5.0-beta.9",
+  "version": "1.5.0-beta.10",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@provartesting/provardx-cli",
-      "version": "1.5.0-beta.9",
+      "version": "1.5.0-beta.10",
       "transport": {
         "type": "stdio"
       },

--- a/src/mcp/tools/antTools.ts
+++ b/src/mcp/tools/antTools.ts
@@ -23,9 +23,7 @@ const FilesetSchema = z.object({
   id: z
     .string()
     .optional()
-    .describe(
-      'Fileset id — use "testplan" for plan-based runs, "testcases" for test case runs, omit for default'
-    ),
+    .describe('Fileset id — use "testplan" for plan-based runs, "testcases" for test case runs, omit for default'),
   includes: z
     .array(z.string())
     .optional()
@@ -35,9 +33,7 @@ const FilesetSchema = z.object({
 });
 
 const PlanFeatureSchema = z.object({
-  name: z
-    .enum(['PDF', 'PIECHART', 'EMAIL', 'JUNIT'])
-    .describe('Feature name (PDF, PIECHART, EMAIL, JUNIT)'),
+  name: z.enum(['PDF', 'PIECHART', 'EMAIL', 'JUNIT']).describe('Feature name (PDF, PIECHART, EMAIL, JUNIT)'),
   type: z.enum(['OUTPUT', 'NOTIFICATION']).describe('Feature type'),
   enabled: z.boolean().describe('Whether this feature is enabled'),
 });
@@ -88,9 +84,7 @@ export function registerAntGenerate(server: McpServer, config: ServerConfig): vo
       project_path: z
         .string()
         .default('..')
-        .describe(
-          'Path to the Provar test project root. Defaults to ".." (parent of the ANT folder).'
-        ),
+        .describe('Path to the Provar test project root. Defaults to ".." (parent of the ANT folder).'),
       results_path: z
         .string()
         .default('../ANT/Results')
@@ -98,9 +92,7 @@ export function registerAntGenerate(server: McpServer, config: ServerConfig): vo
       project_cache_path: z
         .string()
         .optional()
-        .describe(
-          'Path to the .provarCaches directory. Defaults to "../../.provarCaches" relative to the ANT folder.'
-        ),
+        .describe('Path to the .provarCaches directory. Defaults to "../../.provarCaches" relative to the ANT folder.'),
       license_path: z
         .string()
         .optional()
@@ -130,14 +122,8 @@ export function registerAntGenerate(server: McpServer, config: ServerConfig): vo
         .string()
         .default('Full Screen')
         .describe('Browser window configuration (e.g. "Full Screen").'),
-      web_browser_provider_name: z
-        .string()
-        .default('Desktop')
-        .describe('Browser provider name (e.g. "Desktop").'),
-      web_browser_device_name: z
-        .string()
-        .default('Full Screen')
-        .describe('Browser device name (e.g. "Full Screen").'),
+      web_browser_provider_name: z.string().default('Desktop').describe('Browser provider name (e.g. "Desktop").'),
+      web_browser_device_name: z.string().default('Full Screen').describe('Browser device name (e.g. "Full Screen").'),
       test_environment: z
         .string()
         .default('')
@@ -182,10 +168,7 @@ export function registerAntGenerate(server: McpServer, config: ServerConfig): vo
         .describe(
           'When true, the ANT build does not fail even if tests fail. Useful for CI pipelines that collect results separately.'
         ),
-      invoke_test_run_monitor: z
-        .boolean()
-        .default(true)
-        .describe('Enable the Provar test run monitor.'),
+      invoke_test_run_monitor: z.boolean().default(true).describe('Enable the Provar test run monitor.'),
 
       // ── Secrets / security ──────────────────────────────────────────────────
       secrets_password: z
@@ -202,10 +185,7 @@ export function registerAntGenerate(server: McpServer, config: ServerConfig): vo
         ),
 
       // ── Test Cycle ──────────────────────────────────────────────────────────
-      test_cycle_path: z
-        .string()
-        .optional()
-        .describe('Path to a TestCycle folder (used with test cycle reporting).'),
+      test_cycle_path: z.string().optional().describe('Path to a TestCycle folder (used with test cycle reporting).'),
       test_cycle_run_type: z
         .enum(['ALL', 'FAILED', 'NEW'])
         .optional()
@@ -233,14 +213,8 @@ export function registerAntGenerate(server: McpServer, config: ServerConfig): vo
         .string()
         .optional()
         .describe('Where to write the build.xml file (returned in response). Required when dry_run=false.'),
-      overwrite: z
-        .boolean()
-        .default(false)
-        .describe('Overwrite output_path if the file already exists.'),
-      dry_run: z
-        .boolean()
-        .default(true)
-        .describe('true = return XML only (default); false = write to output_path.'),
+      overwrite: z.boolean().default(false).describe('Overwrite output_path if the file already exists.'),
+      dry_run: z.boolean().default(true).describe('true = return XML only (default); false = write to output_path.'),
     },
     (input) => {
       const requestId = makeRequestId();
@@ -296,7 +270,7 @@ export function registerAntGenerate(server: McpServer, config: ServerConfig): vo
       } catch (err: unknown) {
         const error = err as Error & { code?: string };
         const errResult = makeError(
-          error instanceof PathPolicyError ? error.code : (error.code ?? 'GENERATE_ERROR'),
+          error instanceof PathPolicyError ? error.code : error.code ?? 'GENERATE_ERROR',
           error.message,
           requestId,
           false
@@ -320,14 +294,8 @@ export function registerAntValidate(server: McpServer, config: ServerConfig): vo
       'and at least one <fileset> child. Returns is_valid, issues list, and a validity_score.',
     ].join(' '),
     {
-      content: z
-        .string()
-        .optional()
-        .describe('XML content to validate directly'),
-      file_path: z
-        .string()
-        .optional()
-        .describe('Path to the build.xml file to validate'),
+      content: z.string().optional().describe('XML content to validate directly'),
+      file_path: z.string().optional().describe('Path to the build.xml file to validate'),
     },
     ({ content, file_path }) => {
       const requestId = makeRequestId();
@@ -467,9 +435,7 @@ function buildAntXml(input: AntGenerateInput): string {
       `\t<property name="testenvironment.secretspassword" value="${a(input.test_environment_secrets_password)}"/>`
     );
   } else {
-    lines.push(
-      '\t<property name="testenvironment.secretspassword" value="${env.ProvarSecretsPassword_EnvName}"/>'
-    );
+    lines.push('\t<property name="testenvironment.secretspassword" value="${env.ProvarSecretsPassword_EnvName}"/>');
   }
 
   if (input.test_cycle_path) {
@@ -536,9 +502,7 @@ function buildAntXml(input: AntGenerateInput): string {
   // ── Plan features ─────────────────────────────────────────────────────────────
   if (input.plan_features && input.plan_features.length > 0) {
     for (const pf of input.plan_features) {
-      lines.push(
-        `\t\t\t<planFeature name="${a(pf.name)}" type="${a(pf.type)}" enabled="${pf.enabled}"/>`
-      );
+      lines.push(`\t\t\t<planFeature name="${a(pf.name)}" type="${a(pf.type)}" enabled="${pf.enabled}"/>`);
     }
     lines.push('');
   }
@@ -547,7 +511,11 @@ function buildAntXml(input: AntGenerateInput): string {
   if (input.email_properties) {
     const ep = input.email_properties;
     lines.push(
-      `\t\t\t<emailProperties sendEmail="${ep.send_email}" primaryRecipients="${a(ep.primary_recipients)}" ccRecipients="${a(ep.cc_recipients ?? '')}" bccRecipients="${a(ep.bcc_recipients ?? '')}" emailSubject="${a(ep.email_subject)}" attachExecutionReport="${ep.attach_execution_report}" attachZip="${ep.attach_zip}"/>`
+      `\t\t\t<emailProperties sendEmail="${ep.send_email}" primaryRecipients="${a(
+        ep.primary_recipients
+      )}" ccRecipients="${a(ep.cc_recipients ?? '')}" bccRecipients="${a(ep.bcc_recipients ?? '')}" emailSubject="${a(
+        ep.email_subject
+      )}" attachExecutionReport="${ep.attach_execution_report}" attachZip="${ep.attach_zip}"/>`
     );
   }
 
@@ -589,10 +557,7 @@ export interface AntValidationResult {
   issues: ValidationIssue[];
 }
 
-const REQUIRED_TASKDEF_CLASSNAMES = [
-  'com.provar.testrunner.ant.CompileTask',
-  'com.provar.testrunner.ant.RunnerTask',
-];
+const REQUIRED_TASKDEF_CLASSNAMES = ['com.provar.testrunner.ant.CompileTask', 'com.provar.testrunner.ant.RunnerTask'];
 
 const VALID_BROWSERS = ['Chrome', 'Chrome_Headless', 'Firefox', 'Edge', 'Edge_Legacy', 'Safari', 'IE'];
 const VALID_CACHE = ['Reuse', 'Refresh', 'Reload'];
@@ -667,21 +632,55 @@ function validateProjectStructure(
   return target;
 }
 
-function validateRtcEnumAttrs(rtc: Record<string, unknown>, webBrowser: string | null, issues: ValidationIssue[]): void {
+function validateRtcEnumAttrs(
+  rtc: Record<string, unknown>,
+  webBrowser: string | null,
+  issues: ValidationIssue[]
+): void {
   if (webBrowser && !VALID_BROWSERS.includes(webBrowser)) {
-    issues.push({ rule_id: 'ANT_030', severity: 'WARNING', message: `webBrowser "${webBrowser}" is not a recognised value. Expected one of: ${VALID_BROWSERS.join(', ')}.`, applies_to: 'Run-Test-Case', suggestion: `Use one of the supported browser values: ${VALID_BROWSERS.join(', ')}.` });
+    issues.push({
+      rule_id: 'ANT_030',
+      severity: 'WARNING',
+      message: `webBrowser "${webBrowser}" is not a recognised value. Expected one of: ${VALID_BROWSERS.join(', ')}.`,
+      applies_to: 'Run-Test-Case',
+      suggestion: `Use one of the supported browser values: ${VALID_BROWSERS.join(', ')}.`,
+    });
   }
   const metadataCache = rtc['@_salesforceMetadataCache'] as string | undefined;
   if (metadataCache && !VALID_CACHE.includes(metadataCache)) {
-    issues.push({ rule_id: 'ANT_031', severity: 'WARNING', message: `salesforceMetadataCache "${metadataCache}" is not a recognised value. Expected one of: ${VALID_CACHE.join(', ')}.`, applies_to: 'Run-Test-Case', suggestion: `Use one of: ${VALID_CACHE.join(', ')}.` });
+    issues.push({
+      rule_id: 'ANT_031',
+      severity: 'WARNING',
+      message: `salesforceMetadataCache "${metadataCache}" is not a recognised value. Expected one of: ${VALID_CACHE.join(
+        ', '
+      )}.`,
+      applies_to: 'Run-Test-Case',
+      suggestion: `Use one of: ${VALID_CACHE.join(', ')}.`,
+    });
   }
   const testOutputLevel = rtc['@_testOutputlevel'] as string | undefined;
   if (testOutputLevel && !VALID_OUTPUT_LEVELS.includes(testOutputLevel)) {
-    issues.push({ rule_id: 'ANT_032', severity: 'WARNING', message: `testOutputlevel "${testOutputLevel}" is not a recognised value. Expected one of: ${VALID_OUTPUT_LEVELS.join(', ')}.`, applies_to: 'Run-Test-Case', suggestion: `Use one of: ${VALID_OUTPUT_LEVELS.join(', ')}.` });
+    issues.push({
+      rule_id: 'ANT_032',
+      severity: 'WARNING',
+      message: `testOutputlevel "${testOutputLevel}" is not a recognised value. Expected one of: ${VALID_OUTPUT_LEVELS.join(
+        ', '
+      )}.`,
+      applies_to: 'Run-Test-Case',
+      suggestion: `Use one of: ${VALID_OUTPUT_LEVELS.join(', ')}.`,
+    });
   }
   const disposition = rtc['@_resultsPathDisposition'] as string | undefined;
   if (disposition && !VALID_DISPOSITIONS.includes(disposition)) {
-    issues.push({ rule_id: 'ANT_033', severity: 'WARNING', message: `resultsPathDisposition "${disposition}" is not a recognised value. Expected one of: ${VALID_DISPOSITIONS.join(', ')}.`, applies_to: 'Run-Test-Case', suggestion: `Use one of: ${VALID_DISPOSITIONS.join(', ')}.` });
+    issues.push({
+      rule_id: 'ANT_033',
+      severity: 'WARNING',
+      message: `resultsPathDisposition "${disposition}" is not a recognised value. Expected one of: ${VALID_DISPOSITIONS.join(
+        ', '
+      )}.`,
+      applies_to: 'Run-Test-Case',
+      suggestion: `Use one of: ${VALID_DISPOSITIONS.join(', ')}.`,
+    });
   }
 }
 
@@ -693,22 +692,52 @@ function validateRunTestCase(rtc: Record<string, unknown>, issues: ValidationIss
   const testEnvironment = (rtc['@_testEnvironment'] as string | undefined) ?? null;
 
   if (!provarHome) {
-    issues.push({ rule_id: 'ANT_021', severity: 'ERROR', message: '<Run-Test-Case> missing required "provarHome" attribute.', applies_to: 'Run-Test-Case', suggestion: 'Add provarHome="${provar.home}" to <Run-Test-Case>.' });
+    issues.push({
+      rule_id: 'ANT_021',
+      severity: 'ERROR',
+      message: '<Run-Test-Case> missing required "provarHome" attribute.',
+      applies_to: 'Run-Test-Case',
+      suggestion: 'Add provarHome="${provar.home}" to <Run-Test-Case>.',
+    });
   }
   if (!projectPath) {
-    issues.push({ rule_id: 'ANT_022', severity: 'ERROR', message: '<Run-Test-Case> missing required "projectPath" attribute.', applies_to: 'Run-Test-Case', suggestion: 'Add projectPath="${testproject.home}" to <Run-Test-Case>.' });
+    issues.push({
+      rule_id: 'ANT_022',
+      severity: 'ERROR',
+      message: '<Run-Test-Case> missing required "projectPath" attribute.',
+      applies_to: 'Run-Test-Case',
+      suggestion: 'Add projectPath="${testproject.home}" to <Run-Test-Case>.',
+    });
   }
   if (!resultsPath) {
-    issues.push({ rule_id: 'ANT_023', severity: 'ERROR', message: '<Run-Test-Case> missing required "resultsPath" attribute.', applies_to: 'Run-Test-Case', suggestion: 'Add resultsPath="${testproject.results}" to <Run-Test-Case>.' });
+    issues.push({
+      rule_id: 'ANT_023',
+      severity: 'ERROR',
+      message: '<Run-Test-Case> missing required "resultsPath" attribute.',
+      applies_to: 'Run-Test-Case',
+      suggestion: 'Add resultsPath="${testproject.results}" to <Run-Test-Case>.',
+    });
   }
   validateRtcEnumAttrs(rtc, webBrowser, issues);
   const filesets = (rtc['fileset'] as Array<Record<string, unknown>> | undefined) ?? [];
   if (filesets.length === 0) {
-    issues.push({ rule_id: 'ANT_040', severity: 'ERROR', message: '<Run-Test-Case> has no <fileset> children — no tests will be selected.', applies_to: 'Run-Test-Case', suggestion: 'Add at least one <fileset dir="..."/> pointing to your tests or plans folder.' });
+    issues.push({
+      rule_id: 'ANT_040',
+      severity: 'ERROR',
+      message: '<Run-Test-Case> has no <fileset> children — no tests will be selected.',
+      applies_to: 'Run-Test-Case',
+      suggestion: 'Add at least one <fileset dir="..."/> pointing to your tests or plans folder.',
+    });
   }
   for (const [i, fsEntry] of filesets.entries()) {
     if (!(fsEntry['@_dir'] as string | undefined)) {
-      issues.push({ rule_id: 'ANT_041', severity: 'ERROR', message: `<fileset> at index ${i} is missing required "dir" attribute.`, applies_to: 'fileset', suggestion: 'Add dir="..." to each <fileset> element.' });
+      issues.push({
+        rule_id: 'ANT_041',
+        severity: 'ERROR',
+        message: `<fileset> at index ${i} is missing required "dir" attribute.`,
+        applies_to: 'fileset',
+        suggestion: 'Add dir="..." to each <fileset> element.',
+      });
     }
   }
   return { provarHome, projectPath, resultsPath, webBrowser, testEnvironment, filesetCount: filesets.length };
@@ -734,8 +763,7 @@ export function validateAntXml(xmlContent: string): AntValidationResult {
     ignoreAttributes: false,
     attributeNamePrefix: '@_',
     parseAttributeValue: false,
-    isArray: (tagName) =>
-      ['taskdef', 'target', 'fileset', 'include', 'planFeature'].includes(tagName),
+    isArray: (tagName) => ['taskdef', 'target', 'fileset', 'include', 'planFeature'].includes(tagName),
   });
   let parsed: Record<string, unknown>;
   try {
@@ -797,8 +825,10 @@ export function validateAntXml(xmlContent: string): AntValidationResult {
     return finalizeAnt(issues, null, null, null, null, null, 0);
   }
 
-  const { provarHome, projectPath, resultsPath, webBrowser, testEnvironment, filesetCount } =
-    validateRunTestCase(rtc, issues);
+  const { provarHome, projectPath, resultsPath, webBrowser, testEnvironment, filesetCount } = validateRunTestCase(
+    rtc,
+    issues
+  );
 
   return finalizeAnt(issues, provarHome, projectPath, resultsPath, webBrowser, testEnvironment, filesetCount);
 }
@@ -829,6 +859,156 @@ function finalizeAnt(
     warning_count: warningCount,
     issues,
   };
+}
+
+// ── JUnit XML step parsing ────────────────────────────────────────────────────
+
+export interface JUnitStepResult {
+  testItemId: string;
+  title: string;
+  status: 'pass' | 'fail' | 'skip';
+  errorMessage?: string;
+}
+
+export interface JUnitParseResult {
+  steps: JUnitStepResult[];
+  warning?: string;
+}
+
+function extractFailureText(el: unknown): string | undefined {
+  if (!el) return undefined;
+  if (typeof el === 'string') return el.trim() || undefined;
+  if (typeof el === 'object') {
+    const obj = el as Record<string, unknown>;
+    // Prefer CDATA body ('#text') — it has the specific error. Fall back to 'message' attribute.
+    const body = (obj['#text'] as string | undefined)?.trim();
+    const msg = (obj['message'] as string | undefined)?.trim();
+    if (body && msg && body !== msg) return `${msg}: ${body}`;
+    return body ?? msg;
+  }
+  return undefined;
+}
+
+function extractStepsFromJUnit(parsed: Record<string, unknown>): JUnitStepResult[] {
+  const steps: JUnitStepResult[] = [];
+  let idx = 0;
+
+  // Normalise to array of suites — handles both <testsuites> and bare <testsuite>
+  let suites: Array<Record<string, unknown>> = [];
+  if (parsed['testsuites']) {
+    const inner = (parsed['testsuites'] as Record<string, unknown>)['testsuite'];
+    suites = Array.isArray(inner)
+      ? (inner as Array<Record<string, unknown>>)
+      : inner
+      ? [inner as Record<string, unknown>]
+      : [];
+  } else if (parsed['testsuite']) {
+    const ts = parsed['testsuite'];
+    suites = Array.isArray(ts) ? (ts as Array<Record<string, unknown>>) : [ts as Record<string, unknown>];
+  }
+
+  for (const suite of suites) {
+    const rawTc = suite['testcase'];
+    if (!rawTc) continue;
+    const testcases: Array<Record<string, unknown>> = Array.isArray(rawTc)
+      ? (rawTc as Array<Record<string, unknown>>)
+      : [rawTc as Record<string, unknown>];
+
+    for (const tc of testcases) {
+      idx++;
+      // Provar JUnit: name = test case file name (no attribute prefix since attributeNamePrefix: '')
+      const title = (tc['name'] as string | undefined) ?? `Test ${idx}`;
+      const hasFailure = 'failure' in tc || 'error' in tc;
+      const hasSkipped = 'skipped' in tc;
+
+      let status: 'pass' | 'fail' | 'skip' = 'pass';
+      if (hasFailure) status = 'fail';
+      else if (hasSkipped) status = 'skip';
+
+      const errorMessage = extractFailureText(tc['failure'] ?? tc['error']);
+      const step: JUnitStepResult = { testItemId: String(idx), title, status };
+      if (errorMessage) step.errorMessage = errorMessage;
+      steps.push(step);
+    }
+  }
+
+  return steps;
+}
+
+function findXmlFiles(dir: string): string[] {
+  const results: string[] = [];
+  try {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith('.xml') && !entry.name.startsWith('.')) {
+        results.push(path.join(dir, entry.name));
+      }
+    }
+  } catch {
+    // ignore unreadable dirs
+  }
+  return results;
+}
+
+/**
+ * Scan a Provar results directory for JUnit XML files and return structured step results.
+ * Returns an empty steps array (+ optional warning) when no XML is found or parsing fails.
+ */
+export function parseJUnitResults(resultsDir: string): JUnitParseResult {
+  if (!fs.existsSync(resultsDir)) {
+    return { steps: [], warning: `Results directory not found: ${resultsDir}` };
+  }
+
+  const xmlFiles = findXmlFiles(resultsDir);
+  if (xmlFiles.length === 0) {
+    return {
+      steps: [],
+      warning: 'No JUnit XML files found in results directory — structured step output unavailable.',
+    };
+  }
+
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '',
+    textNodeName: '#text',
+    allowBooleanAttributes: true,
+    parseAttributeValue: false,
+    isArray: (tagName) => ['testsuite', 'testcase'].includes(tagName),
+  });
+
+  const allSteps: JUnitStepResult[] = [];
+  let parsedAny = false;
+  let parseFailures = 0;
+
+  for (const xmlFile of xmlFiles) {
+    try {
+      const content = fs.readFileSync(xmlFile, 'utf-8');
+      const parsed = parser.parse(content) as Record<string, unknown>;
+      const steps = extractStepsFromJUnit(parsed);
+      allSteps.push(...steps);
+      parsedAny = true;
+    } catch {
+      parseFailures++;
+    }
+  }
+
+  if (!parsedAny) {
+    return {
+      steps: [],
+      warning: 'JUnit XML files found but could not be parsed — structured step output unavailable.',
+    };
+  }
+  if (allSteps.length === 0) {
+    return {
+      steps: [],
+      warning: 'JUnit XML found but no test steps could be extracted — files may not be standard JUnit format.',
+    };
+  }
+
+  const warning =
+    parseFailures > 0
+      ? `${parseFailures} JUnit XML file(s) could not be parsed — step data may be incomplete.`
+      : undefined;
+  return { steps: allSteps, warning };
 }
 
 // ── Registration ──────────────────────────────────────────────────────────────

--- a/src/mcp/tools/automationTools.ts
+++ b/src/mcp/tools/automationTools.ts
@@ -360,9 +360,9 @@ function resolveLatestResultsDir(resultsBase: string): string {
 /**
  * Reads resultsPath from the currently active provardx-properties.json (via ~/.sf/config.json),
  * then resolves to the latest Increment-mode sibling directory.
- * Returns null when the sf config or properties file cannot be read.
+ * Returns null when the sf config or properties file cannot be read or is outside allowed paths.
  */
-function readResultsPathFromSfConfig(): string | null {
+function readResultsPathFromSfConfig(config: ServerConfig): string | null {
   if (sfResultsPathOverride !== undefined) return sfResultsPathOverride;
   try {
     const sfConfigPath = path.join(os.homedir(), '.sf', 'config.json');
@@ -370,10 +370,15 @@ function readResultsPathFromSfConfig(): string | null {
     const sfConfig = JSON.parse(fs.readFileSync(sfConfigPath, 'utf-8')) as Record<string, unknown>;
     const propFilePath = sfConfig['PROVARDX_PROPERTIES_FILE_PATH'] as string | undefined;
     if (!propFilePath || !fs.existsSync(propFilePath)) return null;
+    // Guard: only read the properties file if it is within the session's allowed paths.
+    assertPathAllowed(propFilePath, config.allowedPaths);
     const props = JSON.parse(fs.readFileSync(propFilePath, 'utf-8')) as Record<string, unknown>;
     const resultsBase = props['resultsPath'] as string | undefined;
     if (!resultsBase) return null;
-    return resolveLatestResultsDir(resultsBase);
+    const resultsDir = resolveLatestResultsDir(resultsBase);
+    // Guard: only read the results directory if it is within the session's allowed paths.
+    assertPathAllowed(resultsDir, config.allowedPaths);
+    return resultsDir;
   } catch {
     return null;
   }
@@ -381,7 +386,7 @@ function readResultsPathFromSfConfig(): string | null {
 
 // ── Tool: provar.automation.testrun ───────────────────────────────────────────
 
-export function registerAutomationTestRun(server: McpServer): void {
+export function registerAutomationTestRun(server: McpServer, config: ServerConfig): void {
   server.tool(
     'provar.automation.testrun',
     [
@@ -412,7 +417,7 @@ export function registerAutomationTestRun(server: McpServer): void {
         const { filtered, suppressed } = filterTestRunOutput(result.stdout);
 
         // Attempt to enrich the response with structured step data from JUnit XML
-        const resultsPath = readResultsPathFromSfConfig();
+        const resultsPath = readResultsPathFromSfConfig(config);
         const { steps, warning: junitWarning } = resultsPath
           ? parseJUnitResults(resultsPath)
           : { steps: [], warning: undefined };
@@ -764,7 +769,7 @@ export function registerAutomationSetup(server: McpServer): void {
 export function registerAllAutomationTools(server: McpServer, config: ServerConfig): void {
   registerAutomationSetup(server);
   registerAutomationConfigLoad(server, config);
-  registerAutomationTestRun(server);
+  registerAutomationTestRun(server, config);
   registerAutomationCompile(server);
   registerAutomationMetadataDownload(server);
 }

--- a/src/mcp/tools/automationTools.ts
+++ b/src/mcp/tools/automationTools.ts
@@ -15,6 +15,7 @@ import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
 import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
+import { parseJUnitResults } from './antTools.js';
 import { sfSpawnHelper, SfNotFoundError } from './sfSpawn.js';
 
 // ── SF CLI discovery ──────────────────────────────────────────────────────────
@@ -321,6 +322,63 @@ export function filterTestRunOutput(raw: string): { filtered: string; suppressed
   return { filtered, suppressed };
 }
 
+// ── JUnit results enrichment ──────────────────────────────────────────────────
+
+// Overrideable in tests — bypasses the sf config file read
+let sfResultsPathOverride: string | null | undefined;
+
+/** Exposed for testing only — set the results path returned by the sf config reader. Pass undefined to reset. */
+export function setSfResultsPathForTesting(p: string | null | undefined): void {
+  sfResultsPathOverride = p;
+}
+
+/**
+ * Resolves the actual results directory for the latest run.
+ * Provar's Increment disposition creates Results(1), Results(2)… as siblings of Results/.
+ * Returns the latest sibling dir, or the base path if no siblings exist.
+ */
+function resolveLatestResultsDir(resultsBase: string): string {
+  const parent = path.dirname(resultsBase);
+  const base = path.basename(resultsBase);
+  try {
+    const safeName = base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`^${safeName}\\((\\d+)\\)$`);
+    const indices = fs
+      .readdirSync(parent, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && pattern.test(e.name))
+      .map((e) => parseInt((pattern.exec(e.name) as RegExpExecArray)[1], 10));
+    if (indices.length > 0) {
+      const maxIdx = indices.reduce((a, b) => (a > b ? a : b), 0);
+      return path.join(parent, `${base}(${maxIdx})`);
+    }
+  } catch {
+    // ignore filesystem errors
+  }
+  return resultsBase;
+}
+
+/**
+ * Reads resultsPath from the currently active provardx-properties.json (via ~/.sf/config.json),
+ * then resolves to the latest Increment-mode sibling directory.
+ * Returns null when the sf config or properties file cannot be read.
+ */
+function readResultsPathFromSfConfig(): string | null {
+  if (sfResultsPathOverride !== undefined) return sfResultsPathOverride;
+  try {
+    const sfConfigPath = path.join(os.homedir(), '.sf', 'config.json');
+    if (!fs.existsSync(sfConfigPath)) return null;
+    const sfConfig = JSON.parse(fs.readFileSync(sfConfigPath, 'utf-8')) as Record<string, unknown>;
+    const propFilePath = sfConfig['PROVARDX_PROPERTIES_FILE_PATH'] as string | undefined;
+    if (!propFilePath || !fs.existsSync(propFilePath)) return null;
+    const props = JSON.parse(fs.readFileSync(propFilePath, 'utf-8')) as Record<string, unknown>;
+    const resultsBase = props['resultsPath'] as string | undefined;
+    if (!resultsBase) return null;
+    return resolveLatestResultsDir(resultsBase);
+  } catch {
+    return null;
+  }
+}
+
 // ── Tool: provar.automation.testrun ───────────────────────────────────────────
 
 export function registerAutomationTestRun(server: McpServer): void {
@@ -353,14 +411,28 @@ export function registerAutomationTestRun(server: McpServer): void {
         const result = runSfCommand(['provar', 'automation', 'test', 'run', ...flags], sf_path);
         const { filtered, suppressed } = filterTestRunOutput(result.stdout);
 
+        // Attempt to enrich the response with structured step data from JUnit XML
+        const resultsPath = readResultsPathFromSfConfig();
+        const { steps, warning: junitWarning } = resultsPath
+          ? parseJUnitResults(resultsPath)
+          : { steps: [], warning: undefined };
+
         if (result.exitCode !== 0) {
           const { filtered: filteredErr, suppressed: suppressedErr } = filterTestRunOutput(
             result.stderr || result.stdout
           );
-          const errBody = {
+          const errBody: Record<string, unknown> = {
             ...makeError('AUTOMATION_TESTRUN_FAILED', filteredErr, requestId),
             ...(suppressedErr > 0 ? { output_lines_suppressed: suppressedErr } : {}),
           };
+          if (steps.length > 0) errBody['steps'] = steps;
+          if (!resultsPath || junitWarning) {
+            errBody['details'] = {
+              warning:
+                junitWarning ??
+                'Could not locate results directory — step-level output unavailable. Run provar.automation.config.load first.',
+            };
+          }
           return { isError: true as const, content: [{ type: 'text' as const, text: JSON.stringify(errBody) }] };
         }
 
@@ -371,6 +443,8 @@ export function registerAutomationTestRun(server: McpServer): void {
           stderr: result.stderr,
         };
         if (suppressed > 0) response['output_lines_suppressed'] = suppressed;
+        if (steps.length > 0) response['steps'] = steps;
+        if (junitWarning) response['details'] = { warning: junitWarning };
         return { content: [{ type: 'text' as const, text: JSON.stringify(response) }], structuredContent: response };
       } catch (err) {
         return handleSpawnError(err, requestId, 'provar.automation.testrun');

--- a/src/mcp/tools/propertiesTools.ts
+++ b/src/mcp/tools/propertiesTools.ts
@@ -501,7 +501,7 @@ export function registerPropertiesSet(server: McpServer, config: ServerConfig): 
                 type: 'text' as const,
                 text: JSON.stringify(
                   makeError(
-                    'FILE_NOT_FOUND',
+                    'PROPERTIES_FILE_NOT_FOUND',
                     `File not found: ${resolved}. Use provar.properties.generate to create it first.`,
                     requestId
                   )
@@ -601,7 +601,9 @@ export function registerPropertiesValidate(server: McpServer, config: ServerConf
               content: [
                 {
                   type: 'text' as const,
-                  text: JSON.stringify(makeError('FILE_NOT_FOUND', `File not found: ${resolved}`, requestId)),
+                  text: JSON.stringify(
+                    makeError('PROPERTIES_FILE_NOT_FOUND', `File not found: ${resolved}`, requestId)
+                  ),
                 },
               ],
             };

--- a/src/mcp/tools/propertiesTools.ts
+++ b/src/mcp/tools/propertiesTools.ts
@@ -7,6 +7,7 @@
 
 /* eslint-disable camelcase */
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -52,10 +53,19 @@ function validateProperties(props: Record<string, unknown>): ValidationError[] {
   const meta = props['metadata'] as Record<string, unknown> | undefined;
   if (meta && typeof meta === 'object') {
     for (const f of METADATA_REQUIRED) {
-      if (!meta[f]) errors.push({ field: `metadata.${f}`, message: `Required field "metadata.${f}" is missing`, severity: 'error' });
+      if (!meta[f])
+        errors.push({
+          field: `metadata.${f}`,
+          message: `Required field "metadata.${f}" is missing`,
+          severity: 'error',
+        });
     }
     if (meta['metadataLevel'] && !VALID_METADATA_LEVELS.includes(meta['metadataLevel'] as string)) {
-      errors.push({ field: 'metadata.metadataLevel', message: `metadata.metadataLevel must be one of: ${VALID_METADATA_LEVELS.join(', ')}`, severity: 'error' });
+      errors.push({
+        field: 'metadata.metadataLevel',
+        message: `metadata.metadataLevel must be one of: ${VALID_METADATA_LEVELS.join(', ')}`,
+        severity: 'error',
+      });
     }
   }
 
@@ -63,29 +73,63 @@ function validateProperties(props: Record<string, unknown>): ValidationError[] {
   const env = props['environment'] as Record<string, unknown> | undefined;
   if (env && typeof env === 'object') {
     for (const f of ENV_REQUIRED) {
-      if (!env[f]) errors.push({ field: `environment.${f}`, message: `Required field "environment.${f}" is missing`, severity: 'error' });
+      if (!env[f])
+        errors.push({
+          field: `environment.${f}`,
+          message: `Required field "environment.${f}" is missing`,
+          severity: 'error',
+        });
     }
     if (env['webBrowser'] && !VALID_BROWSERS.includes(env['webBrowser'] as string)) {
-      errors.push({ field: 'environment.webBrowser', message: `webBrowser must be one of: ${VALID_BROWSERS.join(', ')}`, severity: 'error' });
+      errors.push({
+        field: 'environment.webBrowser',
+        message: `webBrowser must be one of: ${VALID_BROWSERS.join(', ')}`,
+        severity: 'error',
+      });
     }
   }
 
   // Optional enum fields
-  if (props['resultsPathDisposition'] && !VALID_RESULTS_DISPOSITION.includes(props['resultsPathDisposition'] as string)) {
-    errors.push({ field: 'resultsPathDisposition', message: `Must be one of: ${VALID_RESULTS_DISPOSITION.join(', ')}`, severity: 'error' });
+  if (
+    props['resultsPathDisposition'] &&
+    !VALID_RESULTS_DISPOSITION.includes(props['resultsPathDisposition'] as string)
+  ) {
+    errors.push({
+      field: 'resultsPathDisposition',
+      message: `Must be one of: ${VALID_RESULTS_DISPOSITION.join(', ')}`,
+      severity: 'error',
+    });
   }
   if (props['testOutputLevel'] && !VALID_OUTPUT_LEVELS.includes(props['testOutputLevel'] as string)) {
-    errors.push({ field: 'testOutputLevel', message: `Must be one of: ${VALID_OUTPUT_LEVELS.join(', ')}`, severity: 'error' });
+    errors.push({
+      field: 'testOutputLevel',
+      message: `Must be one of: ${VALID_OUTPUT_LEVELS.join(', ')}`,
+      severity: 'error',
+    });
   }
   if (props['pluginOutputlevel'] && !VALID_PLUGIN_LEVELS.includes(props['pluginOutputlevel'] as string)) {
-    errors.push({ field: 'pluginOutputlevel', message: `Must be one of: ${VALID_PLUGIN_LEVELS.join(', ')}`, severity: 'error' });
+    errors.push({
+      field: 'pluginOutputlevel',
+      message: `Must be one of: ${VALID_PLUGIN_LEVELS.join(', ')}`,
+      severity: 'error',
+    });
   }
 
   // Warn about placeholder values still in file
-  const placeholders = ['${PROVAR_HOME}', '${PROVAR_PROJECT_PATH}', '${PROVAR_RESULTS_PATH}', '${PROVAR_TEST_ENVIRONMENT}', '${PROVAR_TEST_PROJECT_SECRETS}'];
+  const placeholders = [
+    '${PROVAR_HOME}',
+    '${PROVAR_PROJECT_PATH}',
+    '${PROVAR_RESULTS_PATH}',
+    '${PROVAR_TEST_ENVIRONMENT}',
+    '${PROVAR_TEST_PROJECT_SECRETS}',
+  ];
   for (const [key, value] of Object.entries(props)) {
     if (typeof value === 'string' && placeholders.includes(value)) {
-      errors.push({ field: key, message: `Field "${key}" still contains placeholder value "${value}" — replace with actual path or use an environment variable`, severity: 'warning' });
+      errors.push({
+        field: key,
+        message: `Field "${key}" still contains placeholder value "${value}" — replace with actual path or use an environment variable`,
+        severity: 'warning',
+      });
     }
   }
 
@@ -96,8 +140,14 @@ function validateProperties(props: Record<string, unknown>): ValidationError[] {
 function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {
   const result = { ...target };
   for (const [key, val] of Object.entries(source)) {
-    if (val !== null && typeof val === 'object' && !Array.isArray(val) &&
-        result[key] !== null && typeof result[key] === 'object' && !Array.isArray(result[key])) {
+    if (
+      val !== null &&
+      typeof val === 'object' &&
+      !Array.isArray(val) &&
+      result[key] !== null &&
+      typeof result[key] === 'object' &&
+      !Array.isArray(result[key])
+    ) {
       result[key] = deepMerge(result[key] as Record<string, unknown>, val as Record<string, unknown>);
     } else {
       result[key] = val;
@@ -122,7 +172,11 @@ export function registerPropertiesGenerate(server: McpServer, config: ServerConf
       project_path: z.string().optional().describe('Pre-fill the projectPath field with this value'),
       provar_home: z.string().optional().describe('Pre-fill the provarHome field with this value'),
       results_path: z.string().optional().describe('Pre-fill the resultsPath field with this value'),
-      overwrite: z.boolean().optional().default(false).describe('Overwrite the file if it already exists (default: false)'),
+      overwrite: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe('Overwrite the file if it already exists (default: false)'),
       dry_run: z.boolean().optional().default(false).describe('Return the content without writing (default: false)'),
     },
     ({ output_path, project_path, provar_home, results_path, overwrite, dry_run }) => {
@@ -134,15 +188,37 @@ export function registerPropertiesGenerate(server: McpServer, config: ServerConf
         const resolved = path.resolve(output_path);
 
         if (!overwrite && fs.existsSync(resolved)) {
-          return { isError: true, content: [{ type: 'text' as const, text: JSON.stringify(makeError('FILE_EXISTS', `File already exists: ${resolved}. Set overwrite: true to replace it.`, requestId)) }] };
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify(
+                  makeError(
+                    'FILE_EXISTS',
+                    `File already exists: ${resolved}. Set overwrite: true to replace it.`,
+                    requestId
+                  )
+                ),
+              },
+            ],
+          };
         }
 
         if (!resolved.endsWith('.json')) {
-          return { isError: true, content: [{ type: 'text' as const, text: JSON.stringify(makeError('INVALID_PATH', 'output_path must end with .json', requestId)) }] };
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify(makeError('INVALID_PATH', 'output_path must end with .json', requestId)),
+              },
+            ],
+          };
         }
 
         // Start from the template and apply any provided overrides
-        const content: Record<string, unknown> = { ...propertyFileContent as unknown as Record<string, unknown> };
+        const content: Record<string, unknown> = { ...(propertyFileContent as unknown as Record<string, unknown>) };
         if (project_path) content['projectPath'] = project_path;
         if (provar_home) content['provarHome'] = provar_home;
         if (results_path) content['resultsPath'] = results_path;
@@ -158,16 +234,85 @@ export function registerPropertiesGenerate(server: McpServer, config: ServerConf
           ? 'Review the content, write to disk, then run provar.automation.config.load to register this file before compiling or running tests.'
           : `Run provar.automation.config.load with properties_path "${resolved}" to register this configuration. Required before provar.automation.compile or provar.automation.testrun will work.`;
 
-        const response = { requestId, file_path: resolved, written: !dry_run, dry_run: dry_run ?? false, content, next_steps: nextSteps };
+        const response = {
+          requestId,
+          file_path: resolved,
+          written: !dry_run,
+          dry_run: dry_run ?? false,
+          content,
+          next_steps: nextSteps,
+        };
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(response) }],
           structuredContent: response,
         };
       } catch (err: unknown) {
         const error = err as Error & { code?: string };
-        return { isError: true, content: [{ type: 'text' as const, text: JSON.stringify(makeError(error instanceof PathPolicyError ? error.code : (error.code ?? 'GENERATE_ERROR'), error.message, requestId)) }] };
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                makeError(
+                  error instanceof PathPolicyError ? error.code : error.code ?? 'GENERATE_ERROR',
+                  error.message,
+                  requestId
+                )
+              ),
+            },
+          ],
+        };
       }
     }
+  );
+}
+
+// ── Runtime divergence detection ──────────────────────────────────────────────
+
+// Overrideable in tests so we don't touch the real ~/.sf directory
+let sfConfigDirOverride: string | null = null;
+
+/** Exposed for testing only — override the directory that contains config.json. Pass null to reset. */
+export function setSfConfigDirForTesting(dir: string | null): void {
+  sfConfigDirOverride = dir;
+}
+
+/**
+ * Returns the properties file path registered via `sf provar automation config load`,
+ * or null if the sf config cannot be read.
+ */
+function readActivePropertiesPath(): string | null {
+  try {
+    const sfDir = sfConfigDirOverride ?? path.join(os.homedir(), '.sf');
+    const sfConfigPath = path.join(sfDir, 'config.json');
+    if (!fs.existsSync(sfConfigPath)) return null;
+    const sfConfig = JSON.parse(fs.readFileSync(sfConfigPath, 'utf-8')) as Record<string, unknown>;
+    return (sfConfig['PROVARDX_PROPERTIES_FILE_PATH'] as string | undefined) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compare two properties objects on the keys most likely to cause silent bugs.
+ * Returns a human-readable description of any divergent keys, or null if all match.
+ */
+function buildDivergenceWarning(
+  diskPath: string,
+  diskContent: Record<string, unknown>,
+  activePath: string,
+  activeContent: Record<string, unknown>
+): string | null {
+  const KEY_FIELDS = ['provarHome', 'projectPath', 'resultsPath'];
+  const divergent = KEY_FIELDS.filter((k) => JSON.stringify(diskContent[k]) !== JSON.stringify(activeContent[k]));
+  if (divergent.length === 0) return null;
+  const details = divergent
+    .map((k) => `${k}: disk="${String(diskContent[k])}" vs active="${String(activeContent[k])}"`)
+    .join(', ');
+  return (
+    `The file you read (${diskPath}) differs from the active sf config (${activePath}) on: ${details}. ` +
+    'Test runs use the active config values — run provar.automation.config.load with the correct file to sync.'
   );
 }
 
@@ -189,7 +334,21 @@ export function registerPropertiesRead(server: McpServer, config: ServerConfig):
         const resolved = path.resolve(file_path);
 
         if (!fs.existsSync(resolved)) {
-          return { isError: true, content: [{ type: 'text' as const, text: JSON.stringify(makeError('FILE_NOT_FOUND', `File not found: ${resolved}`, requestId)) }] };
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify(
+                  makeError(
+                    'PROPERTIES_FILE_NOT_FOUND',
+                    `Properties file not found: ${resolved}. Use provar.properties.generate to create it.`,
+                    requestId
+                  )
+                ),
+              },
+            ],
+          };
         }
 
         const raw = fs.readFileSync(resolved, 'utf-8');
@@ -197,17 +356,55 @@ export function registerPropertiesRead(server: McpServer, config: ServerConfig):
         try {
           parsed = JSON.parse(raw) as Record<string, unknown>;
         } catch {
-          return { isError: true, content: [{ type: 'text' as const, text: JSON.stringify(makeError('MALFORMED_JSON', 'File is not valid JSON', requestId)) }] };
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify(makeError('MALFORMED_JSON', 'File is not valid JSON', requestId)),
+              },
+            ],
+          };
         }
 
-        const response = { requestId, file_path: resolved, content: parsed };
+        // Check whether the file being read matches what's registered as active in the sf config.
+        // If they differ on critical fields, surface a warning so the agent doesn't silently use stale values.
+        let divergenceWarning: string | undefined;
+        const activePath = readActivePropertiesPath();
+        if (activePath && path.resolve(activePath) !== resolved) {
+          try {
+            // Guard: only read the active file if it is within the session's allowed paths.
+            assertPathAllowed(activePath, config.allowedPaths);
+            const activeContent = JSON.parse(fs.readFileSync(activePath, 'utf-8')) as Record<string, unknown>;
+            divergenceWarning = buildDivergenceWarning(resolved, parsed, activePath, activeContent) ?? undefined;
+          } catch {
+            // Ignore — active path may be outside allowed paths or unreadable
+          }
+        }
+
+        const response: Record<string, unknown> = { requestId, file_path: resolved, content: parsed };
+        if (divergenceWarning) response['details'] = { warning: divergenceWarning };
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(response) }],
           structuredContent: response,
         };
       } catch (err: unknown) {
         const error = err as Error & { code?: string };
-        return { isError: true, content: [{ type: 'text' as const, text: JSON.stringify(makeError(error instanceof PathPolicyError ? error.code : (error.code ?? 'READ_ERROR'), error.message, requestId)) }] };
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                makeError(
+                  error instanceof PathPolicyError ? error.code : error.code ?? 'READ_ERROR',
+                  error.message,
+                  requestId
+                )
+              ),
+            },
+          ],
+        };
       }
     }
   );
@@ -215,37 +412,64 @@ export function registerPropertiesRead(server: McpServer, config: ServerConfig):
 
 // ── provar.properties.set ─────────────────────────────────────────────────────
 
-const updatesSchema = z.object({
-  provarHome: z.string().optional().describe('Path to Provar installation directory'),
-  projectPath: z.string().optional().describe('Path to the Provar test project root'),
-  resultsPath: z.string().optional().describe('Path where test results will be written'),
-  resultsPathDisposition: z.enum(['Increment', 'Replace', 'Fail']).optional().describe('What to do if results path already exists'),
-  testOutputLevel: z.enum(['BASIC', 'DETAILED', 'DIAGNOSTIC']).optional().describe('Amount of test output logged'),
-  pluginOutputlevel: z.enum(['SEVERE', 'WARNING', 'INFO', 'FINE', 'FINER', 'FINEST']).optional().describe('Amount of plugin output logged'),
-  stopOnError: z.boolean().optional().describe('Abort test run on first failure'),
-  excludeCallable: z.boolean().optional().describe('Omit callable test cases from execution'),
-  testprojectSecrets: z.string().optional().describe(
-    'Encryption key (password string) used to decrypt the .secrets file in the Provar project root. ' +
-    'This is the key itself — NOT a file path. Omit this field unless your project uses secrets encryption.'
-  ),
-  environment: z.object({
-    testEnvironment: z.string().optional().describe('Name of the test environment to run against'),
-    webBrowser: z.enum(['Chrome', 'Safari', 'Edge', 'Edge_Legacy', 'Firefox', 'IE', 'Chrome_Headless']).optional(),
-    webBrowserConfig: z.string().optional(),
-    webBrowserProviderName: z.string().optional(),
-    webBrowserDeviceName: z.string().optional(),
-  }).optional().describe('Test execution environment settings'),
-  metadata: z.object({
-    metadataLevel: z.enum(['Reuse', 'Reload', 'Refresh']).optional().describe('Salesforce metadata cache strategy'),
-    cachePath: z.string().optional().describe('Path for the metadata cache'),
-  }).optional().describe('Salesforce metadata settings'),
-  testCase: z.array(z.string()).optional().describe('Specific test case file paths to run (relative to projectPath/tests/). NOTE: <dataTable> data-driven iteration does NOT work in this mode — data table variables resolve as null. To run data-driven tests, add the test case to a plan with provar.testplan.add-instance and run via testPlan instead.'),
-  testPlan: z.array(z.string()).optional().describe('Test plan names to run (wildcards permitted)'),
-  connectionOverride: z.array(z.object({
-    connection: z.string().describe('Provar connection name'),
-    username: z.string().describe('SFDX username or alias to substitute'),
-  })).optional().describe('Override Provar connections with SFDX usernames'),
-}).describe('Fields to update in the properties file — only provided fields are changed');
+const updatesSchema = z
+  .object({
+    provarHome: z.string().optional().describe('Path to Provar installation directory'),
+    projectPath: z.string().optional().describe('Path to the Provar test project root'),
+    resultsPath: z.string().optional().describe('Path where test results will be written'),
+    resultsPathDisposition: z
+      .enum(['Increment', 'Replace', 'Fail'])
+      .optional()
+      .describe('What to do if results path already exists'),
+    testOutputLevel: z.enum(['BASIC', 'DETAILED', 'DIAGNOSTIC']).optional().describe('Amount of test output logged'),
+    pluginOutputlevel: z
+      .enum(['SEVERE', 'WARNING', 'INFO', 'FINE', 'FINER', 'FINEST'])
+      .optional()
+      .describe('Amount of plugin output logged'),
+    stopOnError: z.boolean().optional().describe('Abort test run on first failure'),
+    excludeCallable: z.boolean().optional().describe('Omit callable test cases from execution'),
+    testprojectSecrets: z
+      .string()
+      .optional()
+      .describe(
+        'Encryption key (password string) used to decrypt the .secrets file in the Provar project root. ' +
+          'This is the key itself — NOT a file path. Omit this field unless your project uses secrets encryption.'
+      ),
+    environment: z
+      .object({
+        testEnvironment: z.string().optional().describe('Name of the test environment to run against'),
+        webBrowser: z.enum(['Chrome', 'Safari', 'Edge', 'Edge_Legacy', 'Firefox', 'IE', 'Chrome_Headless']).optional(),
+        webBrowserConfig: z.string().optional(),
+        webBrowserProviderName: z.string().optional(),
+        webBrowserDeviceName: z.string().optional(),
+      })
+      .optional()
+      .describe('Test execution environment settings'),
+    metadata: z
+      .object({
+        metadataLevel: z.enum(['Reuse', 'Reload', 'Refresh']).optional().describe('Salesforce metadata cache strategy'),
+        cachePath: z.string().optional().describe('Path for the metadata cache'),
+      })
+      .optional()
+      .describe('Salesforce metadata settings'),
+    testCase: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Specific test case file paths to run (relative to projectPath/tests/). NOTE: <dataTable> data-driven iteration does NOT work in this mode — data table variables resolve as null. To run data-driven tests, add the test case to a plan with provar.testplan.add-instance and run via testPlan instead.'
+      ),
+    testPlan: z.array(z.string()).optional().describe('Test plan names to run (wildcards permitted)'),
+    connectionOverride: z
+      .array(
+        z.object({
+          connection: z.string().describe('Provar connection name'),
+          username: z.string().describe('SFDX username or alias to substitute'),
+        })
+      )
+      .optional()
+      .describe('Override Provar connections with SFDX usernames'),
+  })
+  .describe('Fields to update in the properties file — only provided fields are changed');
 
 export function registerPropertiesSet(server: McpServer, config: ServerConfig): void {
   server.tool(
@@ -270,14 +494,36 @@ export function registerPropertiesSet(server: McpServer, config: ServerConfig): 
         const resolved = path.resolve(file_path);
 
         if (!fs.existsSync(resolved)) {
-          return { isError: true, content: [{ type: 'text' as const, text: JSON.stringify(makeError('FILE_NOT_FOUND', `File not found: ${resolved}. Use provar.properties.generate to create it first.`, requestId)) }] };
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify(
+                  makeError(
+                    'FILE_NOT_FOUND',
+                    `File not found: ${resolved}. Use provar.properties.generate to create it first.`,
+                    requestId
+                  )
+                ),
+              },
+            ],
+          };
         }
 
         let current: Record<string, unknown>;
         try {
           current = JSON.parse(fs.readFileSync(resolved, 'utf-8')) as Record<string, unknown>;
         } catch {
-          return { isError: true, content: [{ type: 'text' as const, text: JSON.stringify(makeError('MALFORMED_JSON', 'Existing file is not valid JSON', requestId)) }] };
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify(makeError('MALFORMED_JSON', 'Existing file is not valid JSON', requestId)),
+              },
+            ],
+          };
         }
 
         const updatesRecord = updates as Record<string, unknown>;
@@ -293,7 +539,21 @@ export function registerPropertiesSet(server: McpServer, config: ServerConfig): 
         };
       } catch (err: unknown) {
         const error = err as Error & { code?: string };
-        return { isError: true, content: [{ type: 'text' as const, text: JSON.stringify(makeError(error instanceof PathPolicyError ? error.code : (error.code ?? 'SET_ERROR'), error.message, requestId)) }] };
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                makeError(
+                  error instanceof PathPolicyError ? error.code : error.code ?? 'SET_ERROR',
+                  error.message,
+                  requestId
+                )
+              ),
+            },
+          ],
+        };
       }
     }
   );
@@ -318,7 +578,15 @@ export function registerPropertiesValidate(server: McpServer, config: ServerConf
       log('info', 'provar.properties.validate', { requestId, file_path });
 
       if (!file_path && !content) {
-        return { isError: true, content: [{ type: 'text' as const, text: JSON.stringify(makeError('MISSING_INPUT', 'Provide either file_path or content', requestId)) }] };
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(makeError('MISSING_INPUT', 'Provide either file_path or content', requestId)),
+            },
+          ],
+        };
       }
 
       try {
@@ -328,7 +596,15 @@ export function registerPropertiesValidate(server: McpServer, config: ServerConf
           assertPathAllowed(file_path, config.allowedPaths);
           const resolved = path.resolve(file_path);
           if (!fs.existsSync(resolved)) {
-            return { isError: true, content: [{ type: 'text' as const, text: JSON.stringify(makeError('FILE_NOT_FOUND', `File not found: ${resolved}`, requestId)) }] };
+            return {
+              isError: true,
+              content: [
+                {
+                  type: 'text' as const,
+                  text: JSON.stringify(makeError('FILE_NOT_FOUND', `File not found: ${resolved}`, requestId)),
+                },
+              ],
+            };
           }
           rawJson = fs.readFileSync(resolved, 'utf-8');
         } else {
@@ -339,7 +615,14 @@ export function registerPropertiesValidate(server: McpServer, config: ServerConf
         try {
           parsed = JSON.parse(rawJson) as Record<string, unknown>;
         } catch {
-          const response = { requestId, is_valid: false, error_count: 1, warning_count: 0, errors: [{ field: '(root)', message: 'File is not valid JSON', severity: 'error' }], warnings: [] };
+          const response = {
+            requestId,
+            is_valid: false,
+            error_count: 1,
+            warning_count: 0,
+            errors: [{ field: '(root)', message: 'File is not valid JSON', severity: 'error' }],
+            warnings: [],
+          };
           return { content: [{ type: 'text' as const, text: JSON.stringify(response) }], structuredContent: response };
         }
 
@@ -361,7 +644,21 @@ export function registerPropertiesValidate(server: McpServer, config: ServerConf
         };
       } catch (err: unknown) {
         const error = err as Error & { code?: string };
-        return { isError: true, content: [{ type: 'text' as const, text: JSON.stringify(makeError(error instanceof PathPolicyError ? error.code : (error.code ?? 'VALIDATE_ERROR'), error.message, requestId)) }] };
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                makeError(
+                  error instanceof PathPolicyError ? error.code : error.code ?? 'VALIDATE_ERROR',
+                  error.message,
+                  requestId
+                )
+              ),
+            },
+          ],
+        };
       }
     }
   );

--- a/src/mcp/tools/testCaseValidate.ts
+++ b/src/mcp/tools/testCaseValidate.ts
@@ -170,6 +170,21 @@ export interface TestCaseValidationResult {
   validation_warning?: string;
 }
 
+/**
+ * Reads a test case file from disk, validates it, and returns the result.
+ * Used by Wave 2 (testCaseGenerate) and Wave 3 (testCaseStepEdit) to validate
+ * after mutations without spawning a separate MCP tool call.
+ * Throws on path-policy violation or missing file.
+ */
+export function validateTestCaseXml(filePath: string, config: ServerConfig): TestCaseValidationResult {
+  assertPathAllowed(filePath, config.allowedPaths);
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    throw Object.assign(new Error(`File not found: ${resolved}`), { code: 'TESTCASE_FILE_NOT_FOUND' });
+  }
+  return validateTestCase(fs.readFileSync(resolved, 'utf-8'));
+}
+
 /** Pure function — exported for unit testing */
 export function validateTestCase(xmlContent: string, testName?: string): TestCaseValidationResult {
   const issues: ValidationIssue[] = [];

--- a/test/unit/mcp/antTools.test.ts
+++ b/test/unit/mcp/antTools.test.ts
@@ -11,7 +11,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, it, beforeEach, afterEach } from 'mocha';
-import { registerAntGenerate, validateAntXml } from '../../../src/mcp/tools/antTools.js';
+import { registerAntGenerate, validateAntXml, parseJUnitResults } from '../../../src/mcp/tools/antTools.js';
 import type { ServerConfig } from '../../../src/mcp/server.js';
 
 // ── Minimal McpServer mock ─────────────────────────────────────────────────────
@@ -52,7 +52,7 @@ function minimalInput(overrides: Record<string, unknown> = {}): Record<string, u
     provar_home: tmpDir,
     project_path: tmpDir,
     results_path: path.join(tmpDir, 'Results'),
-    filesets: [{ dir: '../tests' }],  // filesets.dir is not path-checked at runtime
+    filesets: [{ dir: '../tests' }], // filesets.dir is not path-checked at runtime
     web_browser: 'Chrome',
     web_browser_configuration: 'Full Screen',
     web_browser_provider_name: 'Desktop',
@@ -139,26 +139,17 @@ describe('provar.ant.generate', () => {
 
     it('includes <taskdef> for CompileTask', () => {
       const xml = getXml();
-      assert.ok(
-        xml.includes('com.provar.testrunner.ant.CompileTask'),
-        'Expected CompileTask taskdef'
-      );
+      assert.ok(xml.includes('com.provar.testrunner.ant.CompileTask'), 'Expected CompileTask taskdef');
     });
 
     it('includes <taskdef> for RunnerTask', () => {
       const xml = getXml();
-      assert.ok(
-        xml.includes('com.provar.testrunner.ant.RunnerTask'),
-        'Expected RunnerTask taskdef'
-      );
+      assert.ok(xml.includes('com.provar.testrunner.ant.RunnerTask'), 'Expected RunnerTask taskdef');
     });
 
     it('includes <taskdef> for TestCycleReportTask', () => {
       const xml = getXml();
-      assert.ok(
-        xml.includes('com.provar.testrunner.ant.TestCycleReportTask'),
-        'Expected TestCycleReportTask taskdef'
-      );
+      assert.ok(xml.includes('com.provar.testrunner.ant.TestCycleReportTask'), 'Expected TestCycleReportTask taskdef');
     });
 
     it('includes <Provar-Compile> step', () => {
@@ -184,10 +175,7 @@ describe('provar.ant.generate', () => {
     it('sets the provar.home property to the provided provar_home value', () => {
       const customHome = path.join(tmpDir, 'custom-provar');
       const xml = getXml({ provar_home: customHome });
-      assert.ok(
-        xml.includes(`<property name="provar.home" value="${customHome}"/>`),
-        'Expected provar.home property'
-      );
+      assert.ok(xml.includes(`<property name="provar.home" value="${customHome}"/>`), 'Expected provar.home property');
     });
 
     it('renders webBrowser attribute', () => {
@@ -433,10 +421,7 @@ describe('provar.ant.generate', () => {
 
       assert.equal(isError(result), true);
       const code = parseText(result)['error_code'] as string;
-      assert.ok(
-        code === 'PATH_NOT_ALLOWED' || code === 'PATH_TRAVERSAL',
-        `Unexpected error code: ${code}`
-      );
+      assert.ok(code === 'PATH_NOT_ALLOWED' || code === 'PATH_TRAVERSAL', `Unexpected error code: ${code}`);
     });
 
     it('output_path is not checked in dry_run=true mode', () => {
@@ -464,20 +449,14 @@ describe('provar.ant.generate', () => {
 
       assert.equal(isError(result), true);
       const code = parseText(result)['error_code'] as string;
-      assert.ok(
-        code === 'PATH_NOT_ALLOWED' || code === 'PATH_TRAVERSAL',
-        `Unexpected error code: ${code}`
-      );
+      assert.ok(code === 'PATH_NOT_ALLOWED' || code === 'PATH_TRAVERSAL', `Unexpected error code: ${code}`);
     });
 
     it('rejects project_path containing ".." (PATH_TRAVERSAL)', () => {
       const strictServer = new MockMcpServer();
       registerAntGenerate(strictServer as never, { allowedPaths: [tmpDir] });
 
-      const result = strictServer.call(
-        'provar.ant.generate',
-        strictInput({ project_path: '../evil', dry_run: true })
-      );
+      const result = strictServer.call('provar.ant.generate', strictInput({ project_path: '../evil', dry_run: true }));
 
       assert.equal(isError(result), true);
       assert.equal(parseText(result)['error_code'], 'PATH_TRAVERSAL');
@@ -494,10 +473,7 @@ describe('provar.ant.generate', () => {
 
       assert.equal(isError(result), true);
       const code = parseText(result)['error_code'] as string;
-      assert.ok(
-        code === 'PATH_NOT_ALLOWED' || code === 'PATH_TRAVERSAL',
-        `Unexpected error code: ${code}`
-      );
+      assert.ok(code === 'PATH_NOT_ALLOWED' || code === 'PATH_TRAVERSAL', `Unexpected error code: ${code}`);
     });
 
     it('rejects optional license_path outside allowedPaths when provided', () => {
@@ -511,10 +487,7 @@ describe('provar.ant.generate', () => {
 
       assert.equal(isError(result), true);
       const code = parseText(result)['error_code'] as string;
-      assert.ok(
-        code === 'PATH_NOT_ALLOWED' || code === 'PATH_TRAVERSAL',
-        `Unexpected error code: ${code}`
-      );
+      assert.ok(code === 'PATH_NOT_ALLOWED' || code === 'PATH_TRAVERSAL', `Unexpected error code: ${code}`);
     });
   });
 });
@@ -545,20 +518,29 @@ describe('validateAntXml', () => {
       // No <?xml …?> header — everything else is valid
       const noDecl = VALID_ANT.replace(/^<\?xml[^?]*\?>\n/, '');
       const r = validateAntXml(noDecl);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_001'), 'Expected ANT_001 warning');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_001'),
+        'Expected ANT_001 warning'
+      );
       // Still structurally valid — XML declaration is a warning only
       assert.equal(r.error_count, 0);
     });
 
     it('ANT_002: flags malformed XML', () => {
       const r = validateAntXml('<?xml version="1.0"?><project unclosed');
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_002'), 'Expected ANT_002 error');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_002'),
+        'Expected ANT_002 error'
+      );
       assert.equal(r.is_valid, false);
     });
 
     it('ANT_003: flags wrong root element', () => {
       const r = validateAntXml('<?xml version="1.0"?><notProject/>');
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_003'), 'Expected ANT_003 error');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_003'),
+        'Expected ANT_003 error'
+      );
       assert.equal(r.is_valid, false);
     });
   });
@@ -567,7 +549,10 @@ describe('validateAntXml', () => {
     it('ANT_004: flags missing default attribute on <project>', () => {
       const xml = VALID_ANT.replace('default="runtests"', '');
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_004'), 'Expected ANT_004 error');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_004'),
+        'Expected ANT_004 error'
+      );
     });
 
     it('ANT_005: flags missing CompileTask taskdef', () => {
@@ -609,7 +594,10 @@ describe('validateAntXml', () => {
     it('ANT_006: flags default target not found', () => {
       const xml = VALID_ANT.replace('name="runtests"', 'name="something-else"');
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_006'), 'Expected ANT_006 error');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_006'),
+        'Expected ANT_006 error'
+      );
     });
   });
 
@@ -627,17 +615,20 @@ describe('validateAntXml', () => {
   </target>
 </project>`;
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_010'), 'Expected ANT_010 warning');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_010'),
+        'Expected ANT_010 warning'
+      );
     });
 
     it('ANT_020: flags missing <Run-Test-Case>', () => {
       // Replace the Run-Test-Case block with a noop comment
-      const xml = VALID_ANT.replace(
-        /<Run-Test-Case[\s\S]*?<\/Run-Test-Case>/,
-        '<!-- removed -->'
-      );
+      const xml = VALID_ANT.replace(/<Run-Test-Case[\s\S]*?<\/Run-Test-Case>/, '<!-- removed -->');
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_020'), 'Expected ANT_020 error');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_020'),
+        'Expected ANT_020 error'
+      );
     });
   });
 
@@ -656,7 +647,10 @@ describe('validateAntXml', () => {
   </target>
 </project>`;
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_021'), 'Expected ANT_021 error');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_021'),
+        'Expected ANT_021 error'
+      );
     });
 
     it('ANT_022: flags missing projectPath', () => {
@@ -673,13 +667,19 @@ describe('validateAntXml', () => {
   </target>
 </project>`;
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_022'), 'Expected ANT_022 error');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_022'),
+        'Expected ANT_022 error'
+      );
     });
 
     it('ANT_023: flags missing resultsPath', () => {
       const xml = VALID_ANT.replace(' resultsPath="../ANT/Results"', '');
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_023'), 'Expected ANT_023 error');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_023'),
+        'Expected ANT_023 error'
+      );
     });
   });
 
@@ -687,34 +687,37 @@ describe('validateAntXml', () => {
     it('ANT_030: warns about unrecognised webBrowser value', () => {
       const xml = VALID_ANT.replace('webBrowser="Chrome"', 'webBrowser="InternetExplorer6"');
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_030'), 'Expected ANT_030 warning');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_030'),
+        'Expected ANT_030 warning'
+      );
     });
 
     it('ANT_031: warns about unrecognised salesforceMetadataCache value', () => {
-      const xml = VALID_ANT.replace(
-        '<Run-Test-Case',
-        '<Run-Test-Case salesforceMetadataCache="BadValue"'
-      );
+      const xml = VALID_ANT.replace('<Run-Test-Case', '<Run-Test-Case salesforceMetadataCache="BadValue"');
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_031'), 'Expected ANT_031 warning');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_031'),
+        'Expected ANT_031 warning'
+      );
     });
 
     it('ANT_032: warns about unrecognised testOutputlevel value', () => {
-      const xml = VALID_ANT.replace(
-        '<Run-Test-Case',
-        '<Run-Test-Case testOutputlevel="VERBOSE"'
-      );
+      const xml = VALID_ANT.replace('<Run-Test-Case', '<Run-Test-Case testOutputlevel="VERBOSE"');
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_032'), 'Expected ANT_032 warning');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_032'),
+        'Expected ANT_032 warning'
+      );
     });
 
     it('ANT_033: warns about unrecognised resultsPathDisposition value', () => {
-      const xml = VALID_ANT.replace(
-        '<Run-Test-Case',
-        '<Run-Test-Case resultsPathDisposition="Overwrite"'
-      );
+      const xml = VALID_ANT.replace('<Run-Test-Case', '<Run-Test-Case resultsPathDisposition="Overwrite"');
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_033'), 'Expected ANT_033 warning');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_033'),
+        'Expected ANT_033 warning'
+      );
     });
   });
 
@@ -722,13 +725,19 @@ describe('validateAntXml', () => {
     it('ANT_040: flags Run-Test-Case with no <fileset> children', () => {
       const xml = VALID_ANT.replace('<fileset dir="../tests"/>', '');
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_040'), 'Expected ANT_040 error');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_040'),
+        'Expected ANT_040 error'
+      );
     });
 
     it('ANT_041: flags a fileset missing dir attribute', () => {
       const xml = VALID_ANT.replace('<fileset dir="../tests"/>', '<fileset/>');
       const r = validateAntXml(xml);
-      assert.ok(r.issues.some((i) => i.rule_id === 'ANT_041'), 'Expected ANT_041 error');
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'ANT_041'),
+        'Expected ANT_041 error'
+      );
     });
 
     it('reports fileset_count correctly', () => {
@@ -767,5 +776,71 @@ describe('validateAntXml', () => {
       assert.equal(validation.is_valid, true, `Expected valid XML, got issues: ${JSON.stringify(validation.issues)}`);
       assert.equal(validation.error_count, 0);
     });
+  });
+});
+
+// ── parseJUnitResults ─────────────────────────────────────────────────────────
+
+describe('parseJUnitResults', () => {
+  let junitTmpDir: string;
+
+  beforeEach(() => {
+    junitTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'junit-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(junitTmpDir, { recursive: true, force: true });
+  });
+
+  it('returns warning when results directory does not exist', () => {
+    const result = parseJUnitResults(path.join(junitTmpDir, 'nonexistent'));
+    assert.deepEqual(result.steps, []);
+    assert.ok(result.warning?.includes('not found'));
+  });
+
+  it('returns warning when directory contains no XML files', () => {
+    const result = parseJUnitResults(junitTmpDir);
+    assert.deepEqual(result.steps, []);
+    assert.ok(result.warning?.includes('No JUnit XML'));
+  });
+
+  it('extracts steps from a bare <testsuite> JUnit file', () => {
+    const xml =
+      '<?xml version="1.0"?><testsuite name="suite"><testcase name="LoginTest"/><testcase name="LogoutTest"><failure message="Element not found"/></testcase></testsuite>';
+    fs.writeFileSync(path.join(junitTmpDir, 'JUnit.xml'), xml);
+    const result = parseJUnitResults(junitTmpDir);
+    assert.equal(result.steps.length, 2);
+    assert.equal(result.steps[0].status, 'pass');
+    assert.equal(result.steps[1].status, 'fail');
+    assert.ok(result.steps[1].errorMessage?.includes('Element not found'));
+    assert.equal(result.warning, undefined);
+  });
+
+  it('extracts steps from a <testsuites> wrapper JUnit file', () => {
+    const xml =
+      '<?xml version="1.0"?><testsuites><testsuite name="s1"><testcase name="TC1"><skipped/></testcase></testsuite></testsuites>';
+    fs.writeFileSync(path.join(junitTmpDir, 'JUnit.xml'), xml);
+    const result = parseJUnitResults(junitTmpDir);
+    assert.equal(result.steps.length, 1);
+    assert.equal(result.steps[0].status, 'skip');
+    assert.equal(result.steps[0].title, 'TC1');
+  });
+
+  it('returns warning when XML parses but contains no testcase elements', () => {
+    const xml = '<?xml version="1.0"?><testsuite name="empty"/>';
+    fs.writeFileSync(path.join(junitTmpDir, 'JUnit.xml'), xml);
+    const result = parseJUnitResults(junitTmpDir);
+    assert.deepEqual(result.steps, []);
+    assert.ok((result.warning?.length ?? 0) > 0);
+  });
+
+  it('combines message attribute and CDATA body in failure text', () => {
+    const xml =
+      '<?xml version="1.0"?><testsuite><testcase name="T1"><failure message="Execution failed"><![CDATA[stack trace here]]></failure></testcase></testsuite>';
+    fs.writeFileSync(path.join(junitTmpDir, 'JUnit.xml'), xml);
+    const result = parseJUnitResults(junitTmpDir);
+    assert.equal(result.steps.length, 1);
+    assert.ok(result.steps[0].errorMessage?.includes('Execution failed'));
+    assert.ok(result.steps[0].errorMessage?.includes('stack trace here'));
   });
 });

--- a/test/unit/mcp/automationTools.test.ts
+++ b/test/unit/mcp/automationTools.test.ts
@@ -17,6 +17,7 @@ import {
   needsWindowsShell,
   setSfPlatformForTesting,
   filterTestRunOutput,
+  setSfResultsPathForTesting,
 } from '../../../src/mcp/tools/automationTools.js';
 
 // ── Minimal mock server ───────────────────────────────────────────────────────
@@ -155,6 +156,76 @@ describe('automationTools', () => {
       const result = server.call('provar.automation.testrun', { flags: [] });
       const body = parseBody(result);
       assert.equal(body.output_lines_suppressed, undefined, 'output_lines_suppressed should be absent');
+    });
+
+    it('includes structured steps[] when JUnit XML is present in results dir', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'junit-test-'));
+      const junitXml = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="MyTest">
+  <testcase name="Login to Salesforce"/>
+  <testcase name="Click Account">
+    <failure message="Element not found">stack trace</failure>
+  </testcase>
+  <testcase name="Verify Name">
+    <skipped/>
+  </testcase>
+</testsuite>`;
+      fs.writeFileSync(path.join(tmpDir, 'results.xml'), junitXml, 'utf-8');
+      setSfResultsPathForTesting(tmpDir);
+
+      try {
+        spawnStub.returns(makeSpawnResult('tests done', '', 0));
+        const result = server.call('provar.automation.testrun', { flags: [] });
+        const body = parseBody(result);
+        assert.ok(Array.isArray(body.steps), 'steps should be an array');
+        const steps = body.steps as Array<{ testItemId: string; title: string; status: string; errorMessage?: string }>;
+        assert.equal(steps.length, 3);
+        assert.equal(steps[0].status, 'pass');
+        assert.equal(steps[1].status, 'fail');
+        assert.ok(
+          (steps[1].errorMessage as string).includes('Element not found'),
+          'errorMessage should include the failure message'
+        );
+        assert.equal(steps[2].status, 'skip');
+      } finally {
+        setSfResultsPathForTesting(undefined);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('omits steps[] and adds details.warning when results dir has no XML', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'junit-empty-'));
+      setSfResultsPathForTesting(tmpDir);
+
+      try {
+        spawnStub.returns(makeSpawnResult('tests done', '', 0));
+        const result = server.call('provar.automation.testrun', { flags: [] });
+        const body = parseBody(result);
+        assert.equal(body.steps, undefined, 'steps should be absent when no XML found');
+        assert.ok(body.details, 'details should be present');
+        const details = body.details as Record<string, unknown>;
+        assert.ok(typeof details.warning === 'string', 'details.warning should be a string');
+      } finally {
+        setSfResultsPathForTesting(undefined);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('omits steps[] and adds details.warning when results dir contains malformed XML', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'junit-bad-'));
+      fs.writeFileSync(path.join(tmpDir, 'results.xml'), '<not valid xml < >', 'utf-8');
+      setSfResultsPathForTesting(tmpDir);
+
+      try {
+        spawnStub.returns(makeSpawnResult('tests done', '', 0));
+        const result = server.call('provar.automation.testrun', { flags: [] });
+        const body = parseBody(result);
+        assert.equal(body.steps, undefined, 'steps should be absent when XML is malformed');
+        assert.ok(body.details, 'details should be present with warning');
+      } finally {
+        setSfResultsPathForTesting(undefined);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/test/unit/mcp/propertiesTools.test.ts
+++ b/test/unit/mcp/propertiesTools.test.ts
@@ -16,6 +16,7 @@ import {
   registerPropertiesRead,
   registerPropertiesSet,
   registerPropertiesValidate,
+  setSfConfigDirForTesting,
 } from '../../../src/mcp/tools/propertiesTools.js';
 import type { ServerConfig } from '../../../src/mcp/server.js';
 
@@ -219,13 +220,81 @@ describe('provar.properties.read', () => {
     assert.equal(content['projectPath'], '/proj');
   });
 
-  it('returns FILE_NOT_FOUND when file does not exist', () => {
+  it('returns PROPERTIES_FILE_NOT_FOUND when file does not exist', () => {
     const result = server.call('provar.properties.read', {
       file_path: path.join(tmpDir, 'missing.json'),
     });
 
     assert.equal(isError(result), true);
-    assert.equal(parseText(result)['error_code'], 'FILE_NOT_FOUND');
+    const body = parseText(result);
+    assert.equal(body['error_code'], 'PROPERTIES_FILE_NOT_FOUND');
+    assert.ok((body['message'] as string).includes('provar.properties.generate'), 'suggestion should mention generate');
+  });
+
+  it('surfaces divergence warning when active sf config points to a different file with different values', () => {
+    // "disk" file — the one we're about to read
+    const diskFile = path.join(tmpDir, 'props-disk.json');
+    fs.writeFileSync(diskFile, JSON.stringify({ provarHome: '/disk/provar', projectPath: '/disk/proj' }), 'utf-8');
+
+    // "active" file — what config.load registered
+    const activeFile = path.join(tmpDir, 'props-active.json');
+    fs.writeFileSync(
+      activeFile,
+      JSON.stringify({ provarHome: '/active/provar', projectPath: '/active/proj' }),
+      'utf-8'
+    );
+
+    // Write a temp sf config pointing to the active file
+    const sfDir = path.join(tmpDir, '.sf');
+    fs.mkdirSync(sfDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sfDir, 'config.json'),
+      JSON.stringify({ PROVARDX_PROPERTIES_FILE_PATH: activeFile }),
+      'utf-8'
+    );
+
+    setSfConfigDirForTesting(sfDir);
+    try {
+      const result = server.call('provar.properties.read', { file_path: diskFile });
+
+      assert.equal(isError(result), false);
+      const body = parseText(result);
+      assert.ok(body['details'], 'details should be present');
+      const details = body['details'] as Record<string, unknown>;
+      assert.ok(typeof details['warning'] === 'string', 'details.warning should be a string');
+      assert.ok(
+        typeof details['warning'] === 'string' && details['warning'].includes('provarHome'),
+        'warning should mention the divergent key'
+      );
+    } finally {
+      setSfConfigDirForTesting(null);
+    }
+  });
+
+  it('does not surface divergence warning when reading the same file that is active', () => {
+    const filePath = path.join(tmpDir, 'props.json');
+    const props = { provarHome: '/opt/provar', projectPath: '/proj' };
+    fs.writeFileSync(filePath, JSON.stringify(props), 'utf-8');
+
+    // Active file points to the same file
+    const sfDir = path.join(tmpDir, '.sf');
+    fs.mkdirSync(sfDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sfDir, 'config.json'),
+      JSON.stringify({ PROVARDX_PROPERTIES_FILE_PATH: filePath }),
+      'utf-8'
+    );
+
+    setSfConfigDirForTesting(sfDir);
+    try {
+      const result = server.call('provar.properties.read', { file_path: filePath });
+
+      assert.equal(isError(result), false);
+      const body = parseText(result);
+      assert.ok(!body['details'], 'details should be absent when no divergence');
+    } finally {
+      setSfConfigDirForTesting(null);
+    }
   });
 
   it('returns MALFORMED_JSON when file contains invalid JSON', () => {
@@ -260,7 +329,12 @@ describe('provar.properties.set', () => {
     const initial = {
       provarHome: '/opt/provar',
       projectPath: '/proj',
-      environment: { webBrowser: 'Chrome', webBrowserConfig: 'default', webBrowserProviderName: 'Desktop', webBrowserDeviceName: 'HD' },
+      environment: {
+        webBrowser: 'Chrome',
+        webBrowserConfig: 'default',
+        webBrowserProviderName: 'Desktop',
+        webBrowserDeviceName: 'HD',
+      },
     };
     fs.writeFileSync(filePath, JSON.stringify(initial, null, 2), 'utf-8');
 
@@ -364,7 +438,10 @@ describe('provar.properties.validate', () => {
     const body = parseText(result);
     assert.equal(body['is_valid'], false);
     const errors = body['errors'] as Array<{ field: string }>;
-    assert.ok(errors.some((e) => e.field === 'provarHome'), 'Expected error for provarHome');
+    assert.ok(
+      errors.some((e) => e.field === 'provarHome'),
+      'Expected error for provarHome'
+    );
   });
 
   it('reports warning for placeholder value ${PROVAR_HOME}', () => {
@@ -434,7 +511,10 @@ describe('provar.properties.validate', () => {
     const body = parseText(result);
     assert.equal(body['is_valid'], false);
     const errors = body['errors'] as Array<{ field: string }>;
-    assert.ok(errors.some((e) => e.field === 'environment.webBrowser'), 'Expected error on environment.webBrowser');
+    assert.ok(
+      errors.some((e) => e.field === 'environment.webBrowser'),
+      'Expected error on environment.webBrowser'
+    );
   });
 
   it('flags invalid metadataLevel enum value', () => {
@@ -446,6 +526,9 @@ describe('provar.properties.validate', () => {
     const body = parseText(result);
     assert.equal(body['is_valid'], false);
     const errors = body['errors'] as Array<{ field: string }>;
-    assert.ok(errors.some((e) => e.field === 'metadata.metadataLevel'), 'Expected error on metadata.metadataLevel');
+    assert.ok(
+      errors.some((e) => e.field === 'metadata.metadataLevel'),
+      'Expected error on metadata.metadataLevel'
+    );
   });
 });

--- a/test/unit/mcp/propertiesTools.test.ts
+++ b/test/unit/mcp/propertiesTools.test.ts
@@ -390,14 +390,14 @@ describe('provar.properties.set', () => {
     assert.deepEqual(written['testCase'], ['new/test2.testcase']);
   });
 
-  it('returns FILE_NOT_FOUND when file does not exist', () => {
+  it('returns PROPERTIES_FILE_NOT_FOUND when file does not exist', () => {
     const result = server.call('provar.properties.set', {
       file_path: path.join(tmpDir, 'ghost.json'),
       updates: { provarHome: '/x' },
     });
 
     assert.equal(isError(result), true);
-    assert.equal(parseText(result)['error_code'], 'FILE_NOT_FOUND');
+    assert.equal(parseText(result)['error_code'], 'PROPERTIES_FILE_NOT_FOUND');
   });
 
   it('returns PATH_NOT_ALLOWED for path outside allowedPaths', () => {
@@ -484,13 +484,13 @@ describe('provar.properties.validate', () => {
     assert.equal(parseText(result)['error_code'], 'MISSING_INPUT');
   });
 
-  it('returns FILE_NOT_FOUND when file_path points to a missing file', () => {
+  it('returns PROPERTIES_FILE_NOT_FOUND when file_path points to a missing file', () => {
     const result = server.call('provar.properties.validate', {
       file_path: path.join(tmpDir, 'nope.json'),
     });
 
     assert.equal(isError(result), true);
-    assert.equal(parseText(result)['error_code'], 'FILE_NOT_FOUND');
+    assert.equal(parseText(result)['error_code'], 'PROPERTIES_FILE_NOT_FOUND');
   });
 
   it('returns is_valid=false with root-level error for malformed JSON content', () => {

--- a/test/unit/mcp/testCaseValidate.test.ts
+++ b/test/unit/mcp/testCaseValidate.test.ts
@@ -6,7 +6,12 @@ import path from 'node:path';
 import { describe, it, beforeEach, afterEach } from 'mocha';
 import sinon from 'sinon';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { validateTestCase, registerTestCaseValidate } from '../../../src/mcp/tools/testCaseValidate.js';
+import {
+  validateTestCase,
+  registerTestCaseValidate,
+  validateTestCaseXml,
+} from '../../../src/mcp/tools/testCaseValidate.js';
+import type { ServerConfig } from '../../../src/mcp/server.js';
 import {
   qualityHubClient,
   QualityHubAuthError,
@@ -389,5 +394,44 @@ describe('registerTestCaseValidate handler', () => {
     const result = JSON.parse(res.content[0].text) as Record<string, unknown>;
     assert.equal(result['validation_source'], 'local_fallback');
     assert.ok(String(result['validation_warning']).toLowerCase().includes('rate limit'));
+  });
+});
+
+// ── validateTestCaseXml ───────────────────────────────────────────────────────
+
+function makeConfig(allowedPath: string): ServerConfig {
+  return { allowedPaths: [allowedPath] } as unknown as ServerConfig;
+}
+
+describe('validateTestCaseXml', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-xml-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads file from disk and returns validation result', () => {
+    const filePath = path.join(tmpDir, 'test.testcase');
+    fs.writeFileSync(filePath, VALID_TC);
+    const result = validateTestCaseXml(filePath, makeConfig(tmpDir));
+    assert.equal(result.is_valid, true);
+    assert.equal(result.error_count, 0);
+  });
+
+  it('throws TESTCASE_FILE_NOT_FOUND when file does not exist', () => {
+    const missing = path.join(tmpDir, 'missing.testcase');
+    assert.throws(
+      () => validateTestCaseXml(missing, makeConfig(tmpDir)),
+      (err: Error & { code?: string }) => err.code === 'TESTCASE_FILE_NOT_FOUND'
+    );
+  });
+
+  it('throws when file path is outside allowed paths', () => {
+    const outside = path.join(os.tmpdir(), 'outside.testcase');
+    assert.throws(() => validateTestCaseXml(outside, makeConfig(tmpDir)));
   });
 });


### PR DESCRIPTION
## Summary

Three targeted improvements to tighten the MCP agent debug loop (Wave 1):

- **A1 — `provar.properties.read` disk divergence warning**: When the file being read differs from the one registered in `~/.sf/config.json`, the tool now surfaces which path/resultsPath/provarHome fields differ so agents can self-correct without a manual inspection step. Path-policy guard added before reading the active file.
- **B1 — `provar.automation.testrun` JUnit step output**: After each run, the tool parses JUnit XML from the results directory and returns a structured `steps[]` array (name, status, failure message). Agents get per-step pass/fail data without a separate file-read round-trip.
- **B4 prep — `validateTestCaseXml` export**: Extracts the core XML validation logic from the MCP tool handler into a named export so Wave 2/3 features (test case generation, step editing) can validate in-process without an extra tool call.

## Commits

| SHA | Scope | Description |
|-----|-------|-------------|
| `a3820aa` | feat | A1 — disk divergence warning in provar.properties.read |
| `67aa066` | feat | B1 — JUnit structured step output in provar.automation.testrun |
| `81f4803` | feat | B4 prep — validateTestCaseXml export |
| `8fdfd04` | docs | docs/mcp.md updates for all three changes |
| `822eff7` | chore | version bump → 1.5.0-beta.10 |

## Adversarial review findings fixed

Three CRITICAL issues caught and resolved before merge:

1. **Path-policy bypass** (`propertiesTools.ts`): Active properties file was read without `assertPathAllowed()` guard — added try/catch wrapper that silently skips if the path is outside allowed paths.
2. **Silent partial data corruption** (`antTools.ts`): When some JUnit XML files parsed and others failed, the partial data was returned without any warning. Refactored to track `parseFailures` count and emit a warning even when `parsedAny=true`.
3. **Spread crash on large arrays** (`automationTools.ts`): `Math.max(...indices)` would blow the call stack on result sets with thousands of indices — replaced with `indices.reduce((a, b) => (a > b ? a : b), 0)`.

## Test coverage

- 743 passing (was 729 before this branch — +14 tests)
- New test suites: `parseJUnitResults` (6 tests in antTools.test.ts), `validateTestCaseXml` (3 tests in testCaseValidate.test.ts), JUnit enrichment (3 tests in automationTools.test.ts), divergence warning (2 tests in propertiesTools.test.ts)
- Error code rename: `FILE_NOT_FOUND` → `PROPERTIES_FILE_NOT_FOUND` (breaking for any caller checking the exact code string — intentional, old code was ambiguous)

## Docs

`docs/mcp.md` updated for:
- `PROPERTIES_FILE_NOT_FOUND` error code (renamed from `FILE_NOT_FOUND`)
- `divergence_warning` field in provar.properties.read response
- `steps[]` array shape in provar.automation.testrun response

**External docs flag**: `provar-mcp-public-docs.md` / `university-of-provar-mcp-course.md` need manual update for the divergence warning and JUnit steps features (public-facing behaviour changes).

## Test plan

- [x] `node_modules/.bin/nyc node_modules/.bin/mocha "test/**/*.test.ts"` → 743 passing
- [x] `yarn compile` → clean TypeScript
- [x] `node scripts/mcp-smoke.cjs` → all PASS (no new tools; count unchanged)
- [ ] Manual: read a properties file that differs from the sf-config active path → divergence_warning present in response
- [ ] Manual: run a test suite with failures → steps[] populated with failure details

🤖 Generated with [Claude Code](https://claude.com/claude-code)