### PR TITLE
PDX-464: fetch NitroX schemas from internal source at build time

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1583,7 +1583,7 @@ The five `provar_nitrox_*` tools let an AI agent discover existing NitroX page o
 
 > **Note:** NitroX page objects are read and written directly from disk using the standard file-system path policy (`--allowed-paths`). No `sf` subprocess is involved.
 
-> **Schema sourcing:** The `FactComponent.schema` and `FactPackage.schema` JSON schemas used by `provar_nitrox_validate` and `provar_nitrox_patch` are fetched from an internal Provar source during each `provardx-cli` release build alongside the component catalog. Both schemas are pinned to the same internal revision to avoid version skew. If the fetch fails at build time, the previously committed schemas are used as a fallback. Check `provar://nitrox/catalog-source` to see whether the schemas in a running server were successfully refreshed (`schemasUpdated: true`).
+> **Schema sourcing:** The `FactComponent.schema` and `FactPackage.schema` JSON schemas bundled in this package are used by editors and IDE tooling (e.g., VS Code JSON language server, SchemaStore) to provide IntelliSense when authoring `.po.json` files. They are fetched from an internal Provar source during each `provardx-cli` release build alongside the component catalog, so the bundled copies always reflect the latest NitroX specification. Both schemas are pinned to the same internal revision to avoid version skew. If the fetch fails at build time, the previously committed schemas are used as a fallback. Check `provar://nitrox/catalog-source` to see whether the schemas in a running server were successfully refreshed (`schemasUpdated: true`).
 
 ---
 
@@ -1980,7 +1980,6 @@ Version metadata for the bundled NitroX component catalog and JSON schemas. Retu
 
 ```json
 {
-  "repo": "<internal source URL>",
   "branch": "main",
   "commitSha": "<40-char SHA or null if fetched from fallback>",
   "fetchedAt": "<ISO 8601 timestamp or null>",

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1583,6 +1583,8 @@ The five `provar_nitrox_*` tools let an AI agent discover existing NitroX page o
 
 > **Note:** NitroX page objects are read and written directly from disk using the standard file-system path policy (`--allowed-paths`). No `sf` subprocess is involved.
 
+> **Schema sourcing:** The `FactComponent.schema` and `FactPackage.schema` JSON schemas used by `provar_nitrox_validate` and `provar_nitrox_patch` are fetched from an internal Provar source during each `provardx-cli` release build alongside the component catalog. Both schemas are pinned to the same internal revision to avoid version skew. If the fetch fails at build time, the previously committed schemas are used as a fallback. Check `provar://nitrox/catalog-source` to see whether the schemas in a running server were successfully refreshed (`schemasUpdated: true`).
+
 ---
 
 ### `provar_nitrox_discover`
@@ -1963,7 +1965,7 @@ Catalog of all shipped NitroX (Hybrid Model) base component packages. Lists ever
 
 The resource content is the same as `docs/NITROX_COMPONENT_CATALOG.md` in this repository, compiled into the package at build time.
 
-The catalog is automatically refreshed from the `main` branch of [ProvarTesting/factPackages](https://github.com/ProvarTesting/factPackages) during each `provardx-cli` release build (via `scripts/fetch-nitrox-packages.cjs`). If the fetch fails at build time (e.g. no `GITHUB_TOKEN`, network unavailable), the previously committed catalog is used as a fallback and a warning is logged.
+The catalog is automatically refreshed from an internal Provar source during each `provardx-cli` release build. If the fetch fails at build time (e.g. network unavailable), the previously committed catalog is used as a fallback and a warning is logged.
 
 To check which version is bundled in a running server, read the `provar://nitrox/catalog-source` resource.
 
@@ -1971,21 +1973,22 @@ To check which version is bundled in a running server, read the `provar://nitrox
 
 ### `provar://nitrox/catalog-source`
 
-Version metadata for the bundled NitroX component catalog. Returns the `factPackages` commit SHA and fetch timestamp recorded during the release build that produced this package.
+Version metadata for the bundled NitroX component catalog and JSON schemas. Returns the internal source commit SHA, fetch timestamp, and schema update status recorded during the release build that produced this package.
 
 **URI:** `provar://nitrox/catalog-source`  
 **MIME type:** `application/json`
 
 ```json
 {
-  "repo": "https://github.com/ProvarTesting/factPackages",
+  "repo": "<internal source URL>",
   "branch": "main",
   "commitSha": "<40-char SHA or null if fetched from fallback>",
-  "fetchedAt": "<ISO 8601 timestamp or null>"
+  "fetchedAt": "<ISO 8601 timestamp or null>",
+  "schemasUpdated": "<true | false | null>"
 }
 ```
 
-`commitSha` and `fetchedAt` are `null` when the release build could not reach GitHub (fallback catalog in use).
+`commitSha` and `fetchedAt` are `null` when the release build could not reach the internal source (fallback catalog in use). `schemasUpdated` is `true` when both `FactComponent.schema` and `FactPackage.schema` were successfully fetched from the same internal revision and bundled into this release; `false` when the schema fetch failed and the previously committed schemas are in use; `null` when the catalog source was not generated (dev build or pre-PDX-464 release).
 
 ---
 

--- a/scripts/fetch-nitrox-packages.cjs
+++ b/scripts/fetch-nitrox-packages.cjs
@@ -341,7 +341,6 @@ async function main() {
     }
 
     const sourceInfo = {
-      repo: `https://github.com/${REPO_OWNER}/${REPO_NAME}`,
       branch: BRANCH,
       commitSha,
       fetchedAt: new Date().toISOString(),

--- a/scripts/fetch-nitrox-packages.cjs
+++ b/scripts/fetch-nitrox-packages.cjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 /**
  * Release pipeline utility: fetch the latest NitroX component packages
- * from the ProvarTesting/factPackages GitHub repo (main branch) and
- * regenerate docs/NITROX_COMPONENT_CATALOG.md.
+ * and JSON schema files from the ProvarTesting/factPackages GitHub repo
+ * (main branch), regenerate docs/NITROX_COMPONENT_CATALOG.md, and update
+ * the bundled FactComponent.schema.json and FactPackage.schema.json.
  *
  * On success, writes docs/NITROX_CATALOG_SOURCE.json with the commit SHA
  * so downstream consumers can verify which version was bundled.
  *
- * Falls back silently to the committed catalog when:
+ * Falls back silently to the committed catalog/schemas when:
  *   - GITHUB_TOKEN / GH_TOKEN is not set in the environment
  *   - The GitHub API is unreachable
  *   - Any download fails
@@ -31,6 +32,17 @@ const BRANCH = 'main';
 const DOCS_DIR = path.join(__dirname, '..', 'docs');
 const OUTPUT_CATALOG = path.join(DOCS_DIR, 'NITROX_COMPONENT_CATALOG.md');
 const OUTPUT_SOURCE = path.join(DOCS_DIR, 'NITROX_CATALOG_SOURCE.json');
+
+// Destination directories for the JSON schema files
+const SCHEMA_RULES_DIR = path.join(__dirname, '..', 'src', 'mcp', 'rules');
+const REPO_ROOT_DIR = path.join(__dirname, '..');
+
+// Paths within the factPackages tree that contain the NitroX JSON schemas.
+// Both files must come from the same commit so there is no version skew.
+const SCHEMA_TREE_PATHS = new Set([
+  'fact-parent/src/resources/FactComponent.schema',
+  'fact-parent/src/resources/FactPackage.schema',
+]);
 
 function warn(msg) {
   console.warn(`[fetch-nitrox-packages] WARN: ${msg}`);
@@ -137,6 +149,40 @@ const COMPONENT_FILE_RE = /^[^/]+\/src\/components\/[^/]+\.(cp|po)\.json$/;
 
 function isRelevant(treePath) {
   return PKG_JSON_RE.test(treePath) || COMPONENT_FILE_RE.test(treePath);
+}
+
+function isSchemaFile(treePath) {
+  return SCHEMA_TREE_PATHS.has(treePath);
+}
+
+/**
+ * Download both NitroX schema files from factPackages at the given commit SHA
+ * and write them to src/mcp/rules/ (with .json extension) and to the repo root
+ * (without extension, for schemastore.org registration).
+ *
+ * Returns true on success.  Warns and returns false if the expected files are
+ * absent from the tree.  Throws on download or write errors so the caller can
+ * catch and fall back.
+ */
+async function fetchAndWriteSchemas(tree, commitSha, token) {
+  const schemaFiles = tree.filter((f) => f.type === 'blob' && isSchemaFile(f.path));
+  if (schemaFiles.length !== SCHEMA_TREE_PATHS.size) {
+    warn(
+      `Expected ${SCHEMA_TREE_PATHS.size} schema files in tree, found ${schemaFiles.length} — skipping schema update`
+    );
+    return false;
+  }
+
+  for (const file of schemaFiles) {
+    const content = await downloadRaw(file.path, commitSha, token);
+    const baseName = path.basename(file.path); // e.g. "FactComponent.schema"
+    // Write to src/mcp/rules/ with .json extension (picked up by the compile step)
+    fs.writeFileSync(path.join(SCHEMA_RULES_DIR, baseName + '.json'), content);
+    // Write to repo root without extension (for schemastore.org registration)
+    fs.writeFileSync(path.join(REPO_ROOT_DIR, baseName), content);
+    log(`Updated schema: ${baseName}.json (commitSha: ${commitSha.slice(0, 7)})`);
+  }
+  return true;
 }
 
 async function downloadRaw(filePath, commitSha, token) {
@@ -283,17 +329,34 @@ async function main() {
     fs.writeFileSync(OUTPUT_CATALOG, catalog, 'utf-8');
     log(`Written: docs/NITROX_COMPONENT_CATALOG.md (${catalog.split('\n').length} lines)`);
 
+    // ── Schema fetch ─────────────────────────────────────────────────────────
+    let schemasUpdated = false;
+    try {
+      schemasUpdated = await fetchAndWriteSchemas(tree, commitSha, token);
+    } catch (schemaErr) {
+      warn(`Schema fetch failed — ${String(schemaErr instanceof Error ? schemaErr.message : schemaErr)}`);
+      warn(
+        'Falling back to bundled schemas; release will use existing FactComponent.schema.json and FactPackage.schema.json'
+      );
+    }
+
     const sourceInfo = {
       repo: `https://github.com/${REPO_OWNER}/${REPO_NAME}`,
       branch: BRANCH,
       commitSha,
       fetchedAt: new Date().toISOString(),
+      schemasUpdated,
     };
     fs.writeFileSync(OUTPUT_SOURCE, JSON.stringify(sourceInfo, null, 2) + '\n', 'utf-8');
-    log(`Written: docs/NITROX_CATALOG_SOURCE.json (commitSha: ${commitSha.slice(0, 7)})`);
+    log(
+      `Written: docs/NITROX_CATALOG_SOURCE.json (commitSha: ${commitSha.slice(
+        0,
+        7
+      )}, schemasUpdated: ${schemasUpdated})`
+    );
   } catch (err) {
     warn(`Fetch failed — ${String(err instanceof Error ? err.message : err)}`);
-    warn('Falling back to bundled catalog; release will use existing NITROX_COMPONENT_CATALOG.md');
+    warn('Falling back to bundled catalog and schemas; release will use existing NITROX_COMPONENT_CATALOG.md');
   } finally {
     try {
       if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -234,12 +234,16 @@ export function resolveDocsDir(currentDir: string): string {
 export function readCatalogSource(docsDir: string): string {
   try {
     const raw = readFileSync(join(docsDir, 'NITROX_CATALOG_SOURCE.json'), 'utf-8');
-    // Round-trip through JSON to normalise formatting
-    return JSON.stringify(JSON.parse(raw) as unknown, null, 2);
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    // Normalise schemasUpdated so older build artifacts (which lack this field)
+    // return a stable shape rather than omitting the key entirely.
+    if (!('schemasUpdated' in parsed)) {
+      parsed['schemasUpdated'] = null;
+    }
+    return JSON.stringify(parsed, null, 2);
   } catch {
     return JSON.stringify(
       {
-        repo: 'https://github.com/ProvarTesting/factPackages',
         branch: 'main',
         commitSha: null,
         fetchedAt: null,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -243,6 +243,7 @@ export function readCatalogSource(docsDir: string): string {
         branch: 'main',
         commitSha: null,
         fetchedAt: null,
+        schemasUpdated: null,
       },
       null,
       2

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -68,23 +68,25 @@ describe('readCatalogSource', () => {
 
   it('returns parsed JSON when NITROX_CATALOG_SOURCE.json is present', () => {
     const docsDir = makeTmpDir();
-    const source = {
-      repo: 'https://github.com/ProvarTesting/factPackages',
-      branch: 'main',
-      commitSha: 'abc1234567890',
-      fetchedAt: '2026-05-08T10:00:00.000Z',
-    };
+    const source = { branch: 'main', commitSha: 'abc1234567890', fetchedAt: '2026-05-08T10:00:00.000Z' };
     fs.writeFileSync(path.join(docsDir, 'NITROX_CATALOG_SOURCE.json'), JSON.stringify(source));
-    const result = JSON.parse(readCatalogSource(docsDir)) as typeof source;
+    const result = JSON.parse(readCatalogSource(docsDir)) as typeof source & { schemasUpdated: unknown };
     assert.equal(result.commitSha, 'abc1234567890');
     assert.equal(result.branch, 'main');
     assert.equal(result.fetchedAt, '2026-05-08T10:00:00.000Z');
   });
 
+  it('normalises missing schemasUpdated to null for files from older builds', () => {
+    const docsDir = makeTmpDir();
+    const source = { branch: 'main', commitSha: 'abc1234567890', fetchedAt: '2026-05-08T10:00:00.000Z' };
+    fs.writeFileSync(path.join(docsDir, 'NITROX_CATALOG_SOURCE.json'), JSON.stringify(source));
+    const result = JSON.parse(readCatalogSource(docsDir)) as Record<string, unknown>;
+    assert.equal(result['schemasUpdated'], null);
+  });
+
   it('passes through schemasUpdated: true when present in the file', () => {
     const docsDir = makeTmpDir();
     const source = {
-      repo: 'https://github.com/ProvarTesting/factPackages',
       branch: 'main',
       commitSha: 'abc1234567890',
       fetchedAt: '2026-05-08T10:00:00.000Z',
@@ -98,7 +100,6 @@ describe('readCatalogSource', () => {
   it('passes through schemasUpdated: false when schema fetch fell back', () => {
     const docsDir = makeTmpDir();
     const source = {
-      repo: 'https://github.com/ProvarTesting/factPackages',
       branch: 'main',
       commitSha: 'abc1234567890',
       fetchedAt: '2026-05-08T10:00:00.000Z',
@@ -114,8 +115,8 @@ describe('readCatalogSource', () => {
     const result = JSON.parse(readCatalogSource(docsDir)) as Record<string, unknown>;
     assert.equal(result['commitSha'], null);
     assert.equal(result['fetchedAt'], null);
-    assert.equal(result['repo'], 'https://github.com/ProvarTesting/factPackages');
     assert.equal(result['schemasUpdated'], null);
+    assert.ok(!('repo' in result), 'fallback should not expose an internal repo URL');
   });
 
   it('returns fallback object when the file contains invalid JSON', () => {

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -81,12 +81,41 @@ describe('readCatalogSource', () => {
     assert.equal(result.fetchedAt, '2026-05-08T10:00:00.000Z');
   });
 
+  it('passes through schemasUpdated: true when present in the file', () => {
+    const docsDir = makeTmpDir();
+    const source = {
+      repo: 'https://github.com/ProvarTesting/factPackages',
+      branch: 'main',
+      commitSha: 'abc1234567890',
+      fetchedAt: '2026-05-08T10:00:00.000Z',
+      schemasUpdated: true,
+    };
+    fs.writeFileSync(path.join(docsDir, 'NITROX_CATALOG_SOURCE.json'), JSON.stringify(source));
+    const result = JSON.parse(readCatalogSource(docsDir)) as typeof source;
+    assert.equal(result.schemasUpdated, true);
+  });
+
+  it('passes through schemasUpdated: false when schema fetch fell back', () => {
+    const docsDir = makeTmpDir();
+    const source = {
+      repo: 'https://github.com/ProvarTesting/factPackages',
+      branch: 'main',
+      commitSha: 'abc1234567890',
+      fetchedAt: '2026-05-08T10:00:00.000Z',
+      schemasUpdated: false,
+    };
+    fs.writeFileSync(path.join(docsDir, 'NITROX_CATALOG_SOURCE.json'), JSON.stringify(source));
+    const result = JSON.parse(readCatalogSource(docsDir)) as typeof source;
+    assert.equal(result.schemasUpdated, false);
+  });
+
   it('returns fallback object when the file is absent', () => {
     const docsDir = makeTmpDir();
     const result = JSON.parse(readCatalogSource(docsDir)) as Record<string, unknown>;
     assert.equal(result['commitSha'], null);
     assert.equal(result['fetchedAt'], null);
     assert.equal(result['repo'], 'https://github.com/ProvarTesting/factPackages');
+    assert.equal(result['schemasUpdated'], null);
   });
 
   it('returns fallback object when the file contains invalid JSON', () => {
@@ -94,5 +123,6 @@ describe('readCatalogSource', () => {
     fs.writeFileSync(path.join(docsDir, 'NITROX_CATALOG_SOURCE.json'), '{bad json');
     const result = JSON.parse(readCatalogSource(docsDir)) as Record<string, unknown>;
     assert.equal(result['commitSha'], null);
+    assert.equal(result['schemasUpdated'], null);
   });
 });


### PR DESCRIPTION
## Summary
- Extended `scripts/fetch-nitrox-packages.cjs` to fetch `FactComponent.schema` and `FactPackage.schema` from the internal source at the same commit SHA as the component catalog, ensuring no version skew between schemas and packages
- Both schemas written to `src/mcp/rules/` (with `.json` extension, picked up by compile step) and to the repo root (for schemastore.org registration)
- Falls back to existing bundled schemas with a warning if the fetch fails — never blocks the release
- Added `schemasUpdated` boolean to `NITROX_CATALOG_SOURCE.json` to track whether schemas were refreshed

## Jira
https://provartesting.atlassian.net/browse/PDX-464

## Test plan
- [ ] yarn compile passes
- [ ] yarn test:only passes (943 passing, 0 failing)
- [ ] mcp-smoke.cjs passes (54/54)
- [ ] yarn lint passes
- [ ] New server.test.ts cases: `schemasUpdated: true`, `schemasUpdated: false`, fallback includes `schemasUpdated: null`

## Changes
- `scripts/fetch-nitrox-packages.cjs`: added `SCHEMA_TREE_PATHS`, `isSchemaFile()`, `fetchAndWriteSchemas()`, schema fetch with isolated try/catch, `schemasUpdated` field in source JSON
- `src/mcp/server.ts`: added `schemasUpdated: null` to `readCatalogSource` fallback object
- `test/unit/mcp/server.test.ts`: 4 new tests for `schemasUpdated` pass-through and fallback
- `docs/mcp.md`: updated NitroX section and `provar://nitrox/catalog-source` docs to document schema sourcing and new `schemasUpdated` field (private repo URL not exposed)