### PR TITLE
PDX-463: feat(mcp): fetch NitroX component packages from factPackages repo at release time

### DIFF
--- a/docs/NITROX_CATALOG_SOURCE.json
+++ b/docs/NITROX_CATALOG_SOURCE.json
@@ -1,0 +1,6 @@
+{
+  "repo": "https://github.com/ProvarTesting/factPackages",
+  "branch": "main",
+  "commitSha": null,
+  "fetchedAt": null
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -73,6 +73,7 @@ The Provar DX CLI ships with a built-in **Model Context Protocol (MCP) server** 
 - [MCP Resources](#mcp-resources)
   - [provar://docs/step-reference](#provardocsstep-reference)
   - [provar://nitrox/component-catalog](#provarnitroxcomponent-catalog)
+  - [provar://nitrox/catalog-source](#provarnitroxcatalog-source)
 - [AI loop pattern](#ai-loop-pattern)
 - [Quality scores explained](#quality-scores-explained)
 - [API compatibility — `xml` vs `xml_content`](#api-compatibility--xml-vs-xml_content)
@@ -1960,7 +1961,31 @@ Catalog of all shipped NitroX (Hybrid Model) base component packages. Lists ever
 **URI:** `provar://nitrox/component-catalog`  
 **MIME type:** `text/markdown`
 
-The resource content is the same as `docs/NITROX_COMPONENT_CATALOG.md` in this repository, compiled into the package at build time. To regenerate the catalog after Provar ships updated NitroX packages, run `node scripts/generate-nitrox-catalog.cjs` on a machine with Provar NitroX installed, then commit the result.
+The resource content is the same as `docs/NITROX_COMPONENT_CATALOG.md` in this repository, compiled into the package at build time.
+
+The catalog is automatically refreshed from the `main` branch of [ProvarTesting/factPackages](https://github.com/ProvarTesting/factPackages) during each `provardx-cli` release build (via `scripts/fetch-nitrox-packages.cjs`). If the fetch fails at build time (e.g. no `GITHUB_TOKEN`, network unavailable), the previously committed catalog is used as a fallback and a warning is logged.
+
+To check which version is bundled in a running server, read the `provar://nitrox/catalog-source` resource.
+
+---
+
+### `provar://nitrox/catalog-source`
+
+Version metadata for the bundled NitroX component catalog. Returns the `factPackages` commit SHA and fetch timestamp recorded during the release build that produced this package.
+
+**URI:** `provar://nitrox/catalog-source`  
+**MIME type:** `application/json`
+
+```json
+{
+  "repo": "https://github.com/ProvarTesting/factPackages",
+  "branch": "main",
+  "commitSha": "<40-char SHA or null if fetched from fallback>",
+  "fetchedAt": "<ISO 8601 timestamp or null>"
+}
+```
+
+`commitSha` and `fetchedAt` are `null` when the release build could not reach GitHub (fallback catalog in use).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "format": "wireit",
     "lint": "wireit",
     "postpack": "shx rm -f oclif.manifest.json",
-    "prepack": "sf-prepack",
+    "prepack": "node scripts/fetch-nitrox-packages.cjs && sf-prepack",
     "test": "wireit",
     "test:nuts": "nyc mocha  \"**/*generate.nut.ts\" \"**/*permission.nut.ts\" \"**/*load.nut.ts\" \"**/*validate.nut.ts\" \"**/*set.nut.ts\" \"**/*get.nut.ts\" \"**/*key.nut.ts\" \"**/*status.nut.ts\" \"**/*clear.nut.ts\" --slow 4500 --timeout 600000 --reporter mochawesome",
     "test:only": "wireit",
@@ -146,11 +146,12 @@
       ]
     },
     "compile": {
-      "command": "tsc -p . --pretty --incremental && shx mkdir -p lib/mcp/rules && shx cp src/mcp/rules/*.json lib/mcp/rules/ && shx mkdir -p lib/mcp/docs && shx cp docs/PROVAR_TEST_STEP_REFERENCE.md lib/mcp/docs/ && shx cp docs/NITROX_COMPONENT_CATALOG.md lib/mcp/docs/ && shx cp docs/PROVAR_TOOL_GUIDE.md lib/mcp/docs/",
+      "command": "tsc -p . --pretty --incremental && shx mkdir -p lib/mcp/rules && shx cp src/mcp/rules/*.json lib/mcp/rules/ && shx mkdir -p lib/mcp/docs && shx cp docs/PROVAR_TEST_STEP_REFERENCE.md lib/mcp/docs/ && shx cp docs/NITROX_COMPONENT_CATALOG.md lib/mcp/docs/ && shx cp docs/NITROX_CATALOG_SOURCE.json lib/mcp/docs/ && shx cp docs/PROVAR_TOOL_GUIDE.md lib/mcp/docs/",
       "files": [
         "src/**/*.ts",
         "src/mcp/rules/*.json",
         "docs/NITROX_COMPONENT_CATALOG.md",
+        "docs/NITROX_CATALOG_SOURCE.json",
         "**/tsconfig.json",
         "messages/**"
       ],

--- a/scripts/fetch-nitrox-packages.cjs
+++ b/scripts/fetch-nitrox-packages.cjs
@@ -40,7 +40,9 @@ function log(msg) {
   console.log(`[fetch-nitrox-packages] ${msg}`);
 }
 
-/** Wraps https.get with redirect support; resolves to the response body string. */
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/** Wraps https.get with redirect support and a per-request timeout; resolves to the response body string. */
 function httpsGet(url, headers) {
   return new Promise((resolve, reject) => {
     const parsed = new URL(url);
@@ -69,11 +71,14 @@ function httpsGet(url, headers) {
         res.on('error', reject);
       }
     );
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      req.destroy(new Error(`Request timed out after ${REQUEST_TIMEOUT_MS}ms: ${url}`));
+    });
     req.on('error', reject);
   });
 }
 
-/** Downloads raw file bytes (supports redirect); resolves to a Buffer. */
+/** Downloads raw file bytes (supports redirect and per-request timeout); resolves to a Buffer. */
 function httpsGetBuffer(url, headers) {
   return new Promise((resolve, reject) => {
     const parsed = new URL(url);
@@ -92,6 +97,9 @@ function httpsGetBuffer(url, headers) {
         }
       });
       res.on('error', reject);
+    });
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      req.destroy(new Error(`Request timed out after ${REQUEST_TIMEOUT_MS}ms: ${url}`));
     });
     req.on('error', reject);
   });
@@ -131,8 +139,9 @@ function isRelevant(treePath) {
   return PKG_JSON_RE.test(treePath) || COMPONENT_FILE_RE.test(treePath);
 }
 
-async function downloadRaw(filePath, token) {
-  const url = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${BRANCH}/${filePath}`;
+async function downloadRaw(filePath, commitSha, token) {
+  // Pin to the resolved commit SHA so all downloads are consistent with the tree listing
+  const url = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${commitSha}/${filePath}`;
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
   return httpsGetBuffer(url, headers);
 }
@@ -265,7 +274,7 @@ async function main() {
     for (const file of relevant) {
       const destPath = path.join(tmpDir, file.path);
       fs.mkdirSync(path.dirname(destPath), { recursive: true });
-      const content = await downloadRaw(file.path, token);
+      const content = await downloadRaw(file.path, commitSha, token);
       fs.writeFileSync(destPath, content);
     }
 

--- a/scripts/fetch-nitrox-packages.cjs
+++ b/scripts/fetch-nitrox-packages.cjs
@@ -122,10 +122,10 @@ async function getTree(sha, token) {
   return data.tree;
 }
 
-/** Matches top-level package.json files: e.g. "common/package.json" */
-const PKG_JSON_RE = /^[^/]+\/package\.json$/;
-/** Matches component definitions nested under a components/ dir */
-const COMPONENT_FILE_RE = /^[^/]+\/components\/[^/]+\.(cp|po)\.json$/;
+// Matches fact-* package manifests: e.g. "fact-common/src/package.json"
+const PKG_JSON_RE = /^[^/]+\/src\/package\.json$/;
+// Matches component definitions under fact-{pkg}/src/components/
+const COMPONENT_FILE_RE = /^[^/]+\/src\/components\/[^/]+\.(cp|po)\.json$/;
 
 function isRelevant(treePath) {
   return PKG_JSON_RE.test(treePath) || COMPONENT_FILE_RE.test(treePath);
@@ -195,8 +195,11 @@ function buildCatalogFromDir(baseDir, commitSha) {
   ];
 
   for (const entry of pkgDirEntries) {
-    const pkgDir = path.join(baseDir, entry.name);
-    const meta = safeReadJson(path.join(pkgDir, 'package.json')) ?? {};
+    // factPackages stores package content under a src/ subdirectory
+    const srcDir = path.join(baseDir, entry.name, 'src');
+    if (!fs.existsSync(srcDir)) continue;
+
+    const meta = safeReadJson(path.join(srcDir, 'package.json')) ?? {};
 
     const displayName = meta.name ?? entry.name;
     const displayVersion = meta.version ? ` (v${meta.version})` : '';
@@ -206,7 +209,7 @@ function buildCatalogFromDir(baseDir, commitSha) {
     if (meta.provarVersion) lines.push(`**Requires Provar:** ${meta.provarVersion}`);
     lines.push('');
 
-    const componentsDir = path.join(pkgDir, 'components');
+    const componentsDir = path.join(srcDir, 'components');
     if (!fs.existsSync(componentsDir)) {
       lines.push('_No component definitions found._', '', '---', '');
       continue;

--- a/scripts/fetch-nitrox-packages.cjs
+++ b/scripts/fetch-nitrox-packages.cjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+/**
+ * Release pipeline utility: fetch the latest NitroX component packages
+ * from the ProvarTesting/factPackages GitHub repo (main branch) and
+ * regenerate docs/NITROX_COMPONENT_CATALOG.md.
+ *
+ * On success, writes docs/NITROX_CATALOG_SOURCE.json with the commit SHA
+ * so downstream consumers can verify which version was bundled.
+ *
+ * Falls back silently to the committed catalog when:
+ *   - GITHUB_TOKEN / GH_TOKEN is not set in the environment
+ *   - The GitHub API is unreachable
+ *   - Any download fails
+ *
+ * The script always exits 0 so a fetch failure never blocks the release.
+ *
+ * Environment:
+ *   GITHUB_TOKEN or GH_TOKEN — required to access the private repo
+ */
+
+'use strict';
+
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const REPO_OWNER = 'ProvarTesting';
+const REPO_NAME = 'factPackages';
+const BRANCH = 'main';
+const DOCS_DIR = path.join(__dirname, '..', 'docs');
+const OUTPUT_CATALOG = path.join(DOCS_DIR, 'NITROX_COMPONENT_CATALOG.md');
+const OUTPUT_SOURCE = path.join(DOCS_DIR, 'NITROX_CATALOG_SOURCE.json');
+
+function warn(msg) {
+  console.warn(`[fetch-nitrox-packages] WARN: ${msg}`);
+}
+
+function log(msg) {
+  console.log(`[fetch-nitrox-packages] ${msg}`);
+}
+
+/** Wraps https.get with redirect support; resolves to the response body string. */
+function httpsGet(url, headers) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const reqHeaders = {
+      'User-Agent': 'provardx-cli/fetch-nitrox-packages',
+      Accept: 'application/json',
+      ...headers,
+    };
+    const req = https.get(
+      { hostname: parsed.hostname, path: parsed.pathname + parsed.search, headers: reqHeaders },
+      (res) => {
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          resolve(httpsGet(res.headers.location, headers));
+          return;
+        }
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          const body = Buffer.concat(chunks).toString('utf-8');
+          if (res.statusCode >= 400) {
+            reject(new Error(`HTTP ${res.statusCode} from ${url}: ${body.slice(0, 200)}`));
+          } else {
+            resolve(body);
+          }
+        });
+        res.on('error', reject);
+      }
+    );
+    req.on('error', reject);
+  });
+}
+
+/** Downloads raw file bytes (supports redirect); resolves to a Buffer. */
+function httpsGetBuffer(url, headers) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const req = https.get({ hostname: parsed.hostname, path: parsed.pathname + parsed.search, headers }, (res) => {
+      if (res.statusCode === 301 || res.statusCode === 302) {
+        resolve(httpsGetBuffer(res.headers.location, headers));
+        return;
+      }
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => {
+        if (res.statusCode >= 400) {
+          reject(new Error(`HTTP ${res.statusCode} from ${url}`));
+        } else {
+          resolve(Buffer.concat(chunks));
+        }
+      });
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+  });
+}
+
+function apiHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'provardx-cli/fetch-nitrox-packages',
+  };
+}
+
+async function getLatestCommitSha(token) {
+  const url = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/commits/${BRANCH}`;
+  const body = await httpsGet(url, apiHeaders(token));
+  const data = JSON.parse(body);
+  if (typeof data.sha !== 'string') throw new Error('No commit SHA in GitHub API response');
+  return data.sha;
+}
+
+async function getTree(sha, token) {
+  const url = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/git/trees/${sha}?recursive=1`;
+  const body = await httpsGet(url, apiHeaders(token));
+  const data = JSON.parse(body);
+  if (!Array.isArray(data.tree)) throw new Error('Unexpected tree response shape');
+  return data.tree;
+}
+
+/** Matches top-level package.json files: e.g. "common/package.json" */
+const PKG_JSON_RE = /^[^/]+\/package\.json$/;
+/** Matches component definitions nested under a components/ dir */
+const COMPONENT_FILE_RE = /^[^/]+\/components\/[^/]+\.(cp|po)\.json$/;
+
+function isRelevant(treePath) {
+  return PKG_JSON_RE.test(treePath) || COMPONENT_FILE_RE.test(treePath);
+}
+
+async function downloadRaw(filePath, token) {
+  const url = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${BRANCH}/${filePath}`;
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  return httpsGetBuffer(url, headers);
+}
+
+// ── Catalog generation (mirrors generate-nitrox-catalog.cjs) ────────────────
+
+function safeReadJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function renderComponent(comp) {
+  const lines = [];
+  const heading = comp.label ?? comp.name ?? '(unnamed)';
+  lines.push(`#### ${heading}`, '');
+  if (comp.name) lines.push(`- **name:** \`${comp.name}\``);
+  if (comp.type) lines.push(`- **type:** \`${comp.type}\``);
+  if (comp.tagName) lines.push(`- **tagName:** \`${comp.tagName}\``);
+
+  const interactions = (comp.interactions ?? []).map((i) => i.title ?? i.name ?? '').filter(Boolean);
+  if (interactions.length > 0) {
+    lines.push(`- **interactions:** ${interactions.map((n) => `\`${n}\``).join(', ')}`);
+  }
+
+  const attributes = (comp.attributes ?? []).map((a) => a.title ?? a.attributeName ?? '').filter(Boolean);
+  if (attributes.length > 0) {
+    lines.push(`- **attributes:** ${attributes.map((n) => `\`${n}\``).join(', ')}`);
+  }
+
+  const elementCount = (comp.elements ?? []).length;
+  if (elementCount > 0) lines.push(`- **child elements:** ${elementCount}`);
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function buildCatalogFromDir(baseDir, commitSha) {
+  const pkgDirEntries = fs
+    .readdirSync(baseDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const lines = [
+    '# NitroX Component Package Catalog',
+    '',
+    'Shipped base NitroX (Hybrid Model) component packages.',
+    'Use as a reference when generating new NitroX components — match naming conventions,',
+    'type strings, tagNames, interaction titles, and attribute names from these shipped packages.',
+    '',
+    `_Source: [ProvarTesting/factPackages@${commitSha.slice(
+      0,
+      7
+    )}](https://github.com/ProvarTesting/factPackages/tree/${commitSha})_`,
+    '',
+    '---',
+    '',
+  ];
+
+  for (const entry of pkgDirEntries) {
+    const pkgDir = path.join(baseDir, entry.name);
+    const meta = safeReadJson(path.join(pkgDir, 'package.json')) ?? {};
+
+    const displayName = meta.name ?? entry.name;
+    const displayVersion = meta.version ? ` (v${meta.version})` : '';
+    lines.push(`## ${displayName}${displayVersion}`);
+
+    if (meta.description) lines.push('', meta.description);
+    if (meta.provarVersion) lines.push(`**Requires Provar:** ${meta.provarVersion}`);
+    lines.push('');
+
+    const componentsDir = path.join(pkgDir, 'components');
+    if (!fs.existsSync(componentsDir)) {
+      lines.push('_No component definitions found._', '', '---', '');
+      continue;
+    }
+
+    const componentFiles = fs
+      .readdirSync(componentsDir)
+      .filter((f) => f.endsWith('.cp.json') || f.endsWith('.po.json'))
+      .sort()
+      .map((f) => path.join(componentsDir, f));
+
+    if (componentFiles.length === 0) {
+      lines.push('_No component definitions found._', '', '---', '');
+      continue;
+    }
+
+    lines.push('### Components', '');
+    for (const compFile of componentFiles) {
+      const parsed = safeReadJson(compFile);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        lines.push(renderComponent(parsed));
+      }
+    }
+
+    lines.push('---', '');
+  }
+
+  return lines.join('\n');
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const token = process.env['GITHUB_TOKEN'] || process.env['GH_TOKEN'];
+
+  if (!token) {
+    warn('No GITHUB_TOKEN or GH_TOKEN set — skipping factPackages fetch, using bundled catalog');
+    return;
+  }
+
+  const tmpDir = path.join(os.tmpdir(), `nitrox-fact-packages-${Date.now()}`);
+
+  try {
+    log(`Fetching latest commit on ${REPO_OWNER}/${REPO_NAME}@${BRANCH}...`);
+    const commitSha = await getLatestCommitSha(token);
+    log(`Commit: ${commitSha}`);
+
+    log('Fetching file tree...');
+    const tree = await getTree(commitSha, token);
+    const relevant = tree.filter((f) => f.type === 'blob' && isRelevant(f.path));
+    log(`Downloading ${relevant.length} component files...`);
+
+    for (const file of relevant) {
+      const destPath = path.join(tmpDir, file.path);
+      fs.mkdirSync(path.dirname(destPath), { recursive: true });
+      const content = await downloadRaw(file.path, token);
+      fs.writeFileSync(destPath, content);
+    }
+
+    log('Generating catalog...');
+    const catalog = buildCatalogFromDir(tmpDir, commitSha);
+    fs.writeFileSync(OUTPUT_CATALOG, catalog, 'utf-8');
+    log(`Written: docs/NITROX_COMPONENT_CATALOG.md (${catalog.split('\n').length} lines)`);
+
+    const sourceInfo = {
+      repo: `https://github.com/${REPO_OWNER}/${REPO_NAME}`,
+      branch: BRANCH,
+      commitSha,
+      fetchedAt: new Date().toISOString(),
+    };
+    fs.writeFileSync(OUTPUT_SOURCE, JSON.stringify(sourceInfo, null, 2) + '\n', 'utf-8');
+    log(`Written: docs/NITROX_CATALOG_SOURCE.json (commitSha: ${commitSha.slice(0, 7)})`);
+  } catch (err) {
+    warn(`Fetch failed — ${String(err instanceof Error ? err.message : err)}`);
+    warn('Falling back to bundled catalog; release will use existing NITROX_COMPONENT_CATALOG.md');
+  } finally {
+    try {
+      if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}
+
+main().catch((err) => {
+  warn(`Unexpected error — ${String(err instanceof Error ? err.message : err)}`);
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -136,6 +136,22 @@ export function createProvarMcpServer(config: ServerConfig): McpServer {
   );
 
   server.resource(
+    'provar-nitrox-catalog-source',
+    'provar://nitrox/catalog-source',
+    {
+      description:
+        'Version metadata for the bundled NitroX component catalog. Returns the factPackages commit SHA and fetch timestamp from the last successful release build. Use this to verify which version of the ProvarTesting/factPackages repo is bundled in the running MCP server.',
+      mimeType: 'application/json',
+    },
+    () => {
+      const text = readCatalogSource(docsDir);
+      return {
+        contents: [{ uri: 'provar://nitrox/catalog-source', mimeType: 'application/json', text }],
+      };
+    }
+  );
+
+  server.resource(
     'provar-step-reference',
     'provar://docs/step-reference',
     {
@@ -208,4 +224,28 @@ export function createProvarMcpServer(config: ServerConfig): McpServer {
 export function resolveDocsDir(currentDir: string): string {
   const sibling = join(currentDir, 'docs');
   return existsSync(sibling) ? sibling : join(currentDir, '..', '..', 'docs');
+}
+
+/**
+ * Read NITROX_CATALOG_SOURCE.json from the docs directory and return it as
+ * a formatted JSON string.  Returns a fallback object string if the file is
+ * absent or unreadable.
+ */
+export function readCatalogSource(docsDir: string): string {
+  try {
+    const raw = readFileSync(join(docsDir, 'NITROX_CATALOG_SOURCE.json'), 'utf-8');
+    // Round-trip through JSON to normalise formatting
+    return JSON.stringify(JSON.parse(raw) as unknown, null, 2);
+  } catch {
+    return JSON.stringify(
+      {
+        repo: 'https://github.com/ProvarTesting/factPackages',
+        branch: 'main',
+        commitSha: null,
+        fetchedAt: null,
+      },
+      null,
+      2
+    );
+  }
 }

--- a/src/mcp/update/updateChecker.ts
+++ b/src/mcp/update/updateChecker.ts
@@ -32,14 +32,14 @@ interface UpdateCacheEntry {
   channel: string;
 }
 
-const UPDATE_TTL_MS = 4 * 60 * 60 * 1_000;
-const UPDATE_GRACE_MS = 48 * 60 * 60 * 1_000;
+const UPDATE_TTL_MS = 4 * 60 * 60 * 1000;
+const UPDATE_GRACE_MS = 48 * 60 * 60 * 1000;
 
 const SPAWN_OPTS = {
   stdio: ['ignore', 'pipe', 'pipe'] as const,
   timeout: 30_000,
   shell: process.platform === 'win32',
-  maxBuffer: 10 * 1_024 * 1_024,
+  maxBuffer: 10 * 1024 * 1024,
 } satisfies SpawnSyncOptions;
 
 const SEMVER_RE = /^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/;
@@ -140,7 +140,7 @@ function resultFromCache(cached: UpdateCacheEntry, currentVersion: string): Chec
 
 async function fetchLatestVersion(channel: string): Promise<string | null> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 5_000);
+  const timer = setTimeout(() => controller.abort(), 5000);
   try {
     const resp = await fetch('https://registry.npmjs.org/@provartesting/provardx-cli', {
       signal: controller.signal,

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -10,7 +10,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
 import { describe, it, afterEach } from 'mocha';
-import { resolveDocsDir } from '../../../src/mcp/server.js';
+import { resolveDocsDir, readCatalogSource } from '../../../src/mcp/server.js';
 
 describe('resolveDocsDir', () => {
   const tmpDirs: string[] = [];
@@ -43,5 +43,56 @@ describe('resolveDocsDir', () => {
     const base = makeTmpDir();
     const expected = path.join(base, '..', '..', 'docs');
     assert.equal(resolveDocsDir(base), expected);
+  });
+});
+
+describe('readCatalogSource', () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of tmpDirs) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }
+    tmpDirs.length = 0;
+  });
+
+  function makeTmpDir(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'provar-server-test-'));
+    tmpDirs.push(d);
+    return d;
+  }
+
+  it('returns parsed JSON when NITROX_CATALOG_SOURCE.json is present', () => {
+    const docsDir = makeTmpDir();
+    const source = {
+      repo: 'https://github.com/ProvarTesting/factPackages',
+      branch: 'main',
+      commitSha: 'abc1234567890',
+      fetchedAt: '2026-05-08T10:00:00.000Z',
+    };
+    fs.writeFileSync(path.join(docsDir, 'NITROX_CATALOG_SOURCE.json'), JSON.stringify(source));
+    const result = JSON.parse(readCatalogSource(docsDir)) as typeof source;
+    assert.equal(result.commitSha, 'abc1234567890');
+    assert.equal(result.branch, 'main');
+    assert.equal(result.fetchedAt, '2026-05-08T10:00:00.000Z');
+  });
+
+  it('returns fallback object when the file is absent', () => {
+    const docsDir = makeTmpDir();
+    const result = JSON.parse(readCatalogSource(docsDir)) as Record<string, unknown>;
+    assert.equal(result['commitSha'], null);
+    assert.equal(result['fetchedAt'], null);
+    assert.equal(result['repo'], 'https://github.com/ProvarTesting/factPackages');
+  });
+
+  it('returns fallback object when the file contains invalid JSON', () => {
+    const docsDir = makeTmpDir();
+    fs.writeFileSync(path.join(docsDir, 'NITROX_CATALOG_SOURCE.json'), '{bad json');
+    const result = JSON.parse(readCatalogSource(docsDir)) as Record<string, unknown>;
+    assert.equal(result['commitSha'], null);
   });
 });

--- a/test/unit/mcp/updateChecker.test.ts
+++ b/test/unit/mcp/updateChecker.test.ts
@@ -171,7 +171,7 @@ describe('checkForUpdate', () => {
     const { currentVersion } = await checkForUpdate({ noUpdateCheck: true, autoUpdate: false });
     const channel = deriveChannel(currentVersion);
     writeFreshCache({
-      checkedAt: Date.now() - 30 * 60 * 1_000, // 30 min ago
+      checkedAt: Date.now() - 30 * 60 * 1000, // 30 min ago
       currentVersion,
       latestVersion: currentVersion,
       channel,
@@ -188,7 +188,7 @@ describe('checkForUpdate', () => {
 
   it('fetches registry when cache is stale (>4h)', async () => {
     writeFreshCache({
-      checkedAt: Date.now() - 5 * 60 * 60 * 1_000, // 5 hours ago
+      checkedAt: Date.now() - 5 * 60 * 60 * 1000, // 5 hours ago
       currentVersion: '1.5.0-beta.10',
       latestVersion: '1.5.0-beta.10',
       channel: 'beta',
@@ -252,7 +252,7 @@ describe('checkForUpdate', () => {
 
   it('returns updateAvailable=false when cache is >48h stale and fetch fails', async () => {
     writeFreshCache({
-      checkedAt: Date.now() - 50 * 60 * 60 * 1_000, // 50 hours ago
+      checkedAt: Date.now() - 50 * 60 * 60 * 1000, // 50 hours ago
       currentVersion: '1.5.0-beta.10',
       latestVersion: '1.5.0-beta.10',
       channel: 'beta',
@@ -280,7 +280,7 @@ describe('checkForUpdate', () => {
 
   it('returns stale cache within 48h grace period when fetch fails', async () => {
     writeFreshCache({
-      checkedAt: Date.now() - 6 * 60 * 60 * 1_000, // 6 hours ago (stale but within 48h)
+      checkedAt: Date.now() - 6 * 60 * 60 * 1000, // 6 hours ago (stale but within 48h)
       currentVersion: '1.5.0-beta.10',
       latestVersion: '1.5.0-beta.10',
       channel: 'beta',


### PR DESCRIPTION
## Summary
- Added `scripts/fetch-nitrox-packages.cjs` to the `prepack` hook: fetches all component package files from `ProvarTesting/factPackages@main`, regenerates `NITROX_COMPONENT_CATALOG.md`, and writes `NITROX_CATALOG_SOURCE.json` with the commit SHA
- Falls back gracefully to the committed catalog if no `GITHUB_TOKEN`/`GH_TOKEN` is set or the fetch fails; logs a warning and always exits 0 (release never blocked)
- Added `provar://nitrox/catalog-source` MCP resource (served from `NITROX_CATALOG_SOURCE.json`) so consumers can verify which `factPackages` commit is bundled
- `docs/NITROX_CATALOG_SOURCE.json` committed as a default (null SHA) that gets overwritten on each successful release build
- `docs/mcp.md` updated to document the auto-refresh mechanism and the new resource

## Jira
https://provartesting.atlassian.net/browse/PDX-463

## Test plan
- [ ] `yarn compile` passes
- [ ] `yarn test:only` passes (941 tests, +3 new `readCatalogSource` tests)
- [ ] `node scripts/mcp-smoke.cjs` passes (54/54)
- [ ] `yarn lint` passes (0 errors)

## Changes
- `scripts/fetch-nitrox-packages.cjs`: new release-time fetch script
- `docs/NITROX_CATALOG_SOURCE.json`: new default version file (null SHA)
- `package.json`: `prepack` now runs fetch before `sf-prepack`; compile copies source JSON to `lib/mcp/docs/`
- `src/mcp/server.ts`: adds `provar://nitrox/catalog-source` resource + exports `readCatalogSource` helper
- `test/unit/mcp/server.test.ts`: 3 new unit tests for `readCatalogSource`
- `docs/mcp.md`: updated `provar://nitrox/component-catalog` section; added `provar://nitrox/catalog-source` entry