### PR TITLE
fix: session 4 MCP feedback fixes (beta.14)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -632,6 +632,21 @@ Validates a Java Page Object source file against 30+ quality rules (structural c
 
 Generates an XML test case skeleton with UUID v4 guids and sequential `testItemId` values.
 
+**Generated `<testCase>` element structure (Provar requirements):**
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testCase guid="<uuid>" id="1" registryId="<uuid>">
+  <summary/>
+  <steps>...</steps>
+</testCase>
+```
+
+- `id` is always the integer literal `"1"` — Provar ignores any other value
+- No `name` attribute on `<testCase>` — Provar derives the name from the file name
+- `<summary/>` must appear before `<steps>`
+- `standalone="no"` is required in the XML declaration
+
 **URI-aware XML structure:** use `target_uri` to pick the correct XML nesting:
 
 - Omit or use a `sf:` URI → flat Salesforce step structure (existing behaviour)
@@ -639,13 +654,13 @@ Generates an XML test case skeleton with UUID v4 guids and sequential `testItemI
 
 **Argument XML conventions** (automatically applied by the generator):
 
-| Argument key / value pattern         | Emitted XML class             | API context                         |
-| ------------------------------------ | ----------------------------- | ----------------------------------- |
-| `target` key                         | `class="uiTarget"`            | UiWithScreen, UiWithRow             |
-| `locator` key                        | `class="uiLocator"`           | UiDoAction, UiAssert                |
-| Value matches `{VarName}` or `{A.B}` | `class="variable"` + `<path>` | Any step                            |
-| SetValues attributes                 | `class="valueList"/<namedValues>` | SetValues only                  |
-| All other values                     | `class="value" valueClass="string"` | Any step                      |
+| Argument key / value pattern         | Emitted XML class                   | API context             |
+| ------------------------------------ | ----------------------------------- | ----------------------- |
+| `target` key                         | `class="uiTarget"`                  | UiWithScreen, UiWithRow |
+| `locator` key                        | `class="uiLocator"`                 | UiDoAction, UiAssert    |
+| Value matches `{VarName}` or `{A.B}` | `class="variable"` + `<path>`       | Any step                |
+| SetValues attributes                 | `class="valueList"/<namedValues>`   | SetValues only          |
+| All other values                     | `class="value" valueClass="string"` | Any step                |
 
 AssertValues uses **flat** argument structure (`expectedValue`, `actualValue`, `comparisonType`) — not the `valueList`/namedValues format.
 
@@ -654,7 +669,6 @@ AssertValues uses **flat** argument structure (`expectedValue`, `actualValue`, `
 | Parameter             | Type                                     | Required | Description                                                                                                               |
 | --------------------- | ---------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `test_case_name`      | string                                   | yes      | Human-readable test case name                                                                                             |
-| `test_case_id`        | string                                   | no       | Custom test case ID (auto-generated if omitted)                                                                           |
 | `steps`               | array of `{ api_id, name, attributes? }` | no       | Step definitions                                                                                                          |
 | `target_uri`          | string                                   | no       | Page object URI. `ui:pageobject:target?pageId=pageobjects.X` triggers `UiWithScreen` nesting; `sf:` or absent → flat.     |
 | `output_path`         | string                                   | no       | File path to write (must be within `allowed-paths`)                                                                       |
@@ -662,6 +676,15 @@ AssertValues uses **flat** argument structure (`expectedValue`, `actualValue`, `
 | `dry_run`             | boolean                                  | no       | Return XML without writing to disk                                                                                        |
 | `validate_after_edit` | boolean                                  | no       | Run structural validation after generation (default: `true`). Returns `TESTCASE_INVALID` if invalid. Set `false` to skip. |
 | `idempotency_key`     | string                                   | no       | Prevents duplicate generation for the same key                                                                            |
+
+**`ApexSoqlQuery` argument IDs** (common source of runtime errors — wrong names are silently accepted but fail at runtime):
+
+| Argument ID          | Purpose                                     |
+| -------------------- | ------------------------------------------- |
+| `soqlQuery`          | The SOQL SELECT statement                   |
+| `resultListName`     | Variable name that receives the result list |
+| `apexConnectionName` | Named Salesforce connection                 |
+| `resultScope`        | Optional scope (Test, Local, Global)        |
 
 **Output** — `{ xml_content: string, file_path?: string, written: boolean, validation?: ValidationResult }`
 
@@ -793,16 +816,19 @@ Validates a Provar project directly from its directory on disk. Reads the plan/s
 
 **Output** (slim mode, `include_plan_details: false`)
 
-| Field                  | Description                                           |
-| ---------------------- | ----------------------------------------------------- |
-| `quality_score`        | Project quality score (0–100)                         |
-| `coverage_percent`     | Percentage of test cases covered by at least one plan |
-| `violation_summary`    | Map of `rule_id → count` for all violations found     |
-| `plan_scores`          | Array of `{ name, quality_score }` per plan           |
-| `uncovered_test_cases` | Uncovered test case paths (capped at `max_uncovered`) |
-| `save_error`           | Present only if the results file could not be written |
+| Field                     | Description                                                                                                                                              |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `quality_score`           | Project quality score (0–100)                                                                                                                            |
+| `coverage_percent`        | Percentage of test cases covered by at least one plan                                                                                                    |
+| `violation_summary`       | Map of `rule_id → count` for all violations found                                                                                                        |
+| `plan_scores`             | Array of `{ name, quality_score }` per plan                                                                                                              |
+| `uncovered_test_cases`    | Uncovered test case paths (capped at `max_uncovered`)                                                                                                    |
+| `save_error`              | Present only if the results file could not be written                                                                                                    |
+| `plan_integrity_warnings` | Present when any plan or suite directory is missing a `.planitem` file — test instances in those directories are silently invisible to the Provar runner |
 
 When `include_plan_details: true`, the response additionally includes full `test_plans[]` with nested suite and per-test-case data.
+
+**Plan integrity warnings:** `provar.project.validate` now walks every `plans/` subdirectory and checks that a `.planitem` file is present at both the plan level and each suite subfolder level. If any are missing, the response includes a `plan_integrity_warnings` array. Use `provar.testplan.create-suite` to create missing `.planitem` files without losing any existing test instances.
 
 **Violation rule IDs:** PROJ-EMPTY-001, PROJ-DUP-001, PROJ-DUP-002, PROJ-CALLABLE-001, PROJ-CALLABLE-002, PROJ-CONN-001, PROJ-ENV-001, PROJ-ENV-002, PROJ-SECRET-001
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provartesting/provardx-cli",
   "description": "A plugin for the Salesforce CLI to orchestrate testing activities and report quality metrics to Provar Quality Hub",
-  "version": "1.5.0-beta.13",
+  "version": "1.5.0-beta.14",
   "mcpName": "io.github.ProvarTesting/provar",
   "license": "BSD-3-Clause",
   "plugins": [

--- a/server.json
+++ b/server.json
@@ -14,12 +14,12 @@
     "url": "https://github.com/ProvarTesting/provardx-cli",
     "source": "github"
   },
-  "version": "1.5.0-beta.13",
+  "version": "1.5.0-beta.14",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@provartesting/provardx-cli",
-      "version": "1.5.0-beta.13",
+      "version": "1.5.0-beta.14",
       "transport": {
         "type": "stdio"
       },

--- a/src/mcp/tools/automationTools.ts
+++ b/src/mcp/tools/automationTools.ts
@@ -395,6 +395,8 @@ export function registerAutomationTestRun(server: McpServer, config: ServerConfi
       'Requires Provar to be installed locally and provarHome set correctly in the properties file.',
       'Use provar.automation.setup first if Provar is not yet installed.',
       'For grid/CI execution via Provar Quality Hub instead of running locally, use provar.qualityhub.testrun.',
+      'Output buffer: a 50 MB maxBuffer is set so ENOBUFS on verbose Provar runs is now rare.',
+      'If ENOBUFS still occurs (extremely verbose logging), run `sf provar automation test run --json` directly in the terminal and pipe or tail the output instead of retrying this tool.',
       'Typical local AI loop: config.load → compile → testrun → inspect results.',
     ].join(' '),
     {

--- a/src/mcp/tools/projectValidateFromPath.ts
+++ b/src/mcp/tools/projectValidateFromPath.ts
@@ -32,8 +32,7 @@ interface ViolationSummary {
 }
 
 function buildPlanSummary(plan: ValidatedPlan): PlanSummary {
-  const test_case_count = plan.suites.reduce((n, s) => n + s.test_cases.length, 0)
-    + plan.unplanned_test_cases.length;
+  const test_case_count = plan.suites.reduce((n, s) => n + s.test_cases.length, 0) + plan.unplanned_test_cases.length;
   return {
     name: plan.name,
     quality_score: plan.quality_score,
@@ -69,9 +68,7 @@ function shapeResponse(
   const coverage = {
     ...coverageRest,
     uncovered_test_cases: uncovered_shown,
-    ...(uncovered_truncated
-      ? { uncovered_truncated: true, uncovered_total: uncovered_test_cases.length }
-      : {}),
+    ...(uncovered_truncated ? { uncovered_truncated: true, uncovered_total: uncovered_test_cases.length } : {}),
   };
 
   if (includePlanDetails) {
@@ -99,6 +96,9 @@ function shapeResponse(
     coverage,
     saved_to: result.saved_to,
     ...(result.save_error ? { save_error: result.save_error } : {}),
+    ...(result.plan_integrity_warnings && result.plan_integrity_warnings.length > 0
+      ? { plan_integrity_warnings: result.plan_integrity_warnings }
+      : {}),
     hint: 'Set include_plan_details:true to get per-suite/test-case violations. project_violations and plan violations are grouped by rule_id in this view.',
   };
 }
@@ -119,22 +119,39 @@ export function registerProjectValidateFromPath(server: McpServer, config: Serve
       'Pass include_plan_details:true to get full per-suite and per-test-case data.',
       'By default saves a QH-compatible JSON report to',
       '{project_path}/provardx/validation/ (created if absent).',
+      'Plan integrity: if any plan or suite directory is missing a .planitem file, the response includes a plan_integrity_warnings array.',
+      'Test instances in those directories are silently ignored by the Provar runner — fix these before running tests.',
       'IMPORTANT: Use this tool for whole-project validation —',
       'DO NOT read individual test case files and pass XML content inline.',
       'Pass a project_path and let this tool handle all file reading.',
     ].join(' '),
     {
-      project_path: z.string().describe('Absolute path to the Provar project root (the directory containing the .testproject file)'),
-      quality_threshold: z.number().min(0).max(100).optional().default(80).describe('Minimum quality score for a test case to be considered valid (default: 80)'),
-      save_results: z.boolean().optional().default(true).describe('Write a QH-compatible JSON report to provardx/validation/ (default: true)'),
-      results_dir: z.string().optional().describe('Override the output directory for the saved report (default: {project_path}/provardx/validation)'),
+      project_path: z
+        .string()
+        .describe('Absolute path to the Provar project root (the directory containing the .testproject file)'),
+      quality_threshold: z
+        .number()
+        .min(0)
+        .max(100)
+        .optional()
+        .default(80)
+        .describe('Minimum quality score for a test case to be considered valid (default: 80)'),
+      save_results: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe('Write a QH-compatible JSON report to provardx/validation/ (default: true)'),
+      results_dir: z
+        .string()
+        .optional()
+        .describe('Override the output directory for the saved report (default: {project_path}/provardx/validation)'),
       include_plan_details: z
         .boolean()
         .optional()
         .default(false)
         .describe(
           'When true, include full per-suite and per-test-case violation data in the response. ' +
-          'Default false to keep response small. Use only when you need to inspect specific test case failures.'
+            'Default false to keep response small. Use only when you need to inspect specific test case failures.'
         ),
       max_uncovered: z
         .number()
@@ -142,16 +159,28 @@ export function registerProjectValidateFromPath(server: McpServer, config: Serve
         .min(0)
         .optional()
         .default(20)
-        .describe('Maximum number of uncovered test case paths to include in the response (default: 20). Set to 0 for none, or a large number for all.'),
+        .describe(
+          'Maximum number of uncovered test case paths to include in the response (default: 20). Set to 0 for none, or a large number for all.'
+        ),
       max_violations: z
         .number()
         .int()
         .min(0)
         .optional()
         .default(50)
-        .describe('When include_plan_details:true, caps project_violations returned (default: 50). Ignored in slim mode where violations are grouped by rule_id instead.'),
+        .describe(
+          'When include_plan_details:true, caps project_violations returned (default: 50). Ignored in slim mode where violations are grouped by rule_id instead.'
+        ),
     },
-    ({ project_path, quality_threshold, save_results, results_dir, include_plan_details, max_uncovered, max_violations }) => {
+    ({
+      project_path,
+      quality_threshold,
+      save_results,
+      results_dir,
+      include_plan_details,
+      max_uncovered,
+      max_violations,
+    }) => {
       const requestId = makeRequestId();
       log('info', 'provar.project.validate', { requestId, project_path, include_plan_details });
 
@@ -179,11 +208,12 @@ export function registerProjectValidateFromPath(server: McpServer, config: Serve
         };
       } catch (err: unknown) {
         const error = err as Error & { code?: string };
-        const code = error instanceof PathPolicyError
-          ? error.code
-          : error instanceof ProjectValidationError
+        const code =
+          error instanceof PathPolicyError
             ? error.code
-            : (error.code ?? 'VALIDATE_ERROR');
+            : error instanceof ProjectValidationError
+            ? error.code
+            : error.code ?? 'VALIDATE_ERROR';
         const isUserError = error instanceof PathPolicyError || error instanceof ProjectValidationError;
         const errResult = makeError(code, error.message, requestId, !isUserError);
         log('error', 'provar.project.validate failed', { requestId, error: error.message });

--- a/src/mcp/tools/testCaseGenerate.ts
+++ b/src/mcp/tools/testCaseGenerate.ts
@@ -119,12 +119,14 @@ const StepSchema = z.object({
 const TOOL_DESCRIPTION = [
   'Generate a Provar XML test case skeleton with proper UUID v4 guids, sequential testItemId values, and <steps> structure.',
   'Returns XML content. Writes to disk only when dry_run=false.',
+  'Generated structure: <?xml version="1.0" encoding="UTF-8" standalone="no"?> with <testCase guid="..." id="1" registryId="..."> (id is always the integer literal "1" as required by the Provar runtime), a <summary/> child, then <steps>.',
   'URI-aware generation: use target_uri to control the XML nesting structure.',
   '  - sf:ui:target (or omit target_uri) → flat Salesforce XML structure (existing behaviour).',
   '  - ui:pageobject:target?pageId=pageobjects.PageClass → wraps all steps in a UiWithScreen element targeting that non-SF page object.',
   'API IDs: shorthand forms (e.g. UiConnect, ApexSoqlQuery) are automatically expanded to fully-qualified IDs required by the Provar runtime.',
   'Step arguments: attributes are emitted as <arguments><argument id="..."><value .../></argument></arguments> — the only format the Provar runtime processes.',
   'Shorthand XML attributes on <apiCall> are silently ignored at runtime; always supply arguments via the attributes map.',
+  'ApexSoqlQuery argument IDs: soqlQuery (the SOQL SELECT statement), resultListName (binds result list to a variable), apexConnectionName (named connection), resultScope (optional).',
   'Data-driven note: <dataTable> only iterates rows when the test case runs via a test plan instance (.testinstance).',
   'Running directly via the provardx testCase property resolves all data table variables as null.',
   'Use provar.testplan.add-instance to wire into a plan for data-driven execution.',
@@ -138,6 +140,13 @@ const TOOL_DESCRIPTION = [
   'Variable references: pass values as "{VarName}" (braces); emitted as class="variable" <path element="VarName"/>.',
   'target argument (UiWithScreen/UiWithRow): pass the URI value; emitted as class="uiTarget" uri="...".',
   'locator argument (UiDoAction/UiAssert): pass the URI value; emitted as class="uiLocator" uri="...".',
+  'Edit page objects: action=Edit targets require a compiled page object for the SF object. ' +
+    'If none exists in the project page-objects directory, the locator binding will fail at runtime. ' +
+    'For objects without a compiled Edit page object, use inline edit instead: sfIleActivate to activate the field, ' +
+    'set the value, then SaveEdit binding on the Record view screen.',
+  'Provar IDE warning: opening a generated test case in Provar IDE injects empty <argument id="..."/> elements for known parameter IDs. ' +
+    'If the empty element appears after a populated one, the empty version wins at runtime. ' +
+    'Always check for and remove duplicate empty arguments after any IDE open/save cycle before re-running.',
   'Cleanup warning: ApexDeleteObject steps near end of test will be skipped if an earlier step fails (stopOnError=false). Use a TearDown callable.',
   'Validation: when validate_after_edit=true (default) the response includes a validation field and returns TESTCASE_INVALID if the generated XML fails structural checks.',
   'Grounding: call provar.qualityhub.examples.retrieve before generating to get corpus examples for the scenario — correct XML structure for the step types you need.',
@@ -149,7 +158,6 @@ export function registerTestCaseGenerate(server: McpServer, config: ServerConfig
     TOOL_DESCRIPTION,
     {
       test_case_name: z.string().describe('Test case name (human-readable label)'),
-      test_case_id: z.string().optional().describe('Explicit test case id; auto-generated UUID v4 if omitted'),
       steps: z.array(StepSchema).default([]).describe('Ordered list of test steps'),
       target_uri: z
         .string()
@@ -299,11 +307,7 @@ function buildArgumentsXml(attributes: Record<string, string>, baseIndent = '   
   const argLines = entries
     .map(([k, v]) => {
       const valueXml = buildArgumentValue(k, v, `${baseIndent}  `, false, apiId);
-      return (
-        `${baseIndent}<argument id="${escapeXmlAttr(k)}">\n` +
-        valueXml + '\n' +
-        `${baseIndent}</argument>`
-      );
+      return `${baseIndent}<argument id="${escapeXmlAttr(k)}">\n` + valueXml + '\n' + `${baseIndent}</argument>`;
     })
     .join('\n');
   return `\n${baseIndent}<arguments>\n${argLines}\n${baseIndent}</arguments>\n${baseIndent.slice(0, -2)}`;
@@ -325,7 +329,8 @@ function buildSetValuesXml(attributes: Record<string, string>, baseIndent: strin
     `${i(0)}<argument id="values">\n` +
     `${i(1)}<value class="valueList" mutable="Mutable">\n` +
     `${i(2)}<namedValues>\n` +
-    namedValueLines + '\n' +
+    namedValueLines +
+    '\n' +
     `${i(2)}</namedValues>\n` +
     `${i(1)}</value>\n` +
     `${i(0)}</argument>\n` +
@@ -360,11 +365,9 @@ function buildFlatStepXml(
 
 function buildTestCaseXml(input: {
   test_case_name: string;
-  test_case_id?: string;
   steps: Array<{ api_id: string; name: string; attributes: Record<string, string> }>;
   target_uri?: string;
 }): string {
-  const testCaseId = input.test_case_id ?? randomUUID();
   const testCaseGuid = randomUUID();
   const registryId = randomUUID();
 
@@ -378,10 +381,11 @@ function buildTestCaseXml(input: {
     stepLines = lines || '    <!-- TODO: Add test steps here -->';
   }
 
+  // Provar requires: standalone="no", id="1" (integer literal), no name attr, <summary/> before <steps>.
   return (
-    '<?xml version="1.0" encoding="UTF-8"?>\n' +
-    `<testCase id="${testCaseId}" guid="${testCaseGuid}" registryId="${registryId}"` +
-    ` name="${escapeXmlAttr(input.test_case_name)}">\n` +
+    '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n' +
+    `<testCase guid="${testCaseGuid}" id="1" registryId="${registryId}">\n` +
+    '  <summary/>\n' +
     '  <steps>\n' +
     stepLines +
     '\n  </steps>\n' +
@@ -406,7 +410,11 @@ function buildUiWithScreenXml(
     '      </clauses>\n    ';
   return (
     `    <apiCall guid="${wrapperGuid}" apiId="${wrapperApiId}"` +
-    ` name="With page" testItemId="1">${buildArgumentsXml({ target: targetUri }, '      ', wrapperApiId).trimEnd()}${clausesXml}</apiCall>`
+    ` name="With page" testItemId="1">${buildArgumentsXml(
+      { target: targetUri },
+      '      ',
+      wrapperApiId
+    ).trimEnd()}${clausesXml}</apiCall>`
   );
 }
 

--- a/src/mcp/tools/testCaseValidate.ts
+++ b/src/mcp/tools/testCaseValidate.ts
@@ -185,6 +185,45 @@ export function validateTestCaseXml(filePath: string, config: ServerConfig): Tes
   return validateTestCase(fs.readFileSync(resolved, 'utf-8'));
 }
 
+/** TC_010/TC_011: validate testCase id and guid attributes. */
+function checkTestCaseIdAndGuid(tcId: string | null, tcGuid: string | undefined, issues: ValidationIssue[]): void {
+  if (!tcId) {
+    issues.push({
+      rule_id: 'TC_010',
+      severity: 'ERROR',
+      message: 'testCase missing required id attribute.',
+      applies_to: 'testCase',
+      suggestion: 'Add id="1" to testCase element (Provar requires the integer literal "1").',
+    });
+  } else if (tcId !== '1') {
+    issues.push({
+      rule_id: 'TC_010',
+      severity: 'ERROR',
+      message: `testCase id="${tcId}" is invalid — Provar requires id="1" (integer literal).`,
+      applies_to: 'testCase',
+      suggestion: 'Set id="1" on the testCase element. The unique identifier is the guid attribute, not id.',
+    });
+  }
+  if (!tcGuid) {
+    issues.push({
+      rule_id: 'TC_011',
+      severity: 'ERROR',
+      message: 'testCase missing required guid attribute.',
+      applies_to: 'testCase',
+      suggestion: 'Add guid attribute (UUID v4) to testCase element.',
+    });
+  } else if (!UUID_V4_RE.test(tcGuid)) {
+    issues.push({
+      rule_id: 'TC_012',
+      severity: 'ERROR',
+      message: `testCase guid "${tcGuid}" is not a valid UUID v4.`,
+      applies_to: 'testCase',
+      suggestion:
+        'Replace with a valid UUID v4 — e.g. crypto.randomUUID(). The 4th segment must begin with 8, 9, a, or b.',
+    });
+  }
+}
+
 /** Pure function — exported for unit testing */
 export function validateTestCase(xmlContent: string, testName?: string): TestCaseValidationResult {
   const issues: ValidationIssue[] = [];
@@ -242,33 +281,7 @@ export function validateTestCase(xmlContent: string, testName?: string): TestCas
   const tcName = (tc['@_name'] as string | undefined) ?? null;
   const tcGuid = tc['@_guid'] as string | undefined;
 
-  if (!tcId) {
-    issues.push({
-      rule_id: 'TC_010',
-      severity: 'ERROR',
-      message: 'testCase missing required id attribute.',
-      applies_to: 'testCase',
-      suggestion: 'Add id attribute to testCase element.',
-    });
-  }
-  if (!tcGuid) {
-    issues.push({
-      rule_id: 'TC_011',
-      severity: 'ERROR',
-      message: 'testCase missing required guid attribute.',
-      applies_to: 'testCase',
-      suggestion: 'Add guid attribute (UUID v4) to testCase element.',
-    });
-  } else if (!UUID_V4_RE.test(tcGuid)) {
-    issues.push({
-      rule_id: 'TC_012',
-      severity: 'ERROR',
-      message: `testCase guid "${tcGuid}" is not a valid UUID v4.`,
-      applies_to: 'testCase',
-      suggestion:
-        'Replace with a valid UUID v4 — e.g. crypto.randomUUID(). The 4th segment must begin with 8, 9, a, or b.',
-    });
-  }
+  checkTestCaseIdAndGuid(tcId, tcGuid, issues);
   // TC_013 (registryId) is intentionally not checked here — registryId is a
   // Salesforce Quality Hub record ID assigned when a test case is registered in
   // the QH org. Local project files will never have this attribute, so checking
@@ -323,7 +336,11 @@ export function validateTestCase(xmlContent: string, testName?: string): TestCas
       severity: 'WARNING',
       message: `Argument value "{${varMatch[1]}}" looks like a variable reference but is stored as a plain string — Provar will not resolve it at runtime.`,
       applies_to: 'argument',
-      suggestion: `Replace with <value class="variable"><path element="${varMatch[1].split('.').join('"/><path element="')}"/></value>. In provar.testcase.generate, use the {VarName} syntax in the attributes object — the generator converts it automatically.`,
+      suggestion: `Replace with <value class="variable"><path element="${varMatch[1]
+        .split('.')
+        .join(
+          '"/><path element="'
+        )}"/></value>. In provar.testcase.generate, use the {VarName} syntax in the attributes object — the generator converts it automatically.`,
     });
   }
 
@@ -403,7 +420,12 @@ function validateApiCall(call: Record<string, unknown>, issues: ValidationIssue[
   if (apiId) validateApiCallArgs(call, apiId, name, issues);
 }
 
-function checkUiTarget(call: Record<string, unknown>, apiId: string, stepName: string, issues: ValidationIssue[]): void {
+function checkUiTarget(
+  call: Record<string, unknown>,
+  apiId: string,
+  stepName: string,
+  issues: ValidationIssue[]
+): void {
   const targetArg = getArgList(call).find((a) => (a['@_id'] as string | undefined) === 'target');
   if (!targetArg) return;
   const valueNode = targetArg['value'] as Record<string, unknown> | undefined;
@@ -414,7 +436,9 @@ function checkUiTarget(call: Record<string, unknown>, apiId: string, stepName: s
     issues.push({
       rule_id: 'UI-TARGET-001',
       severity: 'ERROR',
-      message: `${apiLabel} step "${stepName}" target argument uses class="${valClass ?? '(missing)'}" — must be class="uiTarget".`,
+      message: `${apiLabel} step "${stepName}" target argument uses class="${
+        valClass ?? '(missing)'
+      }" — must be class="uiTarget".`,
       applies_to: 'apiCall',
       suggestion:
         'Emit the target as: <value class="uiTarget" uri="sf:ui:target?..."/> or uri="ui:pageobject:target?pageId=...". ' +
@@ -450,7 +474,9 @@ function validateApiCallArgs(
           issues.push({
             rule_id: 'UI-LOCATOR-001',
             severity: 'ERROR',
-            message: `"${stepName}" locator argument uses class="${valClass ?? '(missing)'}" — must be class="uiLocator".`,
+            message: `"${stepName}" locator argument uses class="${
+              valClass ?? '(missing)'
+            }" — must be class="uiLocator".`,
             applies_to: 'apiCall',
             suggestion:
               'Emit the locator as: <value class="uiLocator" uri="sf:ui:locator:..."/>. ' +
@@ -474,7 +500,9 @@ function validateApiCallArgs(
           issues.push({
             rule_id: 'SETVALUES-STRUCTURE-001',
             severity: 'ERROR',
-            message: `SetValues step "${stepName}" values argument uses class="${valClass ?? '(missing)'}" — must use class="valueList" with <namedValues> children.`,
+            message: `SetValues step "${stepName}" values argument uses class="${
+              valClass ?? '(missing)'
+            }" — must use class="valueList" with <namedValues> children.`,
             applies_to: 'apiCall',
             suggestion:
               'Wrap variable assignments in: <value class="valueList" mutable="Mutable"><namedValues>' +

--- a/src/services/projectValidation.ts
+++ b/src/services/projectValidation.ts
@@ -272,7 +272,8 @@ function resolveTestInstanceFull(instancePath: string, projectPath: string): Tes
       }
     }
 
-    return { testCase: { name: tcName, xml_content }, testCasePath, testCaseId };
+    // Only expose testCasePath when in-bounds — out-of-bounds paths must not affect coverage totals
+    return { testCase: { name: tcName, xml_content }, testCasePath: tcInBounds ? testCasePath : null, testCaseId };
   } catch {
     return { testCase: null, testCasePath: null, testCaseId: null };
   }

--- a/src/services/projectValidation.ts
+++ b/src/services/projectValidation.ts
@@ -305,7 +305,8 @@ export function readSuiteDirectory(
   projectPath: string,
   depth = 0,
   coveredPaths?: Set<string>,
-  idMap?: Map<string, string>
+  idMap?: Map<string, string>,
+  planIntegrityWarnings?: string[]
 ): TestSuiteInput {
   const testCases: TestCaseInput[] = [];
   const testSuites: TestSuiteInput[] = [];
@@ -318,7 +319,15 @@ export function readSuiteDirectory(
       if (entry.name === 'node_modules') continue;
       const fullPath = path.join(dirPath, entry.name);
       if (entry.isDirectory() && !entry.name.startsWith('.')) {
-        testSuites.push(readSuiteDirectory(fullPath, entry.name, projectPath, depth + 1, coveredPaths, idMap));
+        if (planIntegrityWarnings && !fs.existsSync(path.join(fullPath, '.planitem'))) {
+          const rel = path.relative(projectPath, fullPath).replace(/\\/g, '/');
+          planIntegrityWarnings.push(
+            `${rel}/ is missing a .planitem file — test instances in this suite will be invisible to the runner.`
+          );
+        }
+        testSuites.push(
+          readSuiteDirectory(fullPath, entry.name, projectPath, depth + 1, coveredPaths, idMap, planIntegrityWarnings)
+        );
       } else if (entry.name.endsWith('.testinstance')) {
         const { testCase, testCasePath, testCaseId } = resolveTestInstanceFull(fullPath, projectPath);
         if (testCase) testCases.push(testCase);
@@ -355,7 +364,9 @@ export function readPlanDirectory(
             `${rel}/ is missing a .planitem file — test instances in this suite will be invisible to the runner.`
           );
         }
-        testSuites.push(readSuiteDirectory(fullPath, entry.name, projectPath, 0, coveredPaths, idMap));
+        testSuites.push(
+          readSuiteDirectory(fullPath, entry.name, projectPath, 0, coveredPaths, idMap, planIntegrityWarnings)
+        );
       } else if (entry.name.endsWith('.testinstance')) {
         const { testCase, testCasePath, testCaseId } = resolveTestInstanceFull(fullPath, projectPath);
         if (testCase) testCases.push(testCase);
@@ -424,7 +435,7 @@ function buildTestCaseIdMap(projectPath: string): Map<string, string> {
           try {
             const content = fs.readFileSync(fullPath, 'utf-8');
             const rel = path.relative(projectPath, fullPath).replace(/\\/g, '/');
-            for (const attr of ['registryId', 'id', 'guid'] as const) {
+            for (const attr of ['registryId', 'guid'] as const) {
               const m = content.match(new RegExp(`${attr}=["']([^"']+)["']`));
               if (m?.[1] && !idMap.has(m[1])) idMap.set(m[1], rel);
             }

--- a/src/services/projectValidation.ts
+++ b/src/services/projectValidation.ts
@@ -40,8 +40,8 @@ export class ProjectValidationError extends Error {
 export interface ProjectValidationOptions {
   project_path: string;
   quality_threshold?: number; // default 80
-  save_results?: boolean;      // default true (any value !== false means save)
-  results_dir?: string;        // default '{project_path}/provardx/validation'
+  save_results?: boolean; // default true (any value !== false means save)
+  results_dir?: string; // default '{project_path}/provardx/validation'
 }
 
 export interface ValidatedTestCase {
@@ -101,6 +101,8 @@ export interface ProjectValidationResult {
     uncovered_test_cases: string[];
   };
   saved_to: string | null;
+  /** Directories within plans/ that are missing a .planitem file and will be silently ignored by the Provar runner. */
+  plan_integrity_warnings?: string[];
   /** Set when save_results was requested but the write failed (disk full, permissions, etc.). */
   save_error?: string;
 }
@@ -153,7 +155,9 @@ export function resolveProjectRoot(givenPath: string): { root: string; candidate
       const sub = path.join(givenPath, entry.name);
       if (fs.existsSync(path.join(sub, '.testproject'))) candidates.push(sub);
     }
-  } catch { /* skip */ }
+  } catch {
+    /* skip */
+  }
 
   if (candidates.length === 1) return { root: candidates[0], candidates: [] };
   return { root: givenPath, candidates }; // caller handles 0 or multiple
@@ -198,7 +202,8 @@ export function readProjectContext(projectPath: string): {
   const secretsFullPath = path.resolve(path.join(projectPath, secretsRelPath));
   const projectPathResolved = path.resolve(projectPath);
   // Bounds check: only read secrets file if it's within the project directory
-  const secretsInBounds = secretsFullPath === projectPathResolved || secretsFullPath.startsWith(projectPathResolved + path.sep);
+  const secretsInBounds =
+    secretsFullPath === projectPathResolved || secretsFullPath.startsWith(projectPathResolved + path.sep);
   if (secretsInBounds && fs.existsSync(secretsFullPath)) {
     try {
       const secretsContent = fs.readFileSync(secretsFullPath, 'utf-8');
@@ -212,7 +217,9 @@ export function readProjectContext(projectPath: string): {
         const value = trimmed.slice(eqIdx + 1).trim();
         if (value && !value.startsWith('ENC1(')) unencryptedSecretCount++;
       }
-    } catch { /* skip */ }
+    } catch {
+      /* skip */
+    }
   }
 
   return {
@@ -256,13 +263,13 @@ function resolveTestInstanceFull(instancePath: string, projectPath: string): Tes
     // Bounds check: only read test case files within the project directory
     const tcInBounds = tcFullPath === projResolved || tcFullPath.startsWith(projResolved + path.sep);
     // Derive name from the bounds-checked resolved path to prevent injection via crafted testCasePath
-    const tcName = tcInBounds
-      ? path.basename(tcFullPath, '.testcase')
-      : path.basename(testCasePath, '.testcase');
+    const tcName = tcInBounds ? path.basename(tcFullPath, '.testcase') : path.basename(testCasePath, '.testcase');
     if (tcInBounds && fs.existsSync(tcFullPath)) {
       try {
         xml_content = fs.readFileSync(tcFullPath, 'utf-8');
-      } catch { /* xml_content stays undefined */ }
+      } catch {
+        /* xml_content stays undefined */
+      }
     }
 
     return { testCase: { name: tcName, xml_content }, testCasePath, testCaseId };
@@ -283,7 +290,7 @@ function accumulateCoveredPath(
   testCasePath: string | null,
   testCaseId: string | null,
   coveredPaths: Set<string>,
-  idMap: Map<string, string>,
+  idMap: Map<string, string>
 ): void {
   if (testCasePath) coveredPaths.add(testCasePath);
   if (testCaseId) {
@@ -298,7 +305,7 @@ export function readSuiteDirectory(
   projectPath: string,
   depth = 0,
   coveredPaths?: Set<string>,
-  idMap?: Map<string, string>,
+  idMap?: Map<string, string>
 ): TestSuiteInput {
   const testCases: TestCaseInput[] = [];
   const testSuites: TestSuiteInput[] = [];
@@ -318,7 +325,9 @@ export function readSuiteDirectory(
         if (coveredPaths && idMap) accumulateCoveredPath(testCasePath, testCaseId, coveredPaths, idMap);
       }
     }
-  } catch { /* skip */ }
+  } catch {
+    /* skip */
+  }
 
   return { name, test_cases: testCases, test_suites: testSuites };
 }
@@ -329,6 +338,7 @@ export function readPlanDirectory(
   projectPath: string,
   coveredPaths?: Set<string>,
   idMap?: Map<string, string>,
+  planIntegrityWarnings?: string[]
 ): TestPlanInput {
   const testCases: TestCaseInput[] = [];
   const testSuites: TestSuiteInput[] = [];
@@ -339,6 +349,12 @@ export function readPlanDirectory(
       if (entry.name === 'node_modules') continue;
       const fullPath = path.join(planPath, entry.name);
       if (entry.isDirectory() && !entry.name.startsWith('.')) {
+        if (planIntegrityWarnings && !fs.existsSync(path.join(fullPath, '.planitem'))) {
+          const rel = path.relative(projectPath, fullPath).replace(/\\/g, '/');
+          planIntegrityWarnings.push(
+            `${rel}/ is missing a .planitem file — test instances in this suite will be invisible to the runner.`
+          );
+        }
         testSuites.push(readSuiteDirectory(fullPath, entry.name, projectPath, 0, coveredPaths, idMap));
       } else if (entry.name.endsWith('.testinstance')) {
         const { testCase, testCasePath, testCaseId } = resolveTestInstanceFull(fullPath, projectPath);
@@ -346,15 +362,22 @@ export function readPlanDirectory(
         if (coveredPaths && idMap) accumulateCoveredPath(testCasePath, testCaseId, coveredPaths, idMap);
       }
     }
-  } catch { /* skip */ }
+  } catch {
+    /* skip */
+  }
 
   return { name, test_cases: testCases, test_suites: testSuites };
 }
 
-export function readPlansDir(projectPath: string): { plans: TestPlanInput[]; coveredPaths: Set<string> } {
+export function readPlansDir(projectPath: string): {
+  plans: TestPlanInput[];
+  coveredPaths: Set<string>;
+  planIntegrityWarnings: string[];
+} {
   const plansDir = path.join(projectPath, 'plans');
   const coveredPaths = new Set<string>();
-  if (!fs.existsSync(plansDir)) return { plans: [], coveredPaths };
+  const planIntegrityWarnings: string[] = [];
+  if (!fs.existsSync(plansDir)) return { plans: [], coveredPaths, planIntegrityWarnings };
 
   // Build UUID→path map once so the plan walk can resolve testCaseId fallbacks
   // without a separate pass over the tests/ directory later.
@@ -366,11 +389,18 @@ export function readPlansDir(projectPath: string): { plans: TestPlanInput[]; cov
     for (const entry of entries) {
       if (!entry.isDirectory() || entry.name.startsWith('.') || entry.name === 'node_modules') continue;
       const planPath = path.join(plansDir, entry.name);
-      plans.push(readPlanDirectory(planPath, entry.name, projectPath, coveredPaths, idMap));
+      if (!fs.existsSync(path.join(planPath, '.planitem'))) {
+        planIntegrityWarnings.push(
+          `plans/${entry.name}/ is missing a .planitem file — this plan will not be recognised by the Provar runner.`
+        );
+      }
+      plans.push(readPlanDirectory(planPath, entry.name, projectPath, coveredPaths, idMap, planIntegrityWarnings));
     }
-  } catch { /* skip */ }
+  } catch {
+    /* skip */
+  }
 
-  return { plans, coveredPaths };
+  return { plans, coveredPaths, planIntegrityWarnings };
 }
 
 /**
@@ -388,8 +418,9 @@ function buildTestCaseIdMap(projectPath: string): Map<string, string> {
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
         if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
         const fullPath = path.join(dir, entry.name);
-        if (entry.isDirectory()) { walk(fullPath); }
-        else if (entry.name.endsWith('.testcase')) {
+        if (entry.isDirectory()) {
+          walk(fullPath);
+        } else if (entry.name.endsWith('.testcase')) {
           try {
             const content = fs.readFileSync(fullPath, 'utf-8');
             const rel = path.relative(projectPath, fullPath).replace(/\\/g, '/');
@@ -397,10 +428,14 @@ function buildTestCaseIdMap(projectPath: string): Map<string, string> {
               const m = content.match(new RegExp(`${attr}=["']([^"']+)["']`));
               if (m?.[1] && !idMap.has(m[1])) idMap.set(m[1], rel);
             }
-          } catch { /* skip */ }
+          } catch {
+            /* skip */
+          }
         }
       }
-    } catch { /* skip */ }
+    } catch {
+      /* skip */
+    }
   }
   walk(testsDir);
   return idMap;
@@ -420,10 +455,13 @@ export function collectAllTestCaseNames(projectPath: string): string[] {
     try {
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
         if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
-        if (entry.isDirectory()) { walk(path.join(dir, entry.name)); }
-        else if (entry.name.endsWith('.testcase')) names.push(path.basename(entry.name, '.testcase'));
+        if (entry.isDirectory()) {
+          walk(path.join(dir, entry.name));
+        } else if (entry.name.endsWith('.testcase')) names.push(path.basename(entry.name, '.testcase'));
       }
-    } catch { /* skip */ }
+    } catch {
+      /* skip */
+    }
   }
   walk(testsDir);
   return names;
@@ -446,8 +484,9 @@ export function collectCoveredPathsFromDisk(projectPath: string): Set<string> {
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
         if (entry.name === 'node_modules') continue;
         const fullPath = path.join(dir, entry.name);
-        if (entry.isDirectory()) { walk(fullPath); }
-        else if (entry.name.endsWith('.testinstance')) {
+        if (entry.isDirectory()) {
+          walk(fullPath);
+        } else if (entry.name.endsWith('.testinstance')) {
           try {
             const content = fs.readFileSync(fullPath, 'utf-8');
             // Primary: path-based match
@@ -459,10 +498,14 @@ export function collectCoveredPathsFromDisk(projectPath: string): Set<string> {
               const resolvedPath = idMap.get(idM[1]);
               if (resolvedPath) covered.add(resolvedPath);
             }
-          } catch { /* skip */ }
+          } catch {
+            /* skip */
+          }
         }
       }
-    } catch { /* skip */ }
+    } catch {
+      /* skip */
+    }
   }
   walk(plansDir);
   return covered;
@@ -478,13 +521,16 @@ export function findUncoveredTestCases(projectPath: string, coveredPaths: Set<st
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
         if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
         const fullPath = path.join(dir, entry.name);
-        if (entry.isDirectory()) { walk(fullPath); }
-        else if (entry.name.endsWith('.testcase')) {
+        if (entry.isDirectory()) {
+          walk(fullPath);
+        } else if (entry.name.endsWith('.testcase')) {
           const rel = path.relative(projectPath, fullPath).replace(/\\/g, '/');
           if (!coveredPaths.has(rel)) uncovered.push(rel);
         }
       }
-    } catch { /* skip */ }
+    } catch {
+      /* skip */
+    }
   }
   walk(testsDir);
   return uncovered.sort();
@@ -549,7 +595,7 @@ function tcIssuesToQhViolations(tc: TestCaseResult): QhViolation[] {
     });
   }
 
-  for (const bp of (tc.best_practices_violations ?? [])) {
+  for (const bp of tc.best_practices_violations ?? []) {
     violations.push({
       number: num++,
       ruleId: bp.rule_id,
@@ -665,7 +711,13 @@ export function buildQhReport(result: ProjectResult, projectName: string): Recor
   return {
     reportInfo: {
       name: `VR-LOCAL-${now.toISOString().replace(/[:.]/g, '-').slice(0, 19)}`,
-      generatedAt: now.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }),
+      generatedAt: now.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      }),
       exportedAt: now.toISOString(),
       source: 'provar-mcp-local',
     },
@@ -692,9 +744,7 @@ export function saveResults(
   report: Record<string, unknown>,
   projectName: string
 ): string {
-  const targetDir = resultsDir
-    ? path.resolve(resultsDir)
-    : path.join(projectPath, 'provardx', 'validation');
+  const targetDir = resultsDir ? path.resolve(resultsDir) : path.join(projectPath, 'provardx', 'validation');
 
   fs.mkdirSync(targetDir, { recursive: true });
 
@@ -719,9 +769,7 @@ export function saveResults(
  * ambiguous project, not a Provar project directory). Lets unexpected I/O
  * errors propagate as-is.
  */
-export function validateProjectFromPath(
-  options: ProjectValidationOptions
-): ProjectValidationResult {
+export function validateProjectFromPath(options: ProjectValidationOptions): ProjectValidationResult {
   const { project_path, quality_threshold, save_results, results_dir } = options;
   const resolved = path.resolve(project_path);
 
@@ -734,7 +782,9 @@ export function validateProjectFromPath(
   if (candidates.length > 1) {
     throw new ProjectValidationError(
       'AMBIGUOUS_PROJECT',
-      `Multiple Provar projects found under "${resolved}". Specify the exact project directory: ${candidates.map((c) => path.basename(c)).join(', ')}`
+      `Multiple Provar projects found under "${resolved}". Specify the exact project directory: ${candidates
+        .map((c) => path.basename(c))
+        .join(', ')}`
     );
   }
 
@@ -752,7 +802,7 @@ export function validateProjectFromPath(
 
   // 2. Read plan hierarchy from plans/ directory; covered paths are computed
   //    as a byproduct of the walk — no second traversal needed.
-  const { plans: testPlans, coveredPaths } = readPlansDir(projectRoot);
+  const { plans: testPlans, coveredPaths, planIntegrityWarnings } = readPlansDir(projectRoot);
 
   // 3. Validate
   const input: ProjectInput = {
@@ -837,6 +887,7 @@ export function validateProjectFromPath(
       uncovered_test_cases: uncoveredTestCases,
     },
     saved_to: savedTo,
+    ...(planIntegrityWarnings.length > 0 ? { plan_integrity_warnings: planIntegrityWarnings } : {}),
     save_error: saveError,
   };
 }

--- a/src/services/projectValidation.ts
+++ b/src/services/projectValidation.ts
@@ -319,14 +319,23 @@ export function readSuiteDirectory(
       if (entry.name === 'node_modules') continue;
       const fullPath = path.join(dirPath, entry.name);
       if (entry.isDirectory() && !entry.name.startsWith('.')) {
-        if (planIntegrityWarnings && !fs.existsSync(path.join(fullPath, '.planitem'))) {
+        const subHasPlanItem = fs.existsSync(path.join(fullPath, '.planitem'));
+        if (planIntegrityWarnings && !subHasPlanItem) {
           const rel = path.relative(projectPath, fullPath).replace(/\\/g, '/');
           planIntegrityWarnings.push(
             `${rel}/ is missing a .planitem file — test instances in this suite will be invisible to the runner.`
           );
         }
         testSuites.push(
-          readSuiteDirectory(fullPath, entry.name, projectPath, depth + 1, coveredPaths, idMap, planIntegrityWarnings)
+          readSuiteDirectory(
+            fullPath,
+            entry.name,
+            projectPath,
+            depth + 1,
+            subHasPlanItem ? coveredPaths : undefined,
+            subHasPlanItem ? idMap : undefined,
+            planIntegrityWarnings
+          )
         );
       } else if (entry.name.endsWith('.testinstance')) {
         const { testCase, testCasePath, testCaseId } = resolveTestInstanceFull(fullPath, projectPath);
@@ -358,14 +367,23 @@ export function readPlanDirectory(
       if (entry.name === 'node_modules') continue;
       const fullPath = path.join(planPath, entry.name);
       if (entry.isDirectory() && !entry.name.startsWith('.')) {
-        if (planIntegrityWarnings && !fs.existsSync(path.join(fullPath, '.planitem'))) {
+        const suiteHasPlanItem = fs.existsSync(path.join(fullPath, '.planitem'));
+        if (planIntegrityWarnings && !suiteHasPlanItem) {
           const rel = path.relative(projectPath, fullPath).replace(/\\/g, '/');
           planIntegrityWarnings.push(
             `${rel}/ is missing a .planitem file — test instances in this suite will be invisible to the runner.`
           );
         }
         testSuites.push(
-          readSuiteDirectory(fullPath, entry.name, projectPath, 0, coveredPaths, idMap, planIntegrityWarnings)
+          readSuiteDirectory(
+            fullPath,
+            entry.name,
+            projectPath,
+            0,
+            suiteHasPlanItem ? coveredPaths : undefined,
+            suiteHasPlanItem ? idMap : undefined,
+            planIntegrityWarnings
+          )
         );
       } else if (entry.name.endsWith('.testinstance')) {
         const { testCase, testCasePath, testCaseId } = resolveTestInstanceFull(fullPath, projectPath);
@@ -400,12 +418,22 @@ export function readPlansDir(projectPath: string): {
     for (const entry of entries) {
       if (!entry.isDirectory() || entry.name.startsWith('.') || entry.name === 'node_modules') continue;
       const planPath = path.join(plansDir, entry.name);
-      if (!fs.existsSync(path.join(planPath, '.planitem'))) {
+      const planHasPlanItem = fs.existsSync(path.join(planPath, '.planitem'));
+      if (!planHasPlanItem) {
         planIntegrityWarnings.push(
           `plans/${entry.name}/ is missing a .planitem file — this plan will not be recognised by the Provar runner.`
         );
       }
-      plans.push(readPlanDirectory(planPath, entry.name, projectPath, coveredPaths, idMap, planIntegrityWarnings));
+      plans.push(
+        readPlanDirectory(
+          planPath,
+          entry.name,
+          projectPath,
+          planHasPlanItem ? coveredPaths : undefined,
+          planHasPlanItem ? idMap : undefined,
+          planIntegrityWarnings
+        )
+      );
     }
   } catch {
     /* skip */

--- a/src/services/projectValidation.ts
+++ b/src/services/projectValidation.ts
@@ -435,9 +435,10 @@ function buildTestCaseIdMap(projectPath: string): Map<string, string> {
           try {
             const content = fs.readFileSync(fullPath, 'utf-8');
             const rel = path.relative(projectPath, fullPath).replace(/\\/g, '/');
-            for (const attr of ['registryId', 'guid'] as const) {
+            for (const attr of ['registryId', 'id', 'guid'] as const) {
               const m = content.match(new RegExp(`${attr}=["']([^"']+)["']`));
-              if (m?.[1] && !idMap.has(m[1])) idMap.set(m[1], rel);
+              // Skip id="1" — new generator emits this literal and it is not UUID-unique
+              if (m?.[1] && m[1] !== '1' && !idMap.has(m[1])) idMap.set(m[1], rel);
             }
           } catch {
             /* skip */

--- a/test/unit/mcp/projectValidateFromPath.test.ts
+++ b/test/unit/mcp/projectValidateFromPath.test.ts
@@ -77,6 +77,10 @@ function makeProject(root: string, planName = 'smoke', tcName = 'Login'): void {
   writeFile(path.join(root, '.testproject'), TESTPROJECT_XML);
   writeFile(path.join(root, 'tests', `${tcName}.testcase`), makeXml(G.tc1, G.s1));
   writeFile(path.join(root, 'plans', planName, `${tcName}.testinstance`), `testCasePath="tests/${tcName}.testcase"\n`);
+  writeFile(
+    path.join(root, 'plans', planName, '.planitem'),
+    '<?xml version="1.0" encoding="UTF-8"?><testPlan guid="abc-123"/>'
+  );
 }
 
 // ── Test setup ─────────────────────────────────────────────────────────────────
@@ -397,6 +401,43 @@ describe('provar.project.validate (from path)', () => {
       assert.ok(
         !('plan_integrity_warnings' in body),
         'No plan_integrity_warnings expected when .planitem files are present'
+      );
+    });
+
+    it('reports plan_integrity_warnings for nested suite dir (depth ≥ 2) missing .planitem', () => {
+      const root = mktemp();
+      writeFile(path.join(root, '.testproject'), TESTPROJECT_XML);
+      writeFile(path.join(root, 'tests', 'Login.testcase'), makeXml(G.tc1, G.s1));
+      // Plan and SuiteA have .planitem, but SuiteA/SubSuite does not
+      writeFile(
+        path.join(root, 'plans', 'smoke', '.planitem'),
+        '<?xml version="1.0" encoding="UTF-8"?><testPlan guid="abc-123"/>'
+      );
+      writeFile(
+        path.join(root, 'plans', 'smoke', 'SuiteA', '.planitem'),
+        '<?xml version="1.0" encoding="UTF-8"?><testPlan guid="def-456"/>'
+      );
+      // SubSuite exists but lacks .planitem — instances here would be invisible to runner
+      writeFile(
+        path.join(root, 'plans', 'smoke', 'SuiteA', 'SubSuite', 'Login.testinstance'),
+        'testCasePath="tests/Login.testcase"\n'
+      );
+
+      const result = server.call('provar.project.validate', {
+        project_path: root,
+        save_results: false,
+      });
+
+      assert.equal(isError(result), false);
+      const body = parseText(result);
+      const warnings = body['plan_integrity_warnings'] as string[] | undefined;
+      assert.ok(
+        Array.isArray(warnings) && warnings.length > 0,
+        'Expected plan_integrity_warnings for nested suite missing .planitem'
+      );
+      assert.ok(
+        warnings.some((w) => w.includes('SubSuite')),
+        'Warning should name the nested suite directory'
       );
     });
   });

--- a/test/unit/mcp/projectValidateFromPath.test.ts
+++ b/test/unit/mcp/projectValidateFromPath.test.ts
@@ -52,9 +52,10 @@ const TESTPROJECT_XML = `<?xml version="1.0" encoding="UTF-8"?>
   <secureStoragePath>.secrets</secureStoragePath>
 </testProject>`;
 
-function makeXml(tcGuid: string, stepGuid: string, id: string): string {
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<testCase id="${id}" guid="${tcGuid}" registryId="${id}" name="${id}">
+function makeXml(tcGuid: string, stepGuid: string): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testCase guid="${tcGuid}" id="1" registryId="${tcGuid}">
+  <summary/>
   <steps>
     <apiCall guid="${stepGuid}" apiId="UiConnect" name="Connect" testItemId="1"/>
   </steps>
@@ -68,16 +69,14 @@ function writeFile(p: string, content: string): void {
 
 const G = {
   tc1: '550e8400-e29b-41d4-a716-446655440001',
-  s1:  '550e8400-e29b-41d4-a716-446655440011',
+  s1: '550e8400-e29b-41d4-a716-446655440011',
 };
 
 /** Build a minimal valid Provar project in the given directory */
 function makeProject(root: string, planName = 'smoke', tcName = 'Login'): void {
   writeFile(path.join(root, '.testproject'), TESTPROJECT_XML);
-  writeFile(path.join(root, 'tests', `${tcName}.testcase`),
-    makeXml(G.tc1, G.s1, `tc-${tcName.toLowerCase()}`));
-  writeFile(path.join(root, 'plans', planName, `${tcName}.testinstance`),
-    `testCasePath="tests/${tcName}.testcase"\n`);
+  writeFile(path.join(root, 'tests', `${tcName}.testcase`), makeXml(G.tc1, G.s1));
+  writeFile(path.join(root, 'plans', planName, `${tcName}.testinstance`), `testCasePath="tests/${tcName}.testcase"\n`);
 }
 
 // ── Test setup ─────────────────────────────────────────────────────────────────
@@ -211,8 +210,7 @@ describe('provar.project.validate (from path)', () => {
       });
 
       const defaultResultsDir = path.join(tmpDir, 'provardx', 'validation');
-      const exists = fs.existsSync(defaultResultsDir) &&
-        fs.readdirSync(defaultResultsDir).length > 0;
+      const exists = fs.existsSync(defaultResultsDir) && fs.readdirSync(defaultResultsDir).length > 0;
       assert.equal(exists, false, 'No results file should be written when save_results=false');
     });
 
@@ -306,7 +304,7 @@ describe('provar.project.validate (from path)', () => {
       const root = mktemp();
       writeFile(path.join(root, '.testproject'), TESTPROJECT_XML);
       for (const name of ['Login', 'Logout', 'Search']) {
-        writeFile(path.join(root, 'tests', `${name}.testcase`), makeXml(G.tc1, G.s1, `tc-${name.toLowerCase()}`));
+        writeFile(path.join(root, 'tests', `${name}.testcase`), makeXml(G.tc1, G.s1));
       }
       writeFile(path.join(root, 'plans', 'smoke', 'Login.testinstance'), 'testCasePath="tests/Login.testcase"\n');
 
@@ -320,6 +318,86 @@ describe('provar.project.validate (from path)', () => {
       const uncovered = coverage['uncovered_test_cases'] as string[];
       assert.ok(uncovered.length <= 1, 'Should be truncated to max_uncovered=1');
       assert.equal(coverage['uncovered_truncated'], true);
+    });
+  });
+
+  describe('plan integrity warnings (E2)', () => {
+    it('reports plan_integrity_warnings when a plan dir is missing .planitem', () => {
+      const root = mktemp();
+      writeFile(path.join(root, '.testproject'), TESTPROJECT_XML);
+      writeFile(path.join(root, 'tests', 'Login.testcase'), makeXml(G.tc1, G.s1));
+      // Plan dir exists but has no .planitem file
+      writeFile(path.join(root, 'plans', 'smoke', 'Login.testinstance'), 'testCasePath="tests/Login.testcase"\n');
+
+      const result = server.call('provar.project.validate', {
+        project_path: root,
+        save_results: false,
+      });
+
+      assert.equal(isError(result), false);
+      const body = parseText(result);
+      const warnings = body['plan_integrity_warnings'] as string[] | undefined;
+      assert.ok(
+        Array.isArray(warnings) && warnings.length > 0,
+        'Expected plan_integrity_warnings for missing .planitem'
+      );
+      assert.ok(warnings[0].includes('smoke'), 'Warning should name the plan');
+      assert.ok(warnings[0].includes('.planitem'), 'Warning should mention .planitem');
+    });
+
+    it('reports plan_integrity_warnings when a suite dir is missing .planitem', () => {
+      const root = mktemp();
+      writeFile(path.join(root, '.testproject'), TESTPROJECT_XML);
+      writeFile(path.join(root, 'tests', 'Login.testcase'), makeXml(G.tc1, G.s1));
+      // Plan has .planitem but a suite subdir does not
+      writeFile(
+        path.join(root, 'plans', 'smoke', '.planitem'),
+        '<?xml version="1.0" encoding="UTF-8"?><testPlan guid="abc-123"/>'
+      );
+      writeFile(
+        path.join(root, 'plans', 'smoke', 'SuiteA', 'Login.testinstance'),
+        'testCasePath="tests/Login.testcase"\n'
+      );
+
+      const result = server.call('provar.project.validate', {
+        project_path: root,
+        save_results: false,
+      });
+
+      assert.equal(isError(result), false);
+      const body = parseText(result);
+      const warnings = body['plan_integrity_warnings'] as string[] | undefined;
+      assert.ok(
+        Array.isArray(warnings) && warnings.length > 0,
+        'Expected plan_integrity_warnings for suite missing .planitem'
+      );
+      assert.ok(
+        warnings.some((w) => w.includes('SuiteA')),
+        'Warning should name the suite directory'
+      );
+    });
+
+    it('does NOT include plan_integrity_warnings when all .planitem files are present', () => {
+      const root = mktemp();
+      writeFile(path.join(root, '.testproject'), TESTPROJECT_XML);
+      writeFile(path.join(root, 'tests', 'Login.testcase'), makeXml(G.tc1, G.s1));
+      writeFile(
+        path.join(root, 'plans', 'smoke', '.planitem'),
+        '<?xml version="1.0" encoding="UTF-8"?><testPlan guid="abc-123"/>'
+      );
+      writeFile(path.join(root, 'plans', 'smoke', 'Login.testinstance'), 'testCasePath="tests/Login.testcase"\n');
+
+      const result = server.call('provar.project.validate', {
+        project_path: root,
+        save_results: false,
+      });
+
+      assert.equal(isError(result), false);
+      const body = parseText(result);
+      assert.ok(
+        !('plan_integrity_warnings' in body),
+        'No plan_integrity_warnings expected when .planitem files are present'
+      );
     });
   });
 });

--- a/test/unit/mcp/testCaseGenerate.test.ts
+++ b/test/unit/mcp/testCaseGenerate.test.ts
@@ -99,7 +99,7 @@ describe('provar.testcase.generate', () => {
   });
 
   describe('generated XML content', () => {
-    it('contains <testCase> root element with name attribute', () => {
+    it('generates correct <testCase> element structure per Provar requirements', () => {
       const result = server.call('provar.testcase.generate', {
         test_case_name: 'Create Account',
         steps: [],
@@ -108,8 +108,11 @@ describe('provar.testcase.generate', () => {
       });
 
       const xml = parseText(result)['xml_content'] as string;
+      assert.ok(xml.includes('standalone="no"'), 'Expected standalone="no" in XML declaration');
       assert.ok(xml.includes('<testCase'), 'Expected <testCase element');
-      assert.ok(xml.includes('name="Create Account"'), 'Expected name attribute');
+      assert.ok(xml.includes('id="1"'), 'Expected id="1" (Provar integer literal)');
+      assert.ok(!xml.includes('name="Create Account"'), 'testCase must NOT have a name attribute');
+      assert.ok(xml.includes('<summary/>'), 'Expected <summary/> as first child of testCase');
     });
 
     it('contains <steps> element', () => {
@@ -138,18 +141,19 @@ describe('provar.testcase.generate', () => {
       assert.ok(UUID_RE.test(guidMatch[1]), `Expected UUID v4, got: ${guidMatch[1]}`);
     });
 
-    it('uses explicit test_case_id when provided', () => {
-      const myId = 'my-explicit-id-123';
+    it('always emits id="1" regardless of test_case_name (Provar integer literal requirement)', () => {
       const result = server.call('provar.testcase.generate', {
         test_case_name: 'Explicit ID Test',
-        test_case_id: myId,
         steps: [],
         dry_run: true,
         overwrite: false,
       });
 
       const xml = parseText(result)['xml_content'] as string;
-      assert.ok(xml.includes(`id="${myId}"`), 'Expected explicit id in XML');
+      assert.ok(xml.includes('id="1"'), 'Expected id="1" literal in testCase element');
+      // Ensure the testCase id attr specifically is "1", not a UUID.
+      // Use word-boundary regex to avoid matching registryId="<uuid>" or guid="<uuid>".
+      assert.ok(!xml.match(/\btestCase\b[^>]*?\bid="[0-9a-f]{8}-/), 'testCase id must not be a UUID');
     });
 
     it('includes steps with correct apiId and sequential testItemId', () => {
@@ -220,7 +224,7 @@ describe('provar.testcase.generate', () => {
       assert.ok(xml.includes('TODO'), 'Expected TODO placeholder for empty steps');
     });
 
-    it('escapes XML special characters in test_case_name', () => {
+    it('does not embed test_case_name in XML (name attr removed per Provar spec)', () => {
       const result = server.call('provar.testcase.generate', {
         test_case_name: 'Test & "Escape" <this>',
         steps: [],
@@ -229,10 +233,9 @@ describe('provar.testcase.generate', () => {
       });
 
       const xml = parseText(result)['xml_content'] as string;
-      assert.ok(xml.includes('&amp;'), 'Expected & escaped to &amp;');
-      assert.ok(xml.includes('&quot;'), 'Expected " escaped to &quot;');
-      assert.ok(xml.includes('&lt;'), 'Expected < escaped to &lt;');
-      assert.ok(xml.includes('&gt;'), 'Expected > escaped to &gt;');
+      // Provar derives test name from the file name — the name attr is not written to testCase
+      assert.ok(!xml.includes('name="Test'), 'testCase must NOT have a name attribute');
+      assert.ok(!xml.includes('Test &amp;'), 'escaped name must not appear in XML');
     });
 
     it('escapes XML special characters in step api_id and name', () => {
@@ -479,7 +482,10 @@ describe('provar.testcase.generate', () => {
       const xml = parseText(result)['xml_content'] as string;
       assert.ok(xml.includes('class="uiTarget"'), 'Expected class="uiTarget"');
       assert.ok(xml.includes('uri="sf:ui:target?'), 'Expected uri attribute with sf:ui:target value');
-      assert.ok(!xml.includes('valueClass="string">sf:ui:target'), 'Must NOT emit uiTarget URI as a plain string value');
+      assert.ok(
+        !xml.includes('valueClass="string">sf:ui:target'),
+        'Must NOT emit uiTarget URI as a plain string value'
+      );
     });
 
     it('emits class="uiLocator" uri="..." for the locator argument', () => {
@@ -500,7 +506,10 @@ describe('provar.testcase.generate', () => {
       const xml = parseText(result)['xml_content'] as string;
       assert.ok(xml.includes('class="uiLocator"'), 'Expected class="uiLocator"');
       assert.ok(xml.includes('uri="sf:ui:locator:'), 'Expected uri attribute with locator value');
-      assert.ok(!xml.includes('valueClass="string">sf:ui:locator'), 'Must NOT emit locator URI as a plain string value');
+      assert.ok(
+        !xml.includes('valueClass="string">sf:ui:locator'),
+        'Must NOT emit locator URI as a plain string value'
+      );
     });
 
     it('uiTarget also applies inside UiWithScreen wrapper when target_uri is non-SF', () => {
@@ -515,7 +524,10 @@ describe('provar.testcase.generate', () => {
 
       const xml = parseText(result)['xml_content'] as string;
       assert.ok(xml.includes('class="uiTarget"'), 'Wrapper UiWithScreen target should use uiTarget class');
-      assert.ok(xml.includes('uri="ui:pageobject:target?pageId=pageobjects.LoginPage"'), 'URI should appear as attribute');
+      assert.ok(
+        xml.includes('uri="ui:pageobject:target?pageId=pageobjects.LoginPage"'),
+        'URI should appear as attribute'
+      );
     });
   });
 
@@ -542,10 +554,7 @@ describe('provar.testcase.generate', () => {
       assert.ok(xml.includes('<namedValue name="testCaseName">'), 'Expected namedValue for testCaseName');
       assert.ok(xml.includes('<namedValue name="testType">'), 'Expected namedValue for testType');
       assert.ok(xml.includes('<argument id="values">'), 'Expected argument id="values"');
-      assert.ok(
-        !xml.includes('testCaseName|TC_New'),
-        'Must NOT emit pipe-delimited string for SetValues'
-      );
+      assert.ok(!xml.includes('testCaseName|TC_New'), 'Must NOT emit pipe-delimited string for SetValues');
     });
 
     it('AssertValues uses flat argument structure (not valueList)', () => {
@@ -572,9 +581,7 @@ describe('provar.testcase.generate', () => {
     it('non-SetValues steps still use flat argument structure', () => {
       const result = server.call('provar.testcase.generate', {
         test_case_name: 'Flat Args Test',
-        steps: [
-          { api_id: 'ApexCreateObject', name: 'Create record', attributes: { objectApiName: 'Opportunity' } },
-        ],
+        steps: [{ api_id: 'ApexCreateObject', name: 'Create record', attributes: { objectApiName: 'Opportunity' } }],
         dry_run: true,
         overwrite: false,
         validate_after_edit: false,

--- a/test/unit/mcp/testCaseValidate.test.ts
+++ b/test/unit/mcp/testCaseValidate.test.ts
@@ -23,8 +23,9 @@ const GUID_TC = '550e8400-e29b-41d4-a716-446655440000';
 const GUID_S1 = '6ba7b810-9dad-4000-8000-00c04fd430c8';
 const GUID_S2 = '6ba7b811-9dad-4001-9001-00c04fd430c8';
 
-const VALID_TC = `<?xml version="1.0" encoding="UTF-8"?>
-<testCase id="test-001" guid="${GUID_TC}" registryId="abc123" name="My Test">
+const VALID_TC = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testCase guid="${GUID_TC}" id="1" registryId="abc123">
+  <summary/>
   <steps>
     <apiCall guid="${GUID_S1}" apiId="UiConnect" name="Connect to browser" testItemId="1"/>
     <apiCall guid="${GUID_S2}" apiId="UiNavigate" name="Navigate to login" testItemId="2"/>
@@ -38,8 +39,8 @@ describe('validateTestCase', () => {
       assert.equal(r.is_valid, true);
       assert.equal(r.error_count, 0);
       assert.equal(r.step_count, 2);
-      assert.equal(r.test_case_id, 'test-001');
-      assert.equal(r.test_case_name, 'My Test');
+      assert.equal(r.test_case_id, '1');
+      assert.equal(r.test_case_name, null); // name attr is absent per Provar spec
     });
   });
 
@@ -78,6 +79,16 @@ describe('validateTestCase', () => {
       assert.ok(
         r.issues.some((i) => i.rule_id === 'TC_010'),
         'Expected TC_010'
+      );
+    });
+
+    it('TC_010: flags non-"1" id (e.g. UUID used as id)', () => {
+      const r = validateTestCase(
+        `<?xml version="1.0" encoding="UTF-8"?><testCase id="${GUID_TC}" guid="${GUID_TC}" registryId="r"><steps/></testCase>`
+      );
+      assert.ok(
+        r.issues.some((i) => i.rule_id === 'TC_010'),
+        'Expected TC_010 for UUID used as id'
       );
     });
 
@@ -841,8 +852,8 @@ describe('registerTestCaseValidate handler', () => {
     assert.equal(result['is_valid'], true);
     assert.equal(result['quality_score'], 90);
     // Metadata extracted from XML locally and merged into the API response
-    assert.equal(result['test_case_id'], 'test-001');
-    assert.equal(result['test_case_name'], 'My Test');
+    assert.equal(result['test_case_id'], '1'); // id="1" per Provar spec
+    assert.equal(result['test_case_name'], null); // name attr absent per Provar spec
     assert.equal(result['step_count'], 2);
   });
 

--- a/test/unit/mcp/testCaseValidate.test.ts
+++ b/test/unit/mcp/testCaseValidate.test.ts
@@ -92,6 +92,11 @@ describe('validateTestCase', () => {
       );
     });
 
+    it('TC_010: does not fire when id="1" (the correct literal)', () => {
+      const r = validateTestCase(VALID_TC);
+      assert.ok(!r.issues.some((i) => i.rule_id === 'TC_010'), 'TC_010 must not fire when id="1"');
+    });
+
     it('TC_011: flags missing guid', () => {
       const r = validateTestCase(
         '<?xml version="1.0" encoding="UTF-8"?><testCase id="x" registryId="r"><steps/></testCase>'

--- a/test/unit/services/projectValidation.test.ts
+++ b/test/unit/services/projectValidation.test.ts
@@ -33,8 +33,8 @@ const VALID_TC_XML = (guid: string, stepGuid: string, id: string): string => `<?
 const G = {
   tc1: '550e8400-e29b-41d4-a716-446655440001',
   tc2: '550e8400-e29b-41d4-a716-446655440002',
-  s1:  '550e8400-e29b-41d4-a716-446655440011',
-  s2:  '550e8400-e29b-41d4-a716-446655440012',
+  s1: '550e8400-e29b-41d4-a716-446655440011',
+  s2: '550e8400-e29b-41d4-a716-446655440012',
 };
 
 const TESTPROJECT_XML = `<?xml version="1.0" encoding="UTF-8"?>
@@ -72,13 +72,23 @@ function makeProject(root: string, planName = 'smoke', tcName = 'Login'): void {
   // plans/<planName>/<tcName>.testinstance
   const instancePath = path.join(root, 'plans', planName, `${tcName}.testinstance`);
   writeFile(instancePath, `testCasePath="tests/${tcName}.testcase"\n`);
+
+  // plans/<planName>/.planitem — required for runner to recognise this plan
+  writeFile(
+    path.join(root, 'plans', planName, '.planitem'),
+    '<?xml version="1.0" encoding="UTF-8"?><testPlan guid="smoke-plan-001"/>'
+  );
 }
 
 // ── Cleanup ───────────────────────────────────────────────────────────────────
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
-    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* skip */ }
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* skip */
+    }
   }
 });
 
@@ -158,7 +168,11 @@ describe('readProjectContext', () => {
     } catch {
       // If chmod doesn't work (Windows), skip the test body — graceful skip
     } finally {
-      try { fs.chmodSync(tpPath, 0o644); } catch { /* skip */ }
+      try {
+        fs.chmodSync(tpPath, 0o644);
+      } catch {
+        /* skip */
+      }
     }
   });
 
@@ -166,11 +180,12 @@ describe('readProjectContext', () => {
     const root = mktemp();
     writeFile(path.join(root, '.testproject'), TESTPROJECT_XML);
     // 2 unencrypted values, 1 encrypted, 1 encryptor check line
-    writeFile(path.join(root, '.secrets'),
+    writeFile(
+      path.join(root, '.secrets'),
       'Encryptor.check=ENC1(abc123)\n' +
-      'password=plaintext\n' +
-      'apiKey=ENC1(encrypted)\n' +
-      'token=another_plaintext\n'
+        'password=plaintext\n' +
+        'apiKey=ENC1(encrypted)\n' +
+        'token=another_plaintext\n'
     );
     const { context } = readProjectContext(root);
     assert.equal(context.secretsPasswordSet, true);
@@ -230,19 +245,49 @@ describe('resolveTestInstance', () => {
 // ── toQualityTier + toQualityGrade ────────────────────────────────────────────
 
 describe('toQualityTier', () => {
-  it('returns S for score >= 95', () => { assert.equal(toQualityTier(100), 'S'); assert.equal(toQualityTier(95), 'S'); });
-  it('returns A for score 85-94', () => { assert.equal(toQualityTier(90), 'A'); assert.equal(toQualityTier(85), 'A'); });
-  it('returns B for score 75-84', () => { assert.equal(toQualityTier(80), 'B'); assert.equal(toQualityTier(75), 'B'); });
-  it('returns C for score 65-74', () => { assert.equal(toQualityTier(70), 'C'); assert.equal(toQualityTier(65), 'C'); });
-  it('returns D for score < 65',  () => { assert.equal(toQualityTier(64), 'D'); assert.equal(toQualityTier(0), 'D'); });
+  it('returns S for score >= 95', () => {
+    assert.equal(toQualityTier(100), 'S');
+    assert.equal(toQualityTier(95), 'S');
+  });
+  it('returns A for score 85-94', () => {
+    assert.equal(toQualityTier(90), 'A');
+    assert.equal(toQualityTier(85), 'A');
+  });
+  it('returns B for score 75-84', () => {
+    assert.equal(toQualityTier(80), 'B');
+    assert.equal(toQualityTier(75), 'B');
+  });
+  it('returns C for score 65-74', () => {
+    assert.equal(toQualityTier(70), 'C');
+    assert.equal(toQualityTier(65), 'C');
+  });
+  it('returns D for score < 65', () => {
+    assert.equal(toQualityTier(64), 'D');
+    assert.equal(toQualityTier(0), 'D');
+  });
 });
 
 describe('toQualityGrade', () => {
-  it('returns Excellent for score >= 95', () => { assert.equal(toQualityGrade(100), 'Excellent'); assert.equal(toQualityGrade(95), 'Excellent'); });
-  it('returns Great for score 90-94',     () => { assert.equal(toQualityGrade(90), 'Great'); assert.equal(toQualityGrade(92), 'Great'); });
-  it('returns Good for score 80-89',      () => { assert.equal(toQualityGrade(80), 'Good'); assert.equal(toQualityGrade(85), 'Good'); });
-  it('returns Fair for score 70-79',      () => { assert.equal(toQualityGrade(70), 'Fair'); assert.equal(toQualityGrade(75), 'Fair'); });
-  it('returns Poor for score < 70',       () => { assert.equal(toQualityGrade(69), 'Poor'); assert.equal(toQualityGrade(0), 'Poor'); });
+  it('returns Excellent for score >= 95', () => {
+    assert.equal(toQualityGrade(100), 'Excellent');
+    assert.equal(toQualityGrade(95), 'Excellent');
+  });
+  it('returns Great for score 90-94', () => {
+    assert.equal(toQualityGrade(90), 'Great');
+    assert.equal(toQualityGrade(92), 'Great');
+  });
+  it('returns Good for score 80-89', () => {
+    assert.equal(toQualityGrade(80), 'Good');
+    assert.equal(toQualityGrade(85), 'Good');
+  });
+  it('returns Fair for score 70-79', () => {
+    assert.equal(toQualityGrade(70), 'Fair');
+    assert.equal(toQualityGrade(75), 'Fair');
+  });
+  it('returns Poor for score < 70', () => {
+    assert.equal(toQualityGrade(69), 'Poor');
+    assert.equal(toQualityGrade(0), 'Poor');
+  });
 });
 
 // ── validateProjectFromPath ───────────────────────────────────────────────────
@@ -372,7 +417,10 @@ describe('validateProjectFromPath', () => {
     assert.ok(result.coverage.uncovered_test_cases.some((p) => p.includes('Orphan')));
     assert.equal(result.coverage.total_test_cases_on_disk, 2);
     // covered + uncovered must always sum to total
-    assert.equal(result.coverage.covered_by_plans + result.coverage.uncovered_count, result.coverage.total_test_cases_on_disk);
+    assert.equal(
+      result.coverage.covered_by_plans + result.coverage.uncovered_count,
+      result.coverage.total_test_cases_on_disk
+    );
   });
 
   it('coverage: UUID-based match marks test as covered when testCasePath is absent but testCaseId matches registryId', () => {
@@ -390,7 +438,11 @@ describe('validateProjectFromPath', () => {
     // We simulate a mismatch by omitting testCasePath and relying solely on testCaseId
     writeFile(
       path.join(root, 'plans', 'smoke', 'UuidTest.testinstance'),
-      `testCaseId="${callableRegId}"\n`  // no testCasePath — UUID fallback must cover it
+      `testCaseId="${callableRegId}"\n` // no testCasePath — UUID fallback must cover it
+    );
+    writeFile(
+      path.join(root, 'plans', 'smoke', '.planitem'),
+      '<?xml version="1.0" encoding="UTF-8"?><testPlan guid="uuid-plan-001"/>'
     );
     const result = validateProjectFromPath({ project_path: root, save_results: false });
     assert.equal(result.coverage.covered_by_plans, 1, 'UUID-based match should count UuidTest as covered');
@@ -436,9 +488,7 @@ describe('buildQhReport', () => {
     // The saved report has the QH structure — verify by re-running with save_results: true
     const withSave = validateProjectFromPath({ project_path: root, save_results: true });
     assert.ok(withSave.saved_to !== null);
-    const report = JSON.parse(
-      fs.readFileSync(path.join(root, withSave.saved_to), 'utf-8')
-    ) as Record<string, unknown>;
+    const report = JSON.parse(fs.readFileSync(path.join(root, withSave.saved_to), 'utf-8')) as Record<string, unknown>;
     assert.ok(report.reportInfo, 'missing reportInfo');
     assert.ok(report.summary, 'missing summary');
     assert.ok(report.context, 'missing context');


### PR DESCRIPTION
## Summary

- **P1 (A3)**: Fix testCase XML structure — add standalone=no, set id=1 literal, remove name attr, add summary element as first child; update TC_010 validator rule
- **P2 (A5)**: Add ApexSoqlQuery argument IDs (soqlQuery, resultListName, apexConnectionName, resultScope) to tool description
- **P3 (E2)**: Add .planitem integrity check to readPlansDir/readPlanDirectory/readSuiteDirectory; surface plan_integrity_warnings in project.validate response; fix coverage inflation so planitem-less dirs no longer count toward covered total
- **P4 (E4)**: Add ENOBUFS transport hint to testrun tool description
- **P5 (E3)**: Add inline-edit guidance (use sfIleActivate + SaveEdit when no compiled Edit page object exists)
- **P6 (C1)**: Add Provar IDE duplicate argument injection warning to tool description
- **adversarial fix**: Restore id attr in buildTestCaseIdMap UUID lookup with guard for literal 1 — preserves backward compat for legacy projects

## Test plan

- [x] 843 passing, 1 pending, 0 failing (node_modules/.bin/nyc mocha)
- [x] yarn compile — clean TypeScript build
- [ ] Manual: provar.testcase.generate output has standalone=no, id=1, summary as first child
- [ ] Manual: provar.project.validate on a project with planitem-less plan subdir shows plan_integrity_warnings

Generated with Claude Code