### PR TITLE
chore(ci): upgrade all GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/CIRelease_Tagging.yml
+++ b/.github/workflows/CIRelease_Tagging.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Install Dependencies

--- a/.github/workflows/CI_Execution.yml
+++ b/.github/workflows/CI_Execution.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: mrdailey99/QualityOrchestrator@v1.0.0
@@ -44,12 +44,12 @@ jobs:
         nodeversion: [20]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.nodeversion }}
       - name: 'Cache node_modules'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ matrix.os == 'windows-latest' && 'C:\\Users\\runneradmin\\AppData\\Roaming\\npm-cache' || '~/.npm' }}
           key: ${{ runner.os }}-node-v${{ matrix.nodeversion }}-${{ hashFiles('**/package.json') }}
@@ -80,7 +80,7 @@ jobs:
 
       - name: Check for target branch in Utils repo
         id: check_branch
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
           script: |
             const branch = process.env.BRANCH_NAME;
@@ -98,7 +98,7 @@ jobs:
             return branchExists;
 
       - name: Check out Utils repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ProvarTesting/provardx-plugins-utils
           path: utils
@@ -125,7 +125,7 @@ jobs:
           PROVAR_DEV_WHITELIST_KEYS: ${{ secrets.PROVAR_DEV_WHITELIST_KEYS }}
         run: node scripts/mcp-smoke.cjs
       - name: Check out Regression repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ProvarTesting/provar-manager-regression
           path: ProvarRegression
@@ -145,7 +145,7 @@ jobs:
           yarn run test:nuts
       - name: Archive NUTS results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuts-report-${{ matrix.os }}
           path: mochawesome-report

--- a/.github/workflows/DeployManual.yml
+++ b/.github/workflows/DeployManual.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/UnpublishManual.yml
+++ b/.github/workflows/UnpublishManual.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

Addresses the deprecation warnings visible on all CI runs — Node.js 20 actions are deprecated and GitHub will force-switch to Node.js 24 on **June 2nd, 2026**.

Upgrades applied across all 4 workflow files (`CI_Execution.yml`, `CIRelease_Tagging.yml`, `DeployManual.yml`, `UnpublishManual.yml`):

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/cache` | v4 | v5 |
| `actions/github-script` | v6 | v9 |
| `actions/upload-artifact` | v4 | v7 |

## Test plan
- [ ] CI passes on this PR without Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)