### PR TITLE
PDX-0: chore(ci): update QualityOrchestrator to floating v1 tag

### DIFF
--- a/.github/workflows/CI_Execution.yml
+++ b/.github/workflows/CI_Execution.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: mrdailey99/QualityOrchestrator@v1.0.0
+      - uses: mrdailey99/QualityOrchestrator@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-dir: 'test'


### PR DESCRIPTION
## Summary
- Updates \`CI_Execution.yml\` to reference \`mrdailey99/QualityOrchestrator@v1\` instead of the pinned \`@v1.0.0\`
- Created a floating \`v1\` tag on the [QualityOrchestrator](https://github.com/mrdailey99/QualityOrchestrator) repo (currently pointing to \`v1.0.2\`) — this tag will be force-updated with each future release, following the same pattern as \`actions/checkout@v4\`
- The workflow will now automatically use the latest \`v1.x\` release without any further changes to this repo

## How "always latest" works going forward
When a new version of QualityOrchestrator is released (e.g. \`v1.1.0\`):
1. Tag the new release in QualityOrchestrator as usual (\`v1.1.0\`)
2. Force-update the floating tag: \`git tag -f v1 && git push origin v1 --force\`
3. provardx-cli CI picks it up automatically on next run — no PR needed here

## Test plan
- [x] yarn compile passes
- [x] yarn test:only passes (pre-push hook)
- [x] yarn lint passes