### PR TITLE
feat(ci): add Quality Orchestrator action for PR risk analysis

### DIFF
--- a/.github/workflows/CI_Execution.yml
+++ b/.github/workflows/CI_Execution.yml
@@ -27,12 +27,14 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: mrdailey99/QualityOrchestrator@v1
+        with:
+          persist-credentials: false
+      - uses: mrdailey99/QualityOrchestrator@v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-dir: 'test'
           framework: 'auto'
-          generate-stubs: 'true'
+          generate-stubs: 'false'
           fail-on-high: 'false'
 
   provardx-ci-execution:

--- a/.github/workflows/CI_Execution.yml
+++ b/.github/workflows/CI_Execution.yml
@@ -19,6 +19,22 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  quality-analysis:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mrdailey99/QualityOrchestrator@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          test-dir: 'test'
+          framework: 'auto'
+          generate-stubs: 'true'
+          fail-on-high: 'false'
+
   provardx-ci-execution:
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Adds a parallel `quality-analysis` job to `CI_Execution.yml` that runs on every PR targeting `develop`. The job uses `mrdailey99/QualityOrchestrator@v1.0.0` to:

- Map changed files to existing test coverage
- Score overall risk (high / med / low)
- Post a risk-tier comment on the PR

The job runs in parallel with `provardx-ci-execution` and never blocks merges (`fail-on-high: false`).

## Pre-Landing Review

Adversarial review found 4 issues — all fixed before merge:

- **[AUTO-FIXED]** `@v1` tag does not exist on action repo → pinned to `@v1.0.0`
- **[AUTO-FIXED]** Stub writer had path-traversal risk via unvalidated filenames → `generate-stubs: false`
- **[AUTO-FIXED]** `persist-credentials` not disabled before third-party Python process runs → added `persist-credentials: false`
- **[INFORMATIONAL]** `fail-on-high: false` means no merge blocking — intentional; can be flipped to `true` when confidence in the action is established

## Test Coverage

Workflow YAML only — no application code paths changed.

## Test plan
- [ ] Open a PR targeting `develop` and verify the `quality-analysis` job appears and posts a risk comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)