### PR TITLE
PDX-465: feat(mcp): add bin entry to enable zero-install npx MCP server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,44 @@ Validation runs in two modes: **local only** (structural rules, no key required)
 
 ## Quick setup
 
-**Requires:** Provar Automation IDE installed with an activated license.
+**Requires:** Provar Automation IDE installed with an activated license. Node.js 18–24 must be on your PATH.
+
+### Option A — Zero-install (recommended for Claude Desktop)
+
+No prior setup needed. Paste this into your Claude Desktop config file and restart the app:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "provar": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@provartesting/provardx-cli@beta",
+        "mcp",
+        "start",
+        "--allowed-paths",
+        "/path/to/your/provar/project"
+      ]
+    }
+  }
+}
+```
+
+`npx -y` downloads the package automatically on first use — no `sf` or separate install step required.
+
+**Claude Code** — run once to register the server:
+
+```sh
+claude mcp add provar -s user -- npx -y @provartesting/provardx-cli@beta mcp start --allowed-paths /path/to/your/provar/project
+```
+
+### Option B — Global sf plugin install
+
+Prefer a persistent global install? Install once, then use the `sf` command:
 
 ```sh
 # 1. Install the plugin — @beta is required for MCP support
@@ -49,16 +86,7 @@ sf plugins install @provartesting/provardx-cli@beta
 sf provar auth login
 ```
 
-**Claude Code** — run once to register the server:
-
-```sh
-claude mcp add provar -s user -- sf provar mcp start --allowed-paths /path/to/your/provar/project
-```
-
-**Claude Desktop** — add to your config file and restart the app:
-
-- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+**Claude Desktop** config using the global install:
 
 ```json
 {
@@ -72,6 +100,12 @@ claude mcp add provar -s user -- sf provar mcp start --allowed-paths /path/to/yo
 ```
 
 > **Windows (Claude Desktop):** Use `sf.cmd` instead of `sf` if the server fails to start.
+
+**Claude Code** using the global install:
+
+```sh
+claude mcp add provar -s user -- sf provar mcp start --allowed-paths /path/to/your/provar/project
+```
 
 📖 **[docs/mcp.md](https://github.com/ProvarTesting/provardx-cli/blob/main/docs/mcp.md) — full setup, all 35+ tools, 7 MCP prompts, troubleshooting.**
 

--- a/bin/mcp-start.js
+++ b/bin/mcp-start.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Lightweight zero-install entrypoint for the Provar MCP server.
+// Usage: npx -y @provartesting/provardx-cli@beta mcp start --allowed-paths /path/to/project
+
+const args = process.argv.slice(2);
+
+if (args[0] !== 'mcp' || args[1] !== 'start') {
+  process.stderr.write(
+    'Usage: provardx mcp start --allowed-paths <path> [--auto-defects] [--auto-update] [--no-update-check]\n'
+  );
+  process.exit(1);
+}
+
+const remaining = args.slice(2);
+/** @type {string[]} */
+const allowedPaths = [];
+let autoDefects = false;
+let autoUpdate = false;
+let noUpdateCheck = false;
+
+for (let i = 0; i < remaining.length; i++) {
+  const arg = remaining[i];
+  if (arg === '--allowed-paths' || arg === '-a') {
+    if (i + 1 >= remaining.length) {
+      process.stderr.write('[provar-mcp] Error: --allowed-paths requires a path value.\n');
+      process.exit(1);
+    }
+    allowedPaths.push(remaining[++i]);
+  } else if (arg.startsWith('--allowed-paths=')) {
+    allowedPaths.push(arg.slice('--allowed-paths='.length));
+  } else if (arg === '--auto-defects') {
+    autoDefects = true;
+  } else if (arg === '--auto-update') {
+    autoUpdate = true;
+  } else if (arg === '--no-update-check') {
+    noUpdateCheck = true;
+  }
+}
+
+if (allowedPaths.length === 0) {
+  process.stderr.write(
+    '[provar-mcp] Error: --allowed-paths is required.\n' +
+      'Example: npx -y @provartesting/provardx-cli@beta mcp start --allowed-paths /path/to/project\n'
+  );
+  process.exit(1);
+}
+
+if (autoDefects) {
+  process.env['PROVAR_AUTO_DEFECTS'] = '1';
+}
+
+// Dynamic imports placed after arg validation so early-exit paths need no compiled lib.
+const { validateLicense, LicenseError } = await import('../lib/mcp/licensing/index.js');
+const { checkForUpdate } = await import('../lib/mcp/update/updateChecker.js');
+const { createProvarMcpServer } = await import('../lib/mcp/server.js');
+const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
+
+try {
+  const result = await validateLicense();
+  if (result.offlineGrace) {
+    process.stderr.write('[provar-mcp] Warning: license validated from offline cache (last checked > 2h ago).\n');
+  }
+} catch (err) {
+  if (err instanceof LicenseError) {
+    process.stderr.write(`[provar-mcp] Error: ${/** @type {Error} */ (err).message}\n`);
+    process.exit(1);
+  }
+  throw err;
+}
+
+const updateResult = await checkForUpdate({ noUpdateCheck, autoUpdate });
+const server = createProvarMcpServer({ allowedPaths, updateResult });
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,11 @@
   "engines": {
     "node": ">=18.0.0 <25.0.0"
   },
+  "bin": {
+    "provardx": "./bin/mcp-start.js"
+  },
   "files": [
+    "/bin/mcp-start.js",
     "/lib",
     "/messages",
     "/oclif.manifest.json"

--- a/test/unit/bin/mcpStart.test.ts
+++ b/test/unit/bin/mcpStart.test.ts
@@ -1,0 +1,51 @@
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'mocha';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const BIN_SCRIPT = join(currentDir, '../../../bin/mcp-start.js');
+
+function runBin(args: string[]): { status: number | null; stderr: string } {
+  const result = spawnSync('node', [BIN_SCRIPT, ...args], { encoding: 'utf8' });
+  return { status: result.status, stderr: result.stderr };
+}
+
+describe('bin/mcp-start.js — argument validation', () => {
+  it('exits 1 with usage when no arguments given', () => {
+    const { status, stderr } = runBin([]);
+    assert.equal(status, 1);
+    assert.ok(stderr.includes('Usage:'), `expected usage hint, got: ${stderr}`);
+  });
+
+  it('exits 1 with usage when "mcp" subcommand is missing', () => {
+    const { status, stderr } = runBin(['start']);
+    assert.equal(status, 1);
+    assert.ok(stderr.includes('Usage:'), `expected usage hint, got: ${stderr}`);
+  });
+
+  it('exits 1 with usage when only "mcp" is given without "start"', () => {
+    const { status, stderr } = runBin(['mcp']);
+    assert.equal(status, 1);
+    assert.ok(stderr.includes('Usage:'), `expected usage hint, got: ${stderr}`);
+  });
+
+  it('exits 1 with required-arg error when --allowed-paths is omitted', () => {
+    const { status, stderr } = runBin(['mcp', 'start']);
+    assert.equal(status, 1);
+    assert.ok(stderr.includes('--allowed-paths is required'), `expected required-arg error, got: ${stderr}`);
+  });
+
+  it('exits 1 with value-required error when --allowed-paths has no value', () => {
+    const { status, stderr } = runBin(['mcp', 'start', '--allowed-paths']);
+    assert.equal(status, 1);
+    assert.ok(stderr.includes('requires a path value'), `expected value-required error, got: ${stderr}`);
+  });
+
+  it('exits 1 with value-required error when -a has no value', () => {
+    const { status, stderr } = runBin(['mcp', 'start', '-a']);
+    assert.equal(status, 1);
+    assert.ok(stderr.includes('requires a path value'), `expected value-required error, got: ${stderr}`);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `bin/mcp-start.js` — a lightweight ESM entrypoint that lets users start the Provar MCP server via `npx -y @provartesting/provardx-cli@beta mcp start --allowed-paths <path>` with no prior `sf` install
- Adds `"bin": { "provardx": "./bin/mcp-start.js" }` to `package.json` so npm publishes and wires up the executable on all platforms
- Updates `README.md` Quick Setup section: npx zero-install is now Option A (recommended), existing `sf plugins install` path is Option B
- Adds `test/unit/bin/mcpStart.test.ts` with subprocess tests for all early-exit argument validation paths

## Jira
https://provartesting.atlassian.net/browse/PDX-465

## Test plan
- [ ] `yarn compile` passes
- [ ] `yarn test:only` passes (947 passing, includes 6 new bin arg-validation tests)
- [ ] `node scripts/mcp-smoke.cjs` passes (54/54 — TOTAL_EXPECTED unchanged)
- [ ] `yarn lint` passes

## Changes
- `bin/mcp-start.js`: new lightweight entrypoint; validates `mcp start` subcommand, requires `--allowed-paths`, then dynamically imports compiled lib modules and bootstraps the server identically to the sf plugin path
- `package.json`: added `"bin"` field and added `"/bin/mcp-start.js"` to `"files"`
- `README.md`: restructured Quick Setup into Option A (npx) / Option B (sf global) with correct config blocks for both Claude Desktop and Claude Code
- `test/unit/bin/mcpStart.test.ts`: 6 subprocess tests covering no-args, wrong subcommand, missing `--allowed-paths`, and missing value for `-a`/`--allowed-paths`