### PR TITLE
PDX-476: fix(mcp): address Copilot review follow-ups from PR #161

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ sf provar auth login
 claude mcp add provar -s user -- sf provar mcp start --allowed-paths /path/to/your/provar/project
 ```
 
-📖 **[docs/mcp.md](https://github.com/ProvarTesting/provardx-cli/blob/main/docs/mcp.md) — full setup, all 35+ tools, 7 MCP prompts, troubleshooting.**
+📖 **[docs/mcp.md](https://github.com/ProvarTesting/provardx-cli/blob/main/docs/mcp.md) — full setup, all 35+ tools, 11 MCP prompts, troubleshooting.**
 
 ---
 

--- a/docs/NITROX_CATALOG_SOURCE.json
+++ b/docs/NITROX_CATALOG_SOURCE.json
@@ -1,6 +1,6 @@
 {
-  "repo": "https://github.com/ProvarTesting/factPackages",
   "branch": "main",
   "commitSha": null,
-  "fetchedAt": null
+  "fetchedAt": null,
+  "schemasUpdated": null
 }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1816,7 +1816,7 @@ The SF Hosted MCP uses per-user OAuth 2.0, respects field-level security and sha
 
 ## MCP Prompts
 
-The Provar MCP server registers **7 MCP prompts** that pre-wire the tool chain into guided workflows. AI clients that support MCP prompts can invoke them directly by name instead of manually orchestrating the underlying tool sequence. **Important:** prompts that need to list, read, or write local project files (for example, `.testcase` files used by `provar.loop.fix` and `provar.loop.coverage`) also require a client with its own workspace/file tools, such as Claude Code or another MCP-compatible client with local file access configured; MCP prompt support alone is not sufficient for those workflows.
+The Provar MCP server registers **11 MCP prompts** that pre-wire the tool chain into guided workflows. AI clients that support MCP prompts can invoke them directly by name instead of manually orchestrating the underlying tool sequence. **Important:** prompts that need to list, read, or write local project files (for example, `.testcase` files used by `provar.loop.fix` and `provar.loop.coverage`) also require a client with its own workspace/file tools, such as Claude Code or another MCP-compatible client with local file access configured; MCP prompt support alone is not sufficient for those workflows.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "node": ">=18.0.0 <25.0.0"
   },
   "bin": {
-    "provardx": "./bin/mcp-start.js"
+    "provardx": "./bin/mcp-start.js",
+    "provardx-cli": "./bin/mcp-start.js"
   },
   "files": [
     "/bin/mcp-start.js",

--- a/src/mcp/tools/nitroXTools.ts
+++ b/src/mcp/tools/nitroXTools.ts
@@ -66,7 +66,16 @@ function getFactComponentValidator(): ValidateFunction | null {
 function ajvErrorToIssue(err: ErrorObject): NitroXIssue {
   const keyword = err.keyword.replace(/([a-z])([A-Z])/g, '$1_$2').toUpperCase();
   const instancePath = err.instancePath;
-  const appliesTo = instancePath ? instancePath.replace(/^\//, '').replace(/\//g, '.') : 'root';
+  // For additionalProperties/required, instancePath points to the parent object;
+  // the actual property name is in err.params.
+  const params = err.params as Record<string, unknown>;
+  const extraProp =
+    err.keyword === 'additionalProperties' ? (params['additionalProperty'] as string | undefined) : undefined;
+  const missingProp = err.keyword === 'required' ? (params['missingProperty'] as string | undefined) : undefined;
+  const leafProp = extraProp ?? missingProp;
+
+  const basePath = instancePath ? instancePath.replace(/^\//, '').replace(/\//g, '.') : 'root';
+  const appliesTo = leafProp ? (basePath === 'root' ? leafProp : `${basePath}.${leafProp}`) : basePath;
   const pathParts = instancePath.split('/').filter(Boolean);
   const severity: 'ERROR' | 'WARNING' = ['REQUIRED', 'TYPE'].includes(keyword) ? 'ERROR' : 'WARNING';
   const issue: NitroXIssue = {
@@ -75,7 +84,7 @@ function ajvErrorToIssue(err: ErrorObject): NitroXIssue {
     message: `Schema: ${instancePath || 'root'} — ${err.message ?? 'validation failed'}`,
     applies_to: appliesTo,
   };
-  if (pathParts.length > 0) issue.field = pathParts[pathParts.length - 1];
+  issue.field = leafProp ?? (pathParts.length > 0 ? pathParts[pathParts.length - 1] : undefined);
   return issue;
 }
 


### PR DESCRIPTION
## Summary
- Fix `ajvErrorToIssue` to use `err.params.additionalProperty`/`missingProperty` for accurate `field`/`applies_to` on `additionalProperties` and `required` AJV errors
- Normalize `docs/NITROX_CATALOG_SOURCE.json` to stable shape: remove `repo` field, add `schemasUpdated: null`
- Add `provardx-cli` bin alias in `package.json` so `npx -y @provartesting/provardx-cli` resolves unambiguously by package name
- Update stale "7 MCP prompts" count to 11 in README.md and docs/mcp.md

## Jira
https://provartesting.atlassian.net/browse/PDX-476

## Test plan
- [x] `yarn compile` passes
- [x] `yarn test:only` passes (954 passing)
- [x] `yarn lint` passes
- [x] `node scripts/mcp-smoke.cjs` passes

## Changes
- `src/mcp/tools/nitroXTools.ts`: special-case `additionalProperties`/`required` keywords in `ajvErrorToIssue` to pull property names from `err.params`
- `docs/NITROX_CATALOG_SOURCE.json`: remove `repo`, add `schemasUpdated: null`
- `package.json`: add `provardx-cli` bin alias pointing to `./bin/mcp-start.js`
- `README.md`, `docs/mcp.md`: update prompt count from 7 to 11