### PR TITLE
PDX-467: chore(docs): bump version to 1.5.0 stable and remove @beta install tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Provar DX CLI is a Salesforce CLI plugin for Provar customers who want to au
 Install the plugin
 
 ```sh-session
-$ sf plugins install @provartesting/provardx-cli@beta
+$ sf plugins install @provartesting/provardx-cli
 ```
 
 Update plugins
@@ -53,14 +53,7 @@ No prior setup needed. Paste this into your Claude Desktop config file and resta
   "mcpServers": {
     "provar": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@provartesting/provardx-cli@beta",
-        "mcp",
-        "start",
-        "--allowed-paths",
-        "/path/to/your/provar/project"
-      ]
+      "args": ["-y", "@provartesting/provardx-cli", "mcp", "start", "--allowed-paths", "/path/to/your/provar/project"]
     }
   }
 }
@@ -71,7 +64,7 @@ No prior setup needed. Paste this into your Claude Desktop config file and resta
 **Claude Code** — run once to register the server:
 
 ```sh
-claude mcp add provar -s user -- npx -y @provartesting/provardx-cli@beta mcp start --allowed-paths /path/to/your/provar/project
+claude mcp add provar -s user -- npx -y @provartesting/provardx-cli mcp start --allowed-paths /path/to/your/provar/project
 ```
 
 ### Option B — Global sf plugin install
@@ -79,8 +72,8 @@ claude mcp add provar -s user -- npx -y @provartesting/provardx-cli@beta mcp sta
 Prefer a persistent global install? Install once, then use the `sf` command:
 
 ```sh
-# 1. Install the plugin — @beta is required for MCP support
-sf plugins install @provartesting/provardx-cli@beta
+# 1. Install the plugin
+sf plugins install @provartesting/provardx-cli
 
 # 2. (Optional) Authenticate for full 170+ rule validation
 sf provar auth login

--- a/docs/mcp-pilot-guide.md
+++ b/docs/mcp-pilot-guide.md
@@ -25,7 +25,7 @@ The server runs **locally on your machine**. It does not phone home, transmit yo
 | --------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | Provar Automation IDE       | ≥ 3.x   | Must be installed with an **activated license** on the same machine. The MCP server reads the license from `~/Provar/.licenses/`.     |
 | Salesforce CLI (`sf`)       | ≥ 2.x   | `npm install -g @salesforce/cli`                                                                                                      |
-| Provar DX CLI plugin        | ≥ 1.5.0 | `sf plugins install @provartesting/provardx-cli@beta`                                                                                 |
+| Provar DX CLI plugin        | ≥ 1.5.0 | `sf plugins install @provartesting/provardx-cli`                                                                                      |
 | An MCP-compatible AI client | —       | Claude Desktop, Claude Code, GitHub Copilot (VS Code), Cursor, or Agentforce Vibes                                                    |
 | Node.js                     | 18–24   | Installed automatically with the SF CLI. **Node 25+ is not supported** — a transitive dependency crashes on startup. Use Node 22 LTS. |
 
@@ -48,7 +48,7 @@ sf --version
 ### 2. Install the Provar DX CLI plugin
 
 ```sh
-sf plugins install @provartesting/provardx-cli@beta
+sf plugins install @provartesting/provardx-cli
 ```
 
 Verify:
@@ -561,7 +561,7 @@ After editing `claude_desktop_config.json`, you must fully restart Claude Deskto
 
 **Server starts but immediately exits**
 
-Check that the SF CLI plugin is installed: `sf plugins | grep provardx`. If missing, run `sf plugins install @provartesting/provardx-cli@beta`.
+Check that the SF CLI plugin is installed: `sf plugins | grep provardx`. If missing, run `sf plugins install @provartesting/provardx-cli`.
 
 ---
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -89,8 +89,8 @@ The Provar DX CLI ships with a built-in **Model Context Protocol (MCP) server** 
 ## Quick start
 
 ```sh
-# 1. Install the plugin — @beta is required for MCP support
-sf plugins install @provartesting/provardx-cli@beta
+# 1. Install the plugin
+sf plugins install @provartesting/provardx-cli
 
 # 2. (Optional) Authenticate for full 170+ rule validation
 sf provar auth login
@@ -224,7 +224,7 @@ claude mcp add provar -s user -- npx -y @salesforce/cli provar mcp start --allow
 }
 ```
 
-> The Provar plugin must still be installed first via `sf plugins install @provartesting/provardx-cli@beta`. The npx invocation shares the same plugin directory as the globally installed `sf` binary.
+> The Provar plugin must still be installed first via `sf plugins install @provartesting/provardx-cli`. The npx invocation shares the same plugin directory as the globally installed `sf` binary.
 
 ### Claude Desktop
 
@@ -493,14 +493,14 @@ A lightweight sanity-check tool. Echoes back the message you send. Useful for ve
 
 **Output**
 
-| Field             | Type           | Description                                               |
-| ----------------- | -------------- | --------------------------------------------------------- |
-| `pong`            | string         | The echoed message                                        |
-| `ts`              | string         | ISO-8601 timestamp                                        |
-| `server`          | string         | Server name and version (e.g. `provar-mcp@1.5.0-beta.15`) |
-| `updateAvailable` | boolean        | Whether a newer version is available in the registry      |
-| `latestVersion`   | string \| null | Latest version found in the npm registry, or `null`       |
-| `updateCommand`   | string \| null | Command to run to update the plugin, or `null`            |
+| Field             | Type           | Description                                          |
+| ----------------- | -------------- | ---------------------------------------------------- |
+| `pong`            | string         | The echoed message                                   |
+| `ts`              | string         | ISO-8601 timestamp                                   |
+| `server`          | string         | Server name and version (e.g. `provar-mcp@1.5.0`)    |
+| `updateAvailable` | boolean        | Whether a newer version is available in the registry |
+| `latestVersion`   | string \| null | Latest version found in the npm registry, or `null`  |
+| `updateCommand`   | string \| null | Command to run to update the plugin, or `null`       |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provartesting/provardx-cli",
   "description": "A plugin for the Salesforce CLI to orchestrate testing activities and report quality metrics to Provar Quality Hub",
-  "version": "1.5.0-beta.19",
+  "version": "1.5.0",
   "mcpName": "io.github.ProvarTesting/provar",
   "license": "BSD-3-Clause",
   "plugins": [

--- a/server.json
+++ b/server.json
@@ -14,12 +14,12 @@
     "url": "https://github.com/ProvarTesting/provardx-cli",
     "source": "github"
   },
-  "version": "1.5.0-beta.19",
+  "version": "1.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@provartesting/provardx-cli",
-      "version": "1.5.0-beta.19",
+      "version": "1.5.0",
       "transport": {
         "type": "stdio"
       },

--- a/test/unit/mcp/updateChecker.test.ts
+++ b/test/unit/mcp/updateChecker.test.ts
@@ -189,14 +189,14 @@ describe('checkForUpdate', () => {
   it('fetches registry when cache is stale (>4h)', async () => {
     writeFreshCache({
       checkedAt: Date.now() - 5 * 60 * 60 * 1000, // 5 hours ago
-      currentVersion: '1.5.0-beta.10',
-      latestVersion: '1.5.0-beta.10',
-      channel: 'beta',
+      currentVersion: '1.5.0',
+      latestVersion: '1.5.0',
+      channel: 'latest',
     });
-    mockFetchOk({ beta: '1.5.0-beta.11' });
+    mockFetchOk({ latest: '1.5.1' });
     const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
     assert.equal(result.fromCache, false);
-    assert.equal(result.latestVersion, '1.5.0-beta.11');
+    assert.equal(result.latestVersion, '1.5.1');
   });
 
   it('returns updateAvailable=true when update is available', async () => {

--- a/test/unit/mcp/updateChecker.test.ts
+++ b/test/unit/mcp/updateChecker.test.ts
@@ -187,16 +187,18 @@ describe('checkForUpdate', () => {
   });
 
   it('fetches registry when cache is stale (>4h)', async () => {
+    const { currentVersion } = await checkForUpdate({ noUpdateCheck: true, autoUpdate: false });
+    const channel = deriveChannel(currentVersion);
     writeFreshCache({
       checkedAt: Date.now() - 5 * 60 * 60 * 1000, // 5 hours ago
-      currentVersion: '1.5.0',
-      latestVersion: '1.5.0',
-      channel: 'latest',
+      currentVersion,
+      latestVersion: currentVersion,
+      channel,
     });
-    mockFetchOk({ latest: '1.5.1' });
+    mockFetchOk({ [channel]: '99.0.0' });
     const result = await checkForUpdate({ noUpdateCheck: false, autoUpdate: false });
     assert.equal(result.fromCache, false);
-    assert.equal(result.latestVersion, '1.5.1');
+    assert.equal(result.latestVersion, '99.0.0');
   });
 
   it('returns updateAvailable=true when update is available', async () => {


### PR DESCRIPTION
## Summary
- Bumped `package.json` and `server.json` version from `1.5.0-beta.19` to `1.5.0`
- Removed `@beta` dist-tag from all install commands in `README.md`, `docs/mcp.md`, and `docs/mcp-pilot-guide.md`
- Updated the `updateChecker` stale-cache test to use the `latest` channel (matching the new stable version)

## Jira
https://provartesting.atlassian.net/browse/PDX-467

## Test plan
- [x] yarn compile passes
- [x] yarn test:only passes (954 passing)
- [x] mcp-smoke.cjs passes (54/54)
- [x] yarn lint passes

## Changes
- `package.json`: `1.5.0-beta.19` → `1.5.0`
- `server.json`: both version fields `1.5.0-beta.19` → `1.5.0`
- `README.md`: removed `@beta` from `sf plugins install`, npx JSON snippet, and Claude Code `claude mcp add` command
- `docs/mcp.md`: removed `@beta` from install commands; updated `provar-mcp@1.5.0-beta.15` example to `provar-mcp@1.5.0`
- `docs/mcp-pilot-guide.md`: removed `@beta` from prerequisites table and all install command snippets
- `test/unit/mcp/updateChecker.test.ts`: updated stale-cache test from `beta` channel to `latest` channel

## External docs note
`docs/provar-mcp-public-docs.md` and `docs/university-of-provar-mcp-course.md` are maintained by the Provar team separately — both still reference `@beta` install commands and `≥ 1.5.0-beta` as the version requirement. These should be updated manually to reflect the 1.5.0 stable release.