### PR TITLE
PDX-476: fix(mcp): Copilot PR #161 follow-ups — AJV error mapping, catalog source shape, bin alias, prompt count + test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ sf provar auth login
 claude mcp add provar -s user -- sf provar mcp start --allowed-paths /path/to/your/provar/project
 ```
 
-📖 **[docs/mcp.md](https://github.com/ProvarTesting/provardx-cli/blob/main/docs/mcp.md) — full setup, all 35+ tools, 7 MCP prompts, troubleshooting.**
+📖 **[docs/mcp.md](https://github.com/ProvarTesting/provardx-cli/blob/main/docs/mcp.md) — full setup, all 35+ tools, 11 MCP prompts, troubleshooting.**
 
 ---
 

--- a/docs/NITROX_CATALOG_SOURCE.json
+++ b/docs/NITROX_CATALOG_SOURCE.json
@@ -1,6 +1,6 @@
 {
-  "repo": "https://github.com/ProvarTesting/factPackages",
   "branch": "main",
   "commitSha": null,
-  "fetchedAt": null
+  "fetchedAt": null,
+  "schemasUpdated": null
 }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1816,7 +1816,7 @@ The SF Hosted MCP uses per-user OAuth 2.0, respects field-level security and sha
 
 ## MCP Prompts
 
-The Provar MCP server registers **7 MCP prompts** that pre-wire the tool chain into guided workflows. AI clients that support MCP prompts can invoke them directly by name instead of manually orchestrating the underlying tool sequence. **Important:** prompts that need to list, read, or write local project files (for example, `.testcase` files used by `provar.loop.fix` and `provar.loop.coverage`) also require a client with its own workspace/file tools, such as Claude Code or another MCP-compatible client with local file access configured; MCP prompt support alone is not sufficient for those workflows.
+The Provar MCP server registers **11 MCP prompts** that pre-wire the tool chain into guided workflows. AI clients that support MCP prompts can invoke them directly by name instead of manually orchestrating the underlying tool sequence. **Important:** prompts that need to list, read, or write local project files (for example, `.testcase` files used by `provar.loop.fix` and `provar.loop.coverage`) also require a client with its own workspace/file tools, such as Claude Code or another MCP-compatible client with local file access configured; MCP prompt support alone is not sufficient for those workflows.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "node": ">=18.0.0 <25.0.0"
   },
   "bin": {
-    "provardx": "./bin/mcp-start.js"
+    "provardx": "./bin/mcp-start.js",
+    "provardx-cli": "./bin/mcp-start.js"
   },
   "files": [
     "/bin/mcp-start.js",

--- a/src/mcp/tools/nitroXTools.ts
+++ b/src/mcp/tools/nitroXTools.ts
@@ -66,7 +66,16 @@ function getFactComponentValidator(): ValidateFunction | null {
 function ajvErrorToIssue(err: ErrorObject): NitroXIssue {
   const keyword = err.keyword.replace(/([a-z])([A-Z])/g, '$1_$2').toUpperCase();
   const instancePath = err.instancePath;
-  const appliesTo = instancePath ? instancePath.replace(/^\//, '').replace(/\//g, '.') : 'root';
+  // For additionalProperties/required, instancePath points to the parent object;
+  // the actual property name is in err.params.
+  const params = err.params as Record<string, unknown>;
+  const extraProp =
+    err.keyword === 'additionalProperties' ? (params['additionalProperty'] as string | undefined) : undefined;
+  const missingProp = err.keyword === 'required' ? (params['missingProperty'] as string | undefined) : undefined;
+  const leafProp = extraProp ?? missingProp;
+
+  const basePath = instancePath ? instancePath.replace(/^\//, '').replace(/\//g, '.') : 'root';
+  const appliesTo = leafProp ? (basePath === 'root' ? leafProp : `${basePath}.${leafProp}`) : basePath;
   const pathParts = instancePath.split('/').filter(Boolean);
   const severity: 'ERROR' | 'WARNING' = ['REQUIRED', 'TYPE'].includes(keyword) ? 'ERROR' : 'WARNING';
   const issue: NitroXIssue = {
@@ -75,7 +84,7 @@ function ajvErrorToIssue(err: ErrorObject): NitroXIssue {
     message: `Schema: ${instancePath || 'root'} — ${err.message ?? 'validation failed'}`,
     applies_to: appliesTo,
   };
-  if (pathParts.length > 0) issue.field = pathParts[pathParts.length - 1];
+  issue.field = leafProp ?? (pathParts.length > 0 ? pathParts[pathParts.length - 1] : undefined);
   return issue;
 }
 

--- a/test/unit/mcp/nitroXTools.test.ts
+++ b/test/unit/mcp/nitroXTools.test.ts
@@ -422,6 +422,7 @@ describe('nitroXTools', () => {
     let extraPropsValidator!: ValidateFunction;
     let typeViolationValidator!: ValidateFunction;
     let permissiveValidator!: ValidateFunction;
+    let requiredValidator!: ValidateFunction;
 
     before(async () => {
       const mod = await import('../../../src/mcp/tools/nitroXTools.js');
@@ -453,19 +454,39 @@ describe('nitroXTools', () => {
           fieldDetailsElement: { type: 'boolean' },
         },
       });
+
+      requiredValidator = ajv.compile({
+        type: 'object',
+        required: ['componentId'],
+        properties: { componentId: { type: 'string' } },
+      });
     });
 
-    it('NX_SCHEMA_ADDITIONAL_PROPERTIES: extra property surfaces as WARNING', () => {
-      // Schema only allows componentId; passing an extra field should produce a schema issue
+    it('NX_SCHEMA_ADDITIONAL_PROPERTIES: extra property surfaces as WARNING with correct field and applies_to', () => {
       const result = validateFn({ componentId: VALID_UUID, _extraProp: true }, extraPropsValidator);
-      assert.ok(result.issues.some((i) => i.rule_id === 'NX_SCHEMA_ADDITIONAL_PROPERTIES'));
-      assert.equal(result.issues.find((i) => i.rule_id === 'NX_SCHEMA_ADDITIONAL_PROPERTIES')?.severity, 'WARNING');
+      const issue = result.issues.find((i) => i.rule_id === 'NX_SCHEMA_ADDITIONAL_PROPERTIES');
+      assert.ok(issue, 'expected NX_SCHEMA_ADDITIONAL_PROPERTIES issue');
+      assert.equal(issue?.severity, 'WARNING');
+      assert.equal(issue?.field, '_extraProp');
+      assert.equal(issue?.applies_to, '_extraProp');
+    });
+
+    it('NX_SCHEMA_REQUIRED: missing required property surfaces as ERROR with correct field and applies_to', () => {
+      const result = validateFn({}, requiredValidator);
+      const issue = result.issues.find((i) => i.rule_id === 'NX_SCHEMA_REQUIRED');
+      assert.ok(issue, 'expected NX_SCHEMA_REQUIRED issue');
+      assert.equal(issue?.severity, 'ERROR');
+      assert.equal(issue?.field, 'componentId');
+      assert.equal(issue?.applies_to, 'componentId');
     });
 
     it('NX_SCHEMA_TYPE: wrong property type surfaces as ERROR', () => {
-      // Schema expects pageStructureElement to be boolean; passing a string should produce a type error
+      // instancePath points directly to the offending property; field derives from pathParts
       const result = validateFn({ ...VALID_ROOT, pageStructureElement: 'yes' }, typeViolationValidator);
-      assert.ok(result.issues.some((i) => i.rule_id === 'NX_SCHEMA_TYPE' && i.severity === 'ERROR'));
+      const issue = result.issues.find((i) => i.rule_id === 'NX_SCHEMA_TYPE');
+      assert.ok(issue && issue.severity === 'ERROR');
+      assert.equal(issue?.field, 'pageStructureElement');
+      assert.equal(issue?.applies_to, 'pageStructureElement');
     });
 
     it('valid object matching schema produces no NX_SCHEMA_ issues', () => {


### PR DESCRIPTION
## Summary
- Fix `ajvErrorToIssue` to derive `field`/`applies_to` from `err.params` for `additionalProperties` and `required` AJV keywords (were silently using parent object path)
- Normalize `docs/NITROX_CATALOG_SOURCE.json` to stable resource shape: remove exposed `repo` field, add `schemasUpdated: null`
- Add `provardx-cli` bin alias in `package.json` so `npx -y @provartesting/provardx-cli` resolves unambiguously by package name
- Update stale "7 MCP prompts" count to 11 in `README.md` and `docs/mcp.md`
- Add regression test assertions for `field` and `applies_to` on all three AJV keyword cases (`additionalProperties`, `required`, `type`)

## Jira
https://provartesting.atlassian.net/browse/PDX-476

## Test plan
- [x] `yarn compile` passes
- [x] `yarn test:only` passes (955 passing)
- [x] `yarn lint` passes
- [x] Pre-push hook passes

## Changes
- `src/mcp/tools/nitroXTools.ts`: special-case `additionalProperties`/`required` in `ajvErrorToIssue` to pull property names from `err.params`
- `docs/NITROX_CATALOG_SOURCE.json`: remove `repo`, add `schemasUpdated: null`
- `package.json`: add `provardx-cli` bin alias
- `README.md`, `docs/mcp.md`: update prompt count 7 → 11
- `test/unit/mcp/nitroXTools.test.ts`: assert `field`/`applies_to` for all three AJV keyword cases; add `required` keyword test