### PR TITLE
PDX-0: feat(mcp): auto-update check at MCP startup (v1.5.0-beta.14)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -143,11 +143,11 @@ The server communicates over **stdio** (standard input / output). It must be sta
 
 ### Flags
 
-| Flag                | Alias | Default                   | Description                                                                                                                          |
-| ------------------- | ----- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `--allowed-paths`   | `-a`  | Current working directory | Base directories that file-system tools are permitted to read and write. Repeat the flag to allow multiple paths.                    |
-| `--auto-update`     |       | false                     | Automatically installs the latest version at startup and restarts the MCP connection. Skipped if running from a development symlink. |
-| `--no-update-check` |       | false                     | Skip the startup update check. Also controlled by the `PROVAR_NO_UPDATE_CHECK` environment variable.                                 |
+| Flag                | Alias | Default                   | Description                                                                                                                                                  |
+| ------------------- | ----- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--allowed-paths`   | `-a`  | Current working directory | Base directories that file-system tools are permitted to read and write. Repeat the flag to allow multiple paths.                                            |
+| `--auto-update`     |       | false                     | Automatically installs the latest version at startup and exits so the client reconnects with the new version. Skipped if running from a development symlink. |
+| `--no-update-check` |       | false                     | Skip the startup update check. Also controlled by the `PROVAR_NO_UPDATE_CHECK` environment variable.                                                         |
 
 ```sh
 # Allow access to a specific project directory
@@ -489,14 +489,14 @@ A lightweight sanity-check tool. Echoes back the message you send. Useful for ve
 
 **Output**
 
-| Field             | Type    | Description                                               |
-| ----------------- | ------- | --------------------------------------------------------- | --------------------------------------------------- |
-| `pong`            | string  | The echoed message                                        |
-| `ts`              | string  | ISO-8601 timestamp                                        |
-| `server`          | string  | Server name and version (e.g. `provar-mcp@1.5.0-beta.10`) |
-| `updateAvailable` | boolean | Whether a newer version is available in the registry      |
-| `latestVersion`   | string  | null                                                      | Latest version found in the npm registry, or `null` |
-| `updateCommand`   | string  | null                                                      | Command to run to update the plugin, or `null`      |
+| Field             | Type           | Description                                               |
+| ----------------- | -------------- | --------------------------------------------------------- |
+| `pong`            | string         | The echoed message                                        |
+| `ts`              | string         | ISO-8601 timestamp                                        |
+| `server`          | string         | Server name and version (e.g. `provar-mcp@1.5.0-beta.14`) |
+| `updateAvailable` | boolean        | Whether a newer version is available in the registry      |
+| `latestVersion`   | string \| null | Latest version found in the npm registry, or `null`       |
+| `updateCommand`   | string \| null | Command to run to update the plugin, or `null`            |
 
 ---
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -143,9 +143,11 @@ The server communicates over **stdio** (standard input / output). It must be sta
 
 ### Flags
 
-| Flag              | Alias | Default                   | Description                                                                                                       |
-| ----------------- | ----- | ------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `--allowed-paths` | `-a`  | Current working directory | Base directories that file-system tools are permitted to read and write. Repeat the flag to allow multiple paths. |
+| Flag                | Alias | Default                   | Description                                                                                                                          |
+| ------------------- | ----- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `--allowed-paths`   | `-a`  | Current working directory | Base directories that file-system tools are permitted to read and write. Repeat the flag to allow multiple paths.                    |
+| `--auto-update`     |       | false                     | Automatically installs the latest version at startup and restarts the MCP connection. Skipped if running from a development symlink. |
+| `--no-update-check` |       | false                     | Skip the startup update check. Also controlled by the `PROVAR_NO_UPDATE_CHECK` environment variable.                                 |
 
 ```sh
 # Allow access to a specific project directory
@@ -485,7 +487,16 @@ A lightweight sanity-check tool. Echoes back the message you send. Useful for ve
 | --------- | ------ | -------- | --------------------- |
 | `message` | string | no       | Any text to echo back |
 
-**Output** — `{ message: string }`
+**Output**
+
+| Field             | Type    | Description                                               |
+| ----------------- | ------- | --------------------------------------------------------- | --------------------------------------------------- |
+| `pong`            | string  | The echoed message                                        |
+| `ts`              | string  | ISO-8601 timestamp                                        |
+| `server`          | string  | Server name and version (e.g. `provar-mcp@1.5.0-beta.10`) |
+| `updateAvailable` | boolean | Whether a newer version is available in the registry      |
+| `latestVersion`   | string  | null                                                      | Latest version found in the npm registry, or `null` |
+| `updateCommand`   | string  | null                                                      | Command to run to update the plugin, or `null`      |
 
 ---
 
@@ -639,13 +650,13 @@ Generates an XML test case skeleton with UUID v4 guids and sequential `testItemI
 
 **Argument XML conventions** (automatically applied by the generator):
 
-| Argument key / value pattern         | Emitted XML class             | API context                         |
-| ------------------------------------ | ----------------------------- | ----------------------------------- |
-| `target` key                         | `class="uiTarget"`            | UiWithScreen, UiWithRow             |
-| `locator` key                        | `class="uiLocator"`           | UiDoAction, UiAssert                |
-| Value matches `{VarName}` or `{A.B}` | `class="variable"` + `<path>` | Any step                            |
-| SetValues attributes                 | `class="valueList"/<namedValues>` | SetValues only                  |
-| All other values                     | `class="value" valueClass="string"` | Any step                      |
+| Argument key / value pattern         | Emitted XML class                   | API context             |
+| ------------------------------------ | ----------------------------------- | ----------------------- |
+| `target` key                         | `class="uiTarget"`                  | UiWithScreen, UiWithRow |
+| `locator` key                        | `class="uiLocator"`                 | UiDoAction, UiAssert    |
+| Value matches `{VarName}` or `{A.B}` | `class="variable"` + `<path>`       | Any step                |
+| SetValues attributes                 | `class="valueList"/<namedValues>`   | SetValues only          |
+| All other values                     | `class="value" valueClass="string"` | Any step                |
 
 AssertValues uses **flat** argument structure (`expectedValue`, `actualValue`, `comparisonType`) — not the `valueList`/namedValues format.
 

--- a/messages/sf.provar.mcp.start.md
+++ b/messages/sf.provar.mcp.start.md
@@ -1,71 +1,107 @@
 # summary
+
 Start a local MCP server for Provar tools over stdio transport.
 
 # description
+
 Launches a stateless MCP (Model Context Protocol) server that exposes Provar tools to
 AI assistants (Claude Desktop, Claude Code, Cursor) via stdio transport. All MCP
 JSON-RPC communication happens over stdout; all internal logging goes to stderr.
 
 Available tools:
 
-  Project & inspection:
-  - provar.project.inspect            — inspect project folder inventory
-  - provar.project.validate           — validate full project from disk: coverage, quality scores
+Project & inspection:
 
-  Page Object:
-  - provar.pageobject.generate        — generate a Java Page Object skeleton
-  - provar.pageobject.validate        — validate Page Object quality and naming
+- provar.project.inspect — inspect project folder inventory
+- provar.project.validate — validate full project from disk: coverage, quality scores
 
-  Test Case:
-  - provar.testcase.generate          — generate an XML test case skeleton
-  - provar.testcase.validate          — validate test case XML (validity + best-practices scores)
+Page Object:
 
-  Test Suite / Plan:
-  - provar.testsuite.validate         — validate test suite hierarchy
-  - provar.testplan.validate          — validate test plan metadata completeness
-  - provar.testplan.create-suite      — create a test suite under a plan
-  - provar.testplan.add-instance      — add a test instance to a plan
-  - provar.testplan.remove-instance   — remove a test instance from a plan
+- provar.pageobject.generate — generate a Java Page Object skeleton
+- provar.pageobject.validate — validate Page Object quality and naming
 
-  Properties files:
-  - provar.properties.read            — read a Provar properties file
-  - provar.properties.set             — set a key in a Provar properties file
-  - provar.properties.validate        — validate a properties file structure
-  - provar.properties.generate        — generate a properties file skeleton
+Test Case:
 
-  Quality Hub (sf provar quality-hub wrappers):
-  - provar.qualityhub.connect         — connect to a Quality Hub org
-  - provar.qualityhub.display         — display connected org info
-  - provar.qualityhub.testrun         — trigger a Quality Hub test run
-  - provar.qualityhub.testrun.report  — poll test run status
-  - provar.qualityhub.testrun.abort   — abort a running test run
-  - provar.qualityhub.testcase.retrieve — retrieve test case results
-  - provar.qualityhub.defect.create   — create defects for failed test executions
+- provar.testcase.generate — generate an XML test case skeleton
+- provar.testcase.validate — validate test case XML (validity + best-practices scores)
+- provar.testcase.step.edit — atomically add or remove a single step in a test case
 
-  Automation (sf provar automation wrappers):
-  - provar.automation.setup           — set up the Provar Automation runtime
-  - provar.automation.metadata.download — download Salesforce metadata
-  - provar.automation.compile         — compile Provar test assets
-  - provar.automation.testrun         — run Provar tests
-  - provar.automation.config.load     — load a Provar configuration
+Test Suite / Plan:
 
-  ANT build:
-  - provar.ant.generate               — generate an ANT build.xml
-  - provar.ant.validate               — validate an ANT build.xml
+- provar.testsuite.validate — validate test suite hierarchy
+- provar.testplan.validate — validate test plan metadata completeness
+- provar.testplan.create-suite — create a test suite under a plan
+- provar.testplan.add-instance — add a test instance to a plan
+- provar.testplan.remove-instance — remove a test instance from a plan
 
-  Test result analysis:
-  - provar.testrun.rca                — root cause analysis on a test result
-  - provar.testrun.report.locate      — locate a test result report
+Properties files:
+
+- provar.properties.read — read a Provar properties file
+- provar.properties.set — set a key in a Provar properties file
+- provar.properties.validate — validate a properties file structure
+- provar.properties.generate — generate a properties file skeleton
+
+Quality Hub (sf provar quality-hub wrappers):
+
+- provar.qualityhub.connect — connect to a Quality Hub org
+- provar.qualityhub.display — display connected org info
+- provar.qualityhub.testrun — trigger a Quality Hub test run
+- provar.qualityhub.testrun.report — poll test run status
+- provar.qualityhub.testrun.abort — abort a running test run
+- provar.qualityhub.testcase.retrieve — retrieve test case results
+- provar.qualityhub.defect.create — create defects for failed test executions
+- provar.qualityhub.examples.retrieve — retrieve corpus examples for a given step type
+
+Automation (sf provar automation wrappers):
+
+- provar.automation.setup — set up the Provar Automation runtime
+- provar.automation.metadata.download — download Salesforce metadata
+- provar.automation.compile — compile Provar test assets
+- provar.automation.testrun — run Provar tests
+- provar.automation.config.load — load a Provar configuration
+
+ANT build:
+
+- provar.ant.generate — generate an ANT build.xml
+- provar.ant.validate — validate an ANT build.xml
+
+Test result analysis:
+
+- provar.testrun.rca — root cause analysis on a test result
+- provar.testrun.report.locate — locate a test result report
+
+NitroX (Provar NitroX component tools):
+
+- provar.nitrox.discover — discover NitroX component metadata
+- provar.nitrox.generate — generate a NitroX component
+- provar.nitrox.patch — patch a NitroX component definition
+- provar.nitrox.read — read a NitroX component definition
+- provar.nitrox.validate — validate a NitroX component
+
+Connections:
+
+- provar.connection.list — list connections and named environments from .testproject
 
 For full tool documentation see docs/mcp.md in this repository.
 
 # flags.allowed-paths.summary
+
 Allowed base directory paths for file operations. Defaults to current directory.
 
 # flags.auto-defects.summary
+
 When enabled, testrun.report suggestions will prompt defect creation on failures.
 
+# flags.auto-update.summary
+
+When enabled, automatically installs the latest version of the plugin and restarts the MCP connection on startup.
+
+# flags.no-update-check.summary
+
+Skip the update check at startup. Also controlled by the PROVAR_NO_UPDATE_CHECK environment variable.
+
 # examples
+
 - Start MCP server (accepts stdio connections from Claude Desktop / Cursor):
   <%= config.bin %> <%= command.id %>
 - Start with explicit allowed paths:

--- a/messages/sf.provar.mcp.start.md
+++ b/messages/sf.provar.mcp.start.md
@@ -94,7 +94,7 @@ When enabled, testrun.report suggestions will prompt defect creation on failures
 
 # flags.auto-update.summary
 
-When enabled, automatically installs the latest version of the plugin and restarts the MCP connection on startup.
+When enabled, automatically installs the latest version at startup and exits. The MCP client must reconnect to load the new version.
 
 # flags.no-update-check.summary
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provartesting/provardx-cli",
   "description": "A plugin for the Salesforce CLI to orchestrate testing activities and report quality metrics to Provar Quality Hub",
-  "version": "1.5.0-beta.12",
+  "version": "1.5.0-beta.14",
   "mcpName": "io.github.ProvarTesting/provar",
   "license": "BSD-3-Clause",
   "plugins": [

--- a/server.json
+++ b/server.json
@@ -14,12 +14,12 @@
     "url": "https://github.com/ProvarTesting/provardx-cli",
     "source": "github"
   },
-  "version": "1.5.0-beta.12",
+  "version": "1.5.0-beta.14",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@provartesting/provardx-cli",
-      "version": "1.5.0-beta.12",
+      "version": "1.5.0-beta.14",
       "transport": {
         "type": "stdio"
       },

--- a/src/commands/provar/mcp/start.ts
+++ b/src/commands/provar/mcp/start.ts
@@ -10,6 +10,7 @@ import { Messages } from '@provartesting/provardx-plugins-utils';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createProvarMcpServer } from '../../../mcp/server.js';
 import { validateLicense, LicenseError } from '../../../mcp/licensing/index.js';
+import { checkForUpdate } from '../../../mcp/update/updateChecker.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@provartesting/provardx-cli', 'sf.provar.mcp.start');
@@ -36,6 +37,14 @@ export default class SfProvarMcpStart extends SfCommand<void> {
       summary: messages.getMessage('flags.auto-defects.summary'),
       default: false,
     }),
+    'auto-update': Flags.boolean({
+      summary: messages.getMessage('flags.auto-update.summary'),
+      default: false,
+    }),
+    'no-update-check': Flags.boolean({
+      summary: messages.getMessage('flags.no-update-check.summary'),
+      default: false,
+    }),
   };
 
   public async run(): Promise<void> {
@@ -51,9 +60,7 @@ export default class SfProvarMcpStart extends SfCommand<void> {
     try {
       const result = await validateLicense();
       if (result.offlineGrace) {
-        process.stderr.write(
-          '[provar-mcp] Warning: license validated from offline cache (last checked > 2h ago).\n'
-        );
+        process.stderr.write('[provar-mcp] Warning: license validated from offline cache (last checked > 2h ago).\n');
       }
     } catch (err: unknown) {
       if (err instanceof LicenseError) {
@@ -62,7 +69,12 @@ export default class SfProvarMcpStart extends SfCommand<void> {
       throw err;
     }
 
-    const server = createProvarMcpServer({ allowedPaths });
+    const updateResult = await checkForUpdate({
+      noUpdateCheck: flags['no-update-check'],
+      autoUpdate: flags['auto-update'],
+    });
+
+    const server = createProvarMcpServer({ allowedPaths, updateResult });
     const transport = new StdioServerTransport();
 
     // Connect hands stdin/stdout ownership to the SDK.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -38,6 +38,11 @@ import { registerAllPrompts } from './prompts/index.js';
 
 export interface ServerConfig {
   allowedPaths: string[];
+  updateResult?: {
+    updateAvailable: boolean;
+    latestVersion: string | null;
+    updateCommand: string | null;
+  };
 }
 
 export function createProvarMcpServer(config: ServerConfig): McpServer {
@@ -56,7 +61,14 @@ export function createProvarMcpServer(config: ServerConfig): McpServer {
       message: z.string().optional().default('ping').describe('Optional message to echo back'),
     },
     ({ message }) => {
-      const result = { pong: message, ts: new Date().toISOString(), server: `provar-mcp@${SERVER_VERSION}` };
+      const result = {
+        pong: message,
+        ts: new Date().toISOString(),
+        server: `provar-mcp@${SERVER_VERSION}`,
+        updateAvailable: config.updateResult?.updateAvailable ?? false,
+        latestVersion: config.updateResult?.latestVersion ?? null,
+        updateCommand: config.updateResult?.updateCommand ?? null,
+      };
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(result) }],
         structuredContent: result,

--- a/src/mcp/update/updateChecker.ts
+++ b/src/mcp/update/updateChecker.ts
@@ -216,7 +216,12 @@ export async function checkForUpdate(opts: {
   const channel = deriveChannel(currentVersion);
   const cached = readUpdateCache();
 
-  if (cached != null && Date.now() - cached.checkedAt < UPDATE_TTL_MS) {
+  if (
+    cached != null &&
+    cached.channel === channel &&
+    cached.currentVersion === currentVersion &&
+    Date.now() - cached.checkedAt < UPDATE_TTL_MS
+  ) {
     log('info', 'updateChecker: cache hit', { channel, latestVersion: cached.latestVersion, fromCache: true });
     return resultFromCache(cached, currentVersion);
   }

--- a/src/mcp/update/updateChecker.ts
+++ b/src/mcp/update/updateChecker.ts
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2024 Provar Limited.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.md file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import type { SpawnSyncOptions } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { log } from '../logging/logger.js';
+
+const requireJson = createRequire(import.meta.url);
+const CURRENT_SERVER_VERSION: string = (requireJson('../../../package.json') as { version: string }).version;
+
+export interface CheckForUpdateResult {
+  currentVersion: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  updateCommand: string | null;
+  fromCache: boolean;
+}
+
+interface UpdateCacheEntry {
+  checkedAt: number;
+  currentVersion: string;
+  latestVersion: string | null;
+  channel: string;
+}
+
+const UPDATE_TTL_MS = 4 * 60 * 60 * 1_000;
+const UPDATE_GRACE_MS = 48 * 60 * 60 * 1_000;
+
+const SPAWN_OPTS = {
+  stdio: ['ignore', 'pipe', 'pipe'] as const,
+  timeout: 30_000,
+  shell: process.platform === 'win32',
+  maxBuffer: 10 * 1_024 * 1_024,
+} satisfies SpawnSyncOptions;
+
+const SEMVER_RE = /^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/;
+
+function cacheDir(): string {
+  const provarHome = process.env['PROVAR_HOME'] ?? path.join(os.homedir(), 'Provar');
+  return path.join(provarHome, '.cache');
+}
+
+function cacheFile(): string {
+  return path.join(cacheDir(), '.mcp-update-cache.json');
+}
+
+// Derives the dist-tag channel from the current version's prerelease identifier.
+// '1.5.0-beta.10' → 'beta', '1.5.0' → 'latest'
+// Same-channel assumption: we fetch dist-tags.{channel} and compare within that channel.
+// Cross-label comparison (e.g. beta vs rc) is explicitly out of scope.
+export function deriveChannel(version: string): string {
+  const hyphen = version.indexOf('-');
+  if (hyphen === -1) return 'latest';
+  return version.slice(hyphen + 1).split('.')[0] ?? 'latest';
+}
+
+export function isNewer(current: string, latest: string): boolean {
+  if (current === latest) return false;
+  if (!SEMVER_RE.test(latest)) return false;
+  const split = (v: string): readonly [number, number, number, number] => {
+    const [main, pre = ''] = v.split('-');
+    const [major, minor, patch] = (main ?? '').split('.').map(Number);
+    // Infinity for stable versions so stable is always newer than any prerelease
+    const preN = pre ? parseInt(pre.split('.').pop() ?? '0', 10) : Infinity;
+    return [major, minor, patch, preN] as const;
+  };
+  const [cm, cn, cp, cpN] = split(current);
+  const [lm, ln, lp, lpN] = split(latest);
+  for (const [c, l] of [
+    [cm, lm],
+    [cn, ln],
+    [cp, lp],
+    [cpN, lpN],
+  ] as const) {
+    if (l > c) return true;
+    if (l < c) return false;
+  }
+  return false;
+}
+
+export function detectInstallMethod(): 'sf-plugin' | 'npm-global' | 'linked' {
+  const modulePath = fileURLToPath(import.meta.url);
+  const sfDataDirs = [
+    path.join('.local', 'share', 'sf'),
+    path.join('AppData', 'Local', 'sf'),
+    path.join('AppData', 'Roaming', 'sf'),
+    path.join('.local', 'share', 'sfdx'),
+  ];
+  if (sfDataDirs.some((d) => modulePath.includes(d))) return 'sf-plugin';
+  if (modulePath.includes('node_modules')) return 'npm-global';
+  return 'linked';
+}
+
+function readUpdateCache(): UpdateCacheEntry | null {
+  try {
+    const raw = fs.readFileSync(cacheFile(), 'utf-8');
+    return JSON.parse(raw) as UpdateCacheEntry;
+  } catch {
+    return null;
+  }
+}
+
+function writeUpdateCache(entry: UpdateCacheEntry): void {
+  try {
+    fs.mkdirSync(cacheDir(), { recursive: true });
+    const file = cacheFile();
+    fs.writeFileSync(file, JSON.stringify(entry, null, 2), { encoding: 'utf-8', mode: 0o600 });
+    try {
+      fs.chmodSync(file, 0o600);
+    } catch {
+      // best effort
+    }
+  } catch (err) {
+    log('warn', 'updateChecker: failed to write cache', { error: String(err) });
+  }
+}
+
+function buildUpdateCommand(latestVersion: string): string {
+  const method = detectInstallMethod();
+  if (method === 'npm-global') {
+    return 'npm install -g @provartesting/provardx-cli@' + latestVersion;
+  }
+  return 'sf plugins install @provartesting/provardx-cli@' + latestVersion;
+}
+
+function resultFromCache(cached: UpdateCacheEntry, currentVersion: string): CheckForUpdateResult {
+  const updateAvailable = cached.latestVersion ? isNewer(currentVersion, cached.latestVersion) : false;
+  const updateCommand = updateAvailable && cached.latestVersion ? buildUpdateCommand(cached.latestVersion) : null;
+  return { currentVersion, latestVersion: cached.latestVersion, updateAvailable, updateCommand, fromCache: true };
+}
+
+async function fetchLatestVersion(channel: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5_000);
+  try {
+    const resp = await fetch('https://registry.npmjs.org/@provartesting/provardx-cli', {
+      signal: controller.signal,
+      headers: { Accept: 'application/json' },
+    });
+    if (!resp.ok) {
+      log('warn', 'updateChecker: registry returned non-200', { status: resp.status });
+      return null;
+    }
+    const data = (await resp.json()) as Record<string, unknown>;
+    const distTags = data['dist-tags'] as Record<string, string> | undefined;
+    const candidate = distTags?.[channel];
+    if (!candidate) {
+      log('warn', 'updateChecker: dist-tag not found in registry', { channel });
+      return null;
+    }
+    if (!SEMVER_RE.test(candidate)) {
+      log('warn', 'updateChecker: registry returned invalid semver', { candidate });
+      return null;
+    }
+    return candidate;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function applyAutoUpdate(latestVersion: string): void {
+  const method = detectInstallMethod();
+  if (method === 'linked') {
+    process.stderr.write(
+      '[provar-mcp] Auto-update skipped: running from development link. Install manually:\n' +
+        '  sf plugins install @provartesting/provardx-cli@' +
+        latestVersion +
+        '\n'
+    );
+    return;
+  }
+  const args =
+    method === 'sf-plugin'
+      ? ['plugins', 'install', '@provartesting/provardx-cli@' + latestVersion]
+      : ['install', '-g', '@provartesting/provardx-cli@' + latestVersion];
+  const cmd = method === 'sf-plugin' ? 'sf' : 'npm';
+  log('info', 'updateChecker: running auto-update', { cmd, args });
+  const result = spawnSync(cmd, args, SPAWN_OPTS);
+  if (result.error != null || result.status !== 0 || result.signal != null) {
+    const detail = result.stderr?.toString().trim() ?? '';
+    log('error', 'updateChecker: auto-update failed', { status: result.status, signal: result.signal, detail });
+  } else {
+    process.stderr.write(
+      '[provar-mcp] Updated to ' + latestVersion + '. Restart your MCP connection to use the new version.\n'
+    );
+    process.exit(0);
+  }
+}
+
+export async function checkForUpdate(opts: {
+  noUpdateCheck: boolean;
+  autoUpdate: boolean;
+}): Promise<CheckForUpdateResult> {
+  const currentVersion = CURRENT_SERVER_VERSION;
+  const earlyExit: CheckForUpdateResult = {
+    currentVersion,
+    latestVersion: null,
+    updateAvailable: false,
+    updateCommand: null,
+    fromCache: false,
+  };
+
+  if (process.env.NODE_ENV === 'test') return earlyExit;
+  if (process.env['PROVAR_NO_UPDATE_CHECK']) return earlyExit;
+  if (opts.noUpdateCheck) return earlyExit;
+
+  const channel = deriveChannel(currentVersion);
+  const cached = readUpdateCache();
+
+  if (cached != null && Date.now() - cached.checkedAt < UPDATE_TTL_MS) {
+    log('info', 'updateChecker: cache hit', { channel, latestVersion: cached.latestVersion, fromCache: true });
+    return resultFromCache(cached, currentVersion);
+  }
+
+  let latestVersion: string | null = null;
+  try {
+    latestVersion = await fetchLatestVersion(channel);
+  } catch (err: unknown) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log('warn', 'updateChecker: registry fetch failed', { error: errMsg });
+    if (cached != null && Date.now() - cached.checkedAt < UPDATE_GRACE_MS) {
+      return resultFromCache(cached, currentVersion);
+    }
+    return earlyExit;
+  }
+
+  writeUpdateCache({ checkedAt: Date.now(), currentVersion, latestVersion, channel });
+
+  const updateAvailable = latestVersion ? isNewer(currentVersion, latestVersion) : false;
+  const updateCommand = updateAvailable && latestVersion ? buildUpdateCommand(latestVersion) : null;
+
+  if (updateAvailable && latestVersion) {
+    process.stderr.write(
+      '[provar-mcp] Update available: ' +
+        latestVersion +
+        ' (current: ' +
+        currentVersion +
+        ')\n' +
+        '  Run: ' +
+        (updateCommand ?? '') +
+        '\n'
+    );
+    log('info', 'updateChecker: update available', { currentVersion, latestVersion, updateCommand });
+    if (opts.autoUpdate) {
+      applyAutoUpdate(latestVersion);
+    }
+  }
+
+  return { currentVersion, latestVersion, updateAvailable, updateCommand, fromCache: false };
+}

--- a/test/unit/mcp/updateChecker.test.ts
+++ b/test/unit/mcp/updateChecker.test.ts
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2024 Provar Limited.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.md file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { checkForUpdate, isNewer, deriveChannel, detectInstallMethod } from '../../../src/mcp/update/updateChecker.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let origProvarHome: string | undefined;
+let origNodeEnv: string | undefined;
+let origProvarNoUpdate: string | undefined;
+let origFetch: typeof globalThis.fetch;
+
+function writeFreshCache(data: object): void {
+  fs.mkdirSync(path.join(tmpDir, '.cache'), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, '.cache', '.mcp-update-cache.json'), JSON.stringify(data), 'utf-8');
+}
+
+type FakeDistTags = Record<string, string>;
+interface FakeRegistryResponse {
+  'dist-tags': FakeDistTags;
+}
+
+function mockFetchOk(distTags: FakeDistTags): void {
+  const body: FakeRegistryResponse = { 'dist-tags': distTags };
+  globalThis.fetch = (): Promise<Response> =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: (): Promise<FakeRegistryResponse> => Promise.resolve(body),
+    } as unknown as Response);
+}
+
+function mockFetchError(status: number): void {
+  globalThis.fetch = (): Promise<Response> =>
+    Promise.resolve({
+      ok: false,
+      status,
+      json: (): Promise<Record<string, unknown>> => Promise.resolve({}),
+    } as unknown as Response);
+}
+
+function mockFetchThrow(err: Error): void {
+  globalThis.fetch = (): Promise<Response> => Promise.reject(err);
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'provar-update-test-'));
+  origProvarHome = process.env['PROVAR_HOME'];
+  process.env['PROVAR_HOME'] = tmpDir;
+  origNodeEnv = process.env.NODE_ENV;
+  delete process.env.NODE_ENV; // bypass test fast-path for integration tests
+  origProvarNoUpdate = process.env['PROVAR_NO_UPDATE_CHECK'];
+  delete process.env['PROVAR_NO_UPDATE_CHECK'];
+  origFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  if (origNodeEnv !== undefined) {
+    process.env.NODE_ENV = origNodeEnv;
+  } else {
+    delete process.env.NODE_ENV;
+  }
+  if (origProvarNoUpdate !== undefined) {
+    process.env['PROVAR_NO_UPDATE_CHECK'] = origProvarNoUpdate;
+  } else {
+    delete process.env['PROVAR_NO_UPDATE_CHECK'];
+  }
+  if (origProvarHome !== undefined) {
+    process.env['PROVAR_HOME'] = origProvarHome;
+  } else {
+    delete process.env['PROVAR_HOME'];
+  }
+  globalThis.fetch = origFetch;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── A. isNewer() ──────────────────────────────────────────────────────────────
+
+describe('isNewer', () => {
+  it('returns false for identical versions', () => {
+    assert.equal(isNewer('1.5.0', '1.5.0'), false);
+  });
+
+  it('stable is newer than prerelease', () => {
+    assert.equal(isNewer('1.5.0-beta.1', '1.5.0'), true);
+  });
+
+  it('stable is not older than prerelease', () => {
+    assert.equal(isNewer('1.5.0', '1.5.0-beta.1'), false);
+  });
+
+  it('higher numeric suffix is newer', () => {
+    assert.equal(isNewer('1.5.0-beta.2', '1.5.0-beta.10'), true);
+  });
+
+  it('lower numeric suffix is not newer', () => {
+    assert.equal(isNewer('1.5.0-beta.10', '1.5.0-beta.2'), false);
+  });
+
+  it('non-semver latest returns false', () => {
+    assert.equal(isNewer('any', 'not-semver'), false);
+  });
+});
+
+// ── B. deriveChannel() ────────────────────────────────────────────────────────
+
+describe('deriveChannel', () => {
+  it('derives beta from prerelease version', () => {
+    assert.equal(deriveChannel('1.5.0-beta.10'), 'beta');
+  });
+
+  it('derives latest from stable version', () => {
+    assert.equal(deriveChannel('1.5.0'), 'latest');
+  });
+
+  it('derives rc from rc version', () => {
+    assert.equal(deriveChannel('1.5.0-rc.1'), 'rc');
+  });
+});
+
+// ── C. detectInstallMethod() ──────────────────────────────────────────────────
+
+describe('detectInstallMethod', () => {
+  it('returns a valid install method', () => {
+    const method = detectInstallMethod();
+    assert.ok(['sf-plugin', 'npm-global', 'linked'].includes(method));
+  });
+
+  it('is deterministic', () => {
+    assert.equal(detectInstallMethod(), detectInstallMethod());
+  });
+});
+
+// ── D. checkForUpdate() integration ─────────────────────────────────────────
+
+describe('checkForUpdate', () => {
+  it('returns earlyExit when PROVAR_NO_UPDATE_CHECK is set', async () => {
+    process.env['PROVAR_NO_UPDATE_CHECK'] = '1';
+    let fetchCalled = false;
+    globalThis.fetch = (): Promise<Response> => {
+      fetchCalled = true;
+      return Promise.resolve({} as Response);
+    };
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(result.updateAvailable, false);
+    assert.equal(result.latestVersion, null);
+    assert.equal(result.fromCache, false);
+    assert.equal(fetchCalled, false);
+  });
+
+  it('returns earlyExit when noUpdateCheck is true', async () => {
+    const result = await checkForUpdate({ noUpdateCheck: true, autoUpdate: false });
+    assert.equal(result.updateAvailable, false);
+    assert.equal(result.latestVersion, null);
+  });
+
+  it('returns fromCache=true for fresh cache (<4h)', async () => {
+    writeFreshCache({
+      checkedAt: Date.now() - 30 * 60 * 1_000, // 30 min ago
+      currentVersion: '1.5.0-beta.10',
+      latestVersion: '1.5.0-beta.10',
+      channel: 'beta',
+    });
+    let fetchCalled = false;
+    globalThis.fetch = (): Promise<Response> => {
+      fetchCalled = true;
+      return Promise.resolve({} as Response);
+    };
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(result.fromCache, true);
+    assert.equal(fetchCalled, false);
+  });
+
+  it('fetches registry when cache is stale (>4h)', async () => {
+    writeFreshCache({
+      checkedAt: Date.now() - 5 * 60 * 60 * 1_000, // 5 hours ago
+      currentVersion: '1.5.0-beta.10',
+      latestVersion: '1.5.0-beta.10',
+      channel: 'beta',
+    });
+    mockFetchOk({ beta: '1.5.0-beta.11' });
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(result.fromCache, false);
+    assert.equal(result.latestVersion, '1.5.0-beta.11');
+  });
+
+  it('returns updateAvailable=true when update is available', async () => {
+    mockFetchOk({ beta: '99.0.0-beta.1', latest: '99.0.0' });
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(result.updateAvailable, true);
+    assert.ok(result.updateCommand !== null);
+  });
+
+  it('returns updateAvailable=false when current equals latest', async () => {
+    const { currentVersion } = await checkForUpdate({ noUpdateCheck: true, autoUpdate: false });
+    const channel = deriveChannel(currentVersion);
+    mockFetchOk({ [channel]: currentVersion });
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(result.updateAvailable, false);
+  });
+
+  it('returns updateAvailable=false on fetch abort (no throw)', async () => {
+    mockFetchThrow(new Error('The operation was aborted'));
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(result.updateAvailable, false);
+    assert.equal(result.latestVersion, null);
+  });
+
+  it('returns updateAvailable=false on network error (no throw)', async () => {
+    mockFetchThrow(new TypeError('Failed to fetch'));
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(result.updateAvailable, false);
+  });
+
+  it('returns updateAvailable=false on HTTP non-200 (no throw)', async () => {
+    mockFetchError(503);
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(result.updateAvailable, false);
+    assert.equal(result.latestVersion, null);
+  });
+
+  it('returns latestVersion=null when dist-tag channel missing', async () => {
+    // Registry has 'latest' but not 'beta' — current version may be beta
+    mockFetchOk({ latest: '1.5.0' });
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    // No throw is the main assertion; updateAvailable depends on current version channel
+    assert.ok(result !== null);
+  });
+
+  it('treats corrupt cache as miss and fetches fresh (no throw)', async () => {
+    fs.mkdirSync(path.join(tmpDir, '.cache'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, '.cache', '.mcp-update-cache.json'), 'NOT-JSON', 'utf-8');
+    mockFetchOk({ beta: '1.5.0-beta.11', latest: '1.5.0' });
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(result.fromCache, false);
+  });
+
+  it('returns updateAvailable=false when cache is >48h stale and fetch fails', async () => {
+    writeFreshCache({
+      checkedAt: Date.now() - 50 * 60 * 60 * 1_000, // 50 hours ago
+      currentVersion: '1.5.0-beta.10',
+      latestVersion: '1.5.0-beta.10',
+      channel: 'beta',
+    });
+    mockFetchThrow(new TypeError('Failed to fetch'));
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(result.updateAvailable, false);
+  });
+
+  it('returns updateAvailable=false when registry returns invalid semver', async () => {
+    mockFetchOk({ beta: 'not-a-version', latest: 'also-bad' });
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(result.updateAvailable, false);
+    assert.equal(result.latestVersion, null);
+  });
+
+  it('writes cache file after successful fetch', async () => {
+    mockFetchOk({ beta: '1.5.0-beta.11', latest: '1.5.0' });
+    await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    const cacheFilePath = path.join(tmpDir, '.cache', '.mcp-update-cache.json');
+    assert.ok(fs.existsSync(cacheFilePath), 'Cache file should have been written');
+    const cacheData = JSON.parse(fs.readFileSync(cacheFilePath, 'utf-8')) as { checkedAt: number };
+    assert.ok(cacheData.checkedAt > 0, 'Cache should have checkedAt');
+  });
+
+  it('returns stale cache within 48h grace period when fetch fails', async () => {
+    writeFreshCache({
+      checkedAt: Date.now() - 6 * 60 * 60 * 1_000, // 6 hours ago (stale but within 48h)
+      currentVersion: '1.5.0-beta.10',
+      latestVersion: '1.5.0-beta.10',
+      channel: 'beta',
+    });
+    mockFetchThrow(new TypeError('Failed to fetch'));
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(result.fromCache, true);
+  });
+
+  it('skips silently when PROVAR_NO_UPDATE_CHECK is set (no network)', async () => {
+    process.env['PROVAR_NO_UPDATE_CHECK'] = '1';
+    let fetchCalled = false;
+    globalThis.fetch = (): Promise<Response> => {
+      fetchCalled = true;
+      return Promise.resolve({} as Response);
+    };
+    const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
+    assert.equal(fetchCalled, false);
+    assert.equal(result.updateAvailable, false);
+    assert.equal(result.fromCache, false);
+  });
+});

--- a/test/unit/mcp/updateChecker.test.ts
+++ b/test/unit/mcp/updateChecker.test.ts
@@ -167,11 +167,14 @@ describe('checkForUpdate', () => {
   });
 
   it('returns fromCache=true for fresh cache (<4h)', async () => {
+    // Use the actual running version so the channel + currentVersion guard passes
+    const { currentVersion } = await checkForUpdate({ noUpdateCheck: true, autoUpdate: false });
+    const channel = deriveChannel(currentVersion);
     writeFreshCache({
       checkedAt: Date.now() - 30 * 60 * 1_000, // 30 min ago
-      currentVersion: '1.5.0-beta.10',
-      latestVersion: '1.5.0-beta.10',
-      channel: 'beta',
+      currentVersion,
+      latestVersion: currentVersion,
+      channel,
     });
     let fetchCalled = false;
     globalThis.fetch = (): Promise<Response> => {


### PR DESCRIPTION
RCA: Users on stale plugin versions get silent failures or missing tools with no indication an update exists.
Fix: Add checkForUpdate() called at startup before server.connect(); writes stderr notification and optionally auto-installs via --auto-update flag.