### PR TITLE
PDX-468/469: feat(mcp): PROVAR_MCP_SCHEMA_MODE compact descriptions + PROVAR_MCP_TOOLS group filtering

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -462,10 +462,61 @@ sf provar auth clear
 
 ### Environment variables
 
-| Variable                 | Purpose                               | Default                                           |
-| ------------------------ | ------------------------------------- | ------------------------------------------------- |
-| `PROVAR_API_KEY`         | API key for Quality Hub validation    | None — falls back to `~/.provar/credentials.json` |
-| `PROVAR_QUALITY_HUB_URL` | Override the Quality Hub API base URL | Dev API Gateway URL (`/dev`)                      |
+| Variable                 | Purpose                                                    | Default                                           |
+| ------------------------ | ---------------------------------------------------------- | ------------------------------------------------- |
+| `PROVAR_API_KEY`         | API key for Quality Hub validation                         | None — falls back to `~/.provar/credentials.json` |
+| `PROVAR_QUALITY_HUB_URL` | Override the Quality Hub API base URL                      | Dev API Gateway URL (`/dev`)                      |
+| `PROVAR_MCP_SCHEMA_MODE` | Set to `compact` to shorten all tool descriptions          | Standard (full) descriptions                      |
+| `PROVAR_MCP_TOOLS`       | Comma-separated list of tool groups to register at startup | All groups registered                             |
+
+---
+
+## Agent performance tuning
+
+Two environment variables let you reduce the context budget consumed by the ProvarDX MCP server — useful when working with agents that have a limited context window or a large number of registered tools.
+
+### Compact descriptions (`PROVAR_MCP_SCHEMA_MODE`)
+
+```
+PROVAR_MCP_SCHEMA_MODE=compact
+```
+
+When set to `compact`, every tool description and parameter description is replaced with a short summary (typically ≤15 words). This can save hundreds of tokens per tool in the initial context handshake, at the cost of reduced in-description guidance for the agent.
+
+Use this mode if:
+
+- Your agent reports context limit warnings on startup
+- You are using a smaller model with a tighter context budget
+- Your agents already have domain context and don't need verbose descriptions
+
+### Tool group filtering (`PROVAR_MCP_TOOLS`)
+
+```
+PROVAR_MCP_TOOLS=nitrox,authoring
+```
+
+Restricts which tool groups are registered when the server starts. Only the groups listed (comma-separated, case-insensitive) are made available. `provardx_ping` is always registered regardless of this setting.
+
+| Group name   | Tools registered                                                                                                                                                                                                                                                              |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `nitrox`     | `provar_nitrox_discover`, `provar_nitrox_generate`, `provar_nitrox_patch`, `provar_nitrox_read`, `provar_nitrox_validate`                                                                                                                                                     |
+| `automation` | `provar_automation_setup`, `provar_automation_config_load`, `provar_automation_metadata_download`, `provar_automation_compile`, `provar_automation_testrun`                                                                                                                   |
+| `qualityhub` | `provar_qualityhub_connect`, `provar_qualityhub_display`, `provar_qualityhub_testrun`, `provar_qualityhub_testrun_abort`, `provar_qualityhub_testrun_report`, `provar_qualityhub_examples_retrieve`, `provar_qualityhub_testcase_retrieve`, `provar_qualityhub_defect_create` |
+| `validation` | `provar_project_validate`, `provar_ant_generate`, `provar_ant_validate`, `provar_properties_*`, `provar_testcase_validate`, `provar_testsuite_validate`, `provar_testplan_validate`, `provar_pageobject_validate`                                                             |
+| `authoring`  | `provar_testcase_generate`, `provar_pageobject_generate`, `provar_testcase_step_edit`, `provar_testplan_*`                                                                                                                                                                    |
+| `inspect`    | `provar_project_inspect`                                                                                                                                                                                                                                                      |
+| `connection` | `provar_connection_list`                                                                                                                                                                                                                                                      |
+| `rca`        | `provar_testrun_rca`, `provar_testrun_report_locate`                                                                                                                                                                                                                          |
+
+**Example — NitroX-only session:**
+
+```json
+{
+  "env": {
+    "PROVAR_MCP_TOOLS": "nitrox"
+  }
+}
+```
 
 ---
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -481,7 +481,7 @@ Two environment variables let you reduce the context budget consumed by the Prov
 PROVAR_MCP_SCHEMA_MODE=compact
 ```
 
-When set to `compact`, every tool description and parameter description is replaced with a short summary (typically ≤15 words). This can save hundreds of tokens per tool in the initial context handshake, at the cost of reduced in-description guidance for the agent.
+When set to `compact`, tool descriptions and parameter descriptions are replaced with short summaries (typically ≤15 words). This can save hundreds of tokens per tool in the initial context handshake, at the cost of reduced in-description guidance for the agent.
 
 Use this mode if:
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -481,7 +481,7 @@ Two environment variables let you reduce the context budget consumed by the Prov
 PROVAR_MCP_SCHEMA_MODE=compact
 ```
 
-When set to `compact`, tool descriptions and parameter descriptions are replaced with short summaries (typically ≤15 words). This can save hundreds of tokens per tool in the initial context handshake, at the cost of reduced in-description guidance for the agent.
+When set to `compact`, most tool and parameter descriptions are replaced with short summaries (typically ≤15 words). This can save hundreds of tokens per tool in the initial context handshake, at the cost of reduced in-description guidance for the agent.
 
 Use this mode if:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provartesting/provardx-cli",
   "description": "A plugin for the Salesforce CLI to orchestrate testing activities and report quality metrics to Provar Quality Hub",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "mcpName": "io.github.ProvarTesting/provar",
   "license": "BSD-3-Clause",
   "plugins": [

--- a/scripts/mcp-smoke.cjs
+++ b/scripts/mcp-smoke.cjs
@@ -3,7 +3,11 @@
 // PASS = JSON-RPC result received (tool responded; content may still contain an error code — that's fine)
 // FAIL = JSON-RPC error (protocol-level: unknown method, missing required arg, server crash, timeout)
 //
-// Usage:  node scripts/mcp-smoke.cjs [2>$null]
+// Usage:  node scripts/mcp-smoke.cjs [--profile <groups>] [2>$null]
+//         --profile  Comma-separated list of tool groups to exercise (default: all groups).
+//                    Group names match PROVAR_MCP_TOOLS values: nitrox, automation, qualityhub,
+//                    validation, authoring, inspect, connection, rca.
+//                    Example: node scripts/mcp-smoke.cjs --profile automation,qualityhub
 // Note:   Run with stderr suppressed to avoid sf update warnings mixing into output.
 //
 // Env flags:
@@ -22,6 +26,31 @@ const REQUEST_TIMEOUT_MS = Number(process.env['SMOKE_REQUEST_TIMEOUT_MS'] ?? 30_
 const OVERALL_TIMEOUT_MS = Number(process.env['SMOKE_OVERALL_TIMEOUT_MS'] ?? 120_000);
 const INCLUDE_SETUP = process.env['SMOKE_INCLUDE_SETUP'] === '1';
 
+// --profile flag: restrict which tool groups are exercised
+const profileArg = (() => {
+  const idx = process.argv.indexOf('--profile');
+  if (idx !== -1 && process.argv[idx + 1]) return process.argv[idx + 1];
+  const eq = process.argv.find((a) => a.startsWith('--profile='));
+  return eq ? eq.slice('--profile='.length) : null;
+})();
+const ACTIVE_GROUPS = profileArg
+  ? new Set(
+      profileArg
+        .split(',')
+        .map((g) => g.trim().toLowerCase())
+        .filter(Boolean)
+    )
+  : null;
+
+/** Returns true if the group should be exercised (profile includes it, or no profile set). */
+function inGroup(group) {
+  return ACTIVE_GROUPS === null || ACTIVE_GROUPS.has(group);
+}
+
+if (ACTIVE_GROUPS) {
+  console.log(`Profile: [${[...ACTIVE_GROUPS].join(', ')}] — skipping other groups`);
+}
+
 // ----------------------------------------------------------------------------
 // Server process
 // ----------------------------------------------------------------------------
@@ -31,6 +60,7 @@ const server = spawn('sf', ['provar', 'mcp', 'start', '--allowed-paths', TMP], {
   env: {
     ...process.env,
     PROVAR_DEV_WHITELIST_KEYS: process.env.PROVAR_DEV_WHITELIST_KEYS || '',
+    ...(ACTIVE_GROUPS ? { PROVAR_MCP_TOOLS: [...ACTIVE_GROUPS].join(',') } : {}),
   },
 });
 
@@ -76,7 +106,10 @@ overallTimer.unref(); // don't prevent natural exit if tests finish early
 // ----------------------------------------------------------------------------
 // RPC helpers (with per-request timeout)
 // ----------------------------------------------------------------------------
+let expectedCount = 0;
+
 function rpc(label, method, params) {
+  expectedCount++;
   return new Promise((resolve) => {
     const id = ++msgId;
     const timer = setTimeout(() => {
@@ -120,204 +153,224 @@ async function runTests() {
 
   // ── 3. provar_project_inspect ─────────────────────────────────────────────
   // TMP has no .testproject → structured "not a Provar project" response
-  await callTool('provar_project_inspect', { project_path: TMP });
+  if (inGroup('inspect')) await callTool('provar_project_inspect', { project_path: TMP });
 
   // ── 4. provar_pageobject_generate (dry_run) ───────────────────────────────
-  await callTool('provar_pageobject_generate', {
-    class_name: 'AccountDetailPage',
-    package_name: 'pageobjects.accounts',
-    page_type: 'standard',
-    dry_run: true,
-  });
+  if (inGroup('authoring'))
+    await callTool('provar_pageobject_generate', {
+      class_name: 'AccountDetailPage',
+      package_name: 'pageobjects.accounts',
+      page_type: 'standard',
+      dry_run: true,
+    });
 
   // ── 5. provar_pageobject_validate ─────────────────────────────────────────
-  await callTool('provar_pageobject_validate', {
-    content: 'public class AccountDetailPage {}',
-  });
+  if (inGroup('validation'))
+    await callTool('provar_pageobject_validate', {
+      content: 'public class AccountDetailPage {}',
+    });
 
   // ── 6. provar_testcase_generate (dry_run) ─────────────────────────────────
-  await callTool('provar_testcase_generate', {
-    test_case_name: 'Smoke Test Case',
-    dry_run: true,
-  });
+  if (inGroup('authoring'))
+    await callTool('provar_testcase_generate', {
+      test_case_name: 'Smoke Test Case',
+      dry_run: true,
+    });
 
   // ── 7. provar_testcase_validate ───────────────────────────────────────────
-  await callTool('provar_testcase_validate', { content: '<testCase/>' });
+  if (inGroup('validation')) await callTool('provar_testcase_validate', { content: '<testCase/>' });
 
   // ── 8. provar_testsuite_validate ──────────────────────────────────────────
-  await callTool('provar_testsuite_validate', { suite_name: 'SmokeTestSuite' });
+  if (inGroup('validation')) await callTool('provar_testsuite_validate', { suite_name: 'SmokeTestSuite' });
 
   // ── 9. provar_testplan_validate ───────────────────────────────────────────
-  await callTool('provar_testplan_validate', { plan_name: 'SmokeTestPlan' });
+  if (inGroup('validation')) await callTool('provar_testplan_validate', { plan_name: 'SmokeTestPlan' });
 
   // ── 10. provar_project_validate ───────────────────────────────────────────
   // TMP is not a Provar project → PATH_NOT_FOUND or NOT_A_PROJECT result
-  await callTool('provar_project_validate', { project_path: TMP });
+  if (inGroup('validation')) await callTool('provar_project_validate', { project_path: TMP });
 
   // ── 11. provar_properties_generate (dry_run) ──────────────────────────────
-  await callTool('provar_properties_generate', {
-    output_path: path.join(TMP, 'smoke-props.json'),
-    dry_run: true,
-  });
+  if (inGroup('validation'))
+    await callTool('provar_properties_generate', {
+      output_path: path.join(TMP, 'smoke-props.json'),
+      dry_run: true,
+    });
 
   // ── 12. provar_properties_read ────────────────────────────────────────────
   // Non-existent file → FILE_NOT_FOUND result
-  await callTool('provar_properties_read', {
-    file_path: path.join(TMP, 'nonexistent-props.json'),
-  });
+  if (inGroup('validation'))
+    await callTool('provar_properties_read', {
+      file_path: path.join(TMP, 'nonexistent-props.json'),
+    });
 
   // ── 13. provar_properties_set ─────────────────────────────────────────────
   // Non-existent file → FILE_NOT_FOUND result
-  await callTool('provar_properties_set', {
-    file_path: path.join(TMP, 'nonexistent-props.json'),
-    updates: { stopOnError: true },
-  });
+  if (inGroup('validation'))
+    await callTool('provar_properties_set', {
+      file_path: path.join(TMP, 'nonexistent-props.json'),
+      updates: { stopOnError: true },
+    });
 
   // ── 14. provar_properties_validate ───────────────────────────────────────
   // Empty JSON → validation issues about missing required fields
-  await callTool('provar_properties_validate', { content: '{}' });
+  if (inGroup('validation')) await callTool('provar_properties_validate', { content: '{}' });
 
   // ── 15. provar_ant_generate (dry_run) ─────────────────────────────────────
-  await callTool('provar_ant_generate', {
-    provar_home: path.join(TMP, 'provar'),
-    filesets: [{ dir: '../tests' }],
-    dry_run: true,
-  });
+  if (inGroup('validation'))
+    await callTool('provar_ant_generate', {
+      provar_home: path.join(TMP, 'provar'),
+      filesets: [{ dir: '../tests' }],
+      dry_run: true,
+    });
 
   // ── 16. provar_ant_validate ───────────────────────────────────────────────
   // Minimal XML — will have validation issues but not crash
-  await callTool('provar_ant_validate', { content: '<project/>' });
+  if (inGroup('validation')) await callTool('provar_ant_validate', { content: '<project/>' });
 
   // ── 17. provar_qualityhub_connect ─────────────────────────────────────────
   // No real org → SF_NOT_FOUND or auth error result
-  await callTool('provar_qualityhub_connect', { target_org: 'smoke-test-org' });
+  if (inGroup('qualityhub')) await callTool('provar_qualityhub_connect', { target_org: 'smoke-test-org' });
 
   // ── 18. provar_qualityhub_display ─────────────────────────────────────────
-  await callTool('provar_qualityhub_display', {});
+  if (inGroup('qualityhub')) await callTool('provar_qualityhub_display', {});
 
   // ── 19. provar_qualityhub_testrun ─────────────────────────────────────────
-  await callTool('provar_qualityhub_testrun', { target_org: 'smoke-test-org' });
+  if (inGroup('qualityhub')) await callTool('provar_qualityhub_testrun', { target_org: 'smoke-test-org' });
 
   // ── 20. provar_qualityhub_testrun_report ──────────────────────────────────
-  await callTool('provar_qualityhub_testrun_report', {
-    target_org: 'smoke-test-org',
-    run_id: 'fake-run-id-000',
-  });
+  if (inGroup('qualityhub'))
+    await callTool('provar_qualityhub_testrun_report', {
+      target_org: 'smoke-test-org',
+      run_id: 'fake-run-id-000',
+    });
 
   // ── 21. provar_qualityhub_testrun_abort ───────────────────────────────────
-  await callTool('provar_qualityhub_testrun_abort', {
-    target_org: 'smoke-test-org',
-    run_id: 'fake-run-id-000',
-  });
+  if (inGroup('qualityhub'))
+    await callTool('provar_qualityhub_testrun_abort', {
+      target_org: 'smoke-test-org',
+      run_id: 'fake-run-id-000',
+    });
 
   // ── 22. provar_qualityhub_testcase_retrieve ───────────────────────────────
-  await callTool('provar_qualityhub_testcase_retrieve', { target_org: 'smoke-test-org' });
+  if (inGroup('qualityhub')) await callTool('provar_qualityhub_testcase_retrieve', { target_org: 'smoke-test-org' });
 
   // ── 23. provar_qualityhub_defect_create ───────────────────────────────────
-  await callTool('provar_qualityhub_defect_create', {
-    run_id: 'fake-run-id-000',
-    target_org: 'smoke-test-org',
-  });
+  if (inGroup('qualityhub'))
+    await callTool('provar_qualityhub_defect_create', {
+      run_id: 'fake-run-id-000',
+      target_org: 'smoke-test-org',
+    });
 
   // ── 24. provar_automation_setup ───────────────────────────────────────────
   // Skipped by default: when no Provar installation is found on the CI runner,
   // this tool downloads the full Provar binary (~200 MB), which is a destructive
   // side effect in a smoke test. Enable with SMOKE_INCLUDE_SETUP=1.
-  if (INCLUDE_SETUP) {
+  if (INCLUDE_SETUP && inGroup('automation')) {
     await callTool('provar_automation_setup', {});
   }
 
   // ── 25. provar_automation_metadata_download ───────────────────────────────
-  await callTool('provar_automation_metadata_download', {});
+  if (inGroup('automation')) await callTool('provar_automation_metadata_download', {});
 
   // ── 26. provar_automation_compile ─────────────────────────────────────────
-  await callTool('provar_automation_compile', {});
+  if (inGroup('automation')) await callTool('provar_automation_compile', {});
 
   // ── 27. provar_automation_testrun ─────────────────────────────────────────
-  await callTool('provar_automation_testrun', {});
+  if (inGroup('automation')) await callTool('provar_automation_testrun', {});
 
   // ── 28. provar_automation_config_load ─────────────────────────────────────
-  await callTool('provar_automation_config_load', {
-    properties_path: path.join(TMP, 'nonexistent-props.json'),
-  });
+  if (inGroup('automation'))
+    await callTool('provar_automation_config_load', {
+      properties_path: path.join(TMP, 'nonexistent-props.json'),
+    });
 
   // ── 29. provar_testrun_report_locate ─────────────────────────────────────
   // TMP is not a Provar project → RESULTS_NOT_CONFIGURED result
-  await callTool('provar_testrun_report_locate', { project_path: TMP });
+  if (inGroup('rca')) await callTool('provar_testrun_report_locate', { project_path: TMP });
 
   // ── 30. provar_testrun_rca ───────────────────────────────────────────────
-  await callTool('provar_testrun_rca', { project_path: TMP });
+  if (inGroup('rca')) await callTool('provar_testrun_rca', { project_path: TMP });
 
   // ── 31. provar_testplan_create ────────────────────────────────────────────
   // TMP is not a Provar project → NOT_A_PROJECT result
-  await callTool('provar_testplan_create', {
-    project_path: TMP,
-    plan_name: 'SmokePlan',
-  });
+  if (inGroup('authoring'))
+    await callTool('provar_testplan_create', {
+      project_path: TMP,
+      plan_name: 'SmokePlan',
+    });
 
   // ── 32. provar_testplan_add-instance ─────────────────────────────────────
   // TMP is not a Provar project → NOT_A_PROJECT result
-  await callTool('provar_testplan_add-instance', {
-    project_path: TMP,
-    test_case_path: 'tests/Smoke/SmokeTest.testcase',
-    plan_name: 'SmokePlan',
-  });
+  if (inGroup('authoring'))
+    await callTool('provar_testplan_add-instance', {
+      project_path: TMP,
+      test_case_path: 'tests/Smoke/SmokeTest.testcase',
+      plan_name: 'SmokePlan',
+    });
 
   // ── 33. provar_testplan_create-suite ─────────────────────────────────────
-  await callTool('provar_testplan_create-suite', {
-    project_path: TMP,
-    plan_name: 'SmokePlan',
-    suite_name: 'SmokeSuite',
-  });
+  if (inGroup('authoring'))
+    await callTool('provar_testplan_create-suite', {
+      project_path: TMP,
+      plan_name: 'SmokePlan',
+      suite_name: 'SmokeSuite',
+    });
 
   // ── 34. provar_testplan_remove-instance ──────────────────────────────────
-  await callTool('provar_testplan_remove-instance', {
-    project_path: TMP,
-    instance_path: 'plans/SmokePlan/SmokeSuite/smoke.testinstance',
-  });
+  if (inGroup('authoring'))
+    await callTool('provar_testplan_remove-instance', {
+      project_path: TMP,
+      instance_path: 'plans/SmokePlan/SmokeSuite/smoke.testinstance',
+    });
 
   // ── 35. provar_nitrox_discover ────────────────────────────────────────────
   // TMP has no .testproject → empty projects list, no crash
-  await callTool('provar_nitrox_discover', { search_roots: [TMP] });
+  if (inGroup('nitrox')) await callTool('provar_nitrox_discover', { search_roots: [TMP] });
 
   // ── 36. provar_nitrox_validate ────────────────────────────────────────────
   // Minimal valid root component → score 100
-  await callTool('provar_nitrox_validate', {
-    content: JSON.stringify({
-      componentId: '550e8400-e29b-41d4-a716-446655440000',
-      name: '/com/smoke/SmokeComponent',
-      type: 'Block',
-      pageStructureElement: true,
-      fieldDetailsElement: false,
-    }),
-  });
+  if (inGroup('nitrox'))
+    await callTool('provar_nitrox_validate', {
+      content: JSON.stringify({
+        componentId: '550e8400-e29b-41d4-a716-446655440000',
+        name: '/com/smoke/SmokeComponent',
+        type: 'Block',
+        pageStructureElement: true,
+        fieldDetailsElement: false,
+      }),
+    });
 
   // ── 36. provar_nitrox_generate (dry_run) ─────────────────────────────────
-  await callTool('provar_nitrox_generate', {
-    name: '/com/smoke/SmokeComponent',
-    tag_name: 'c-smoke',
-    dry_run: true,
-  });
+  if (inGroup('nitrox'))
+    await callTool('provar_nitrox_generate', {
+      name: '/com/smoke/SmokeComponent',
+      tag_name: 'c-smoke',
+      dry_run: true,
+    });
 
   // ── 37. provar_nitrox_read ────────────────────────────────────────────────
   // Non-existent file → FILE_NOT_FOUND result (not a protocol error)
-  await callTool('provar_nitrox_read', {
-    file_paths: [path.join(TMP, 'nonexistent.po.json')],
-  });
+  if (inGroup('nitrox'))
+    await callTool('provar_nitrox_read', {
+      file_paths: [path.join(TMP, 'nonexistent.po.json')],
+    });
 
   // ── 38. provar_nitrox_patch ───────────────────────────────────────────────
   // Non-existent file → FILE_NOT_FOUND result (not a protocol error)
-  await callTool('provar_nitrox_patch', {
-    file_path: path.join(TMP, 'nonexistent.po.json'),
-    patch: { name: '/com/smoke/Patched' },
-  });
+  if (inGroup('nitrox'))
+    await callTool('provar_nitrox_patch', {
+      file_path: path.join(TMP, 'nonexistent.po.json'),
+      patch: { name: '/com/smoke/Patched' },
+    });
 
   // ── 39. provar_qualityhub_examples_retrieve ───────────────────────────────
   // No API key in CI → graceful degrade with warning, empty examples (isError: false)
-  await callTool('provar_qualityhub_examples_retrieve', {
-    query: 'As a sales rep I want to create an Opportunity in Salesforce',
-    n: 3,
-  });
+  if (inGroup('qualityhub'))
+    await callTool('provar_qualityhub_examples_retrieve', {
+      query: 'As a sales rep I want to create an Opportunity in Salesforce',
+      n: 3,
+    });
 
   // ── 40. prompts/list ──────────────────────────────────────────────────────
   await send('prompts/list', {});
@@ -383,15 +436,16 @@ async function runTests() {
 
   // ── 52. provar_connection_list ────────────────────────────────────────────
   // TMP has no .testproject → CONNECTION_FILE_NOT_FOUND result (not a protocol error)
-  await callTool('provar_connection_list', { project_path: TMP });
+  if (inGroup('connection')) await callTool('provar_connection_list', { project_path: TMP });
 
   // ── 53. provar_testcase_step_edit ─────────────────────────────────────────
   // TMP/nonexistent.testcase does not exist → FILE_NOT_FOUND result
-  await callTool('provar_testcase_step_edit', {
-    test_case_path: path.join(TMP, 'nonexistent.testcase'),
-    mode: 'remove',
-    test_item_id: '1',
-  });
+  if (inGroup('authoring'))
+    await callTool('provar_testcase_step_edit', {
+      test_case_path: path.join(TMP, 'nonexistent.testcase'),
+      mode: 'remove',
+      test_item_id: '1',
+    });
 
   server.stdin.end();
 }
@@ -401,8 +455,7 @@ async function runTests() {
 // ----------------------------------------------------------------------------
 server.on('close', () => {
   clearTimeout(overallTimer);
-  // initialize + tools/list + 40 tools + prompts/list + 11 prompts/get (setup excluded from default count)
-  const TOTAL_EXPECTED = 54 + (INCLUDE_SETUP ? 1 : 0);
+  const TOTAL_EXPECTED = expectedCount;
   let passed = 0;
   let failed = 0;
 

--- a/server.json
+++ b/server.json
@@ -14,12 +14,12 @@
     "url": "https://github.com/ProvarTesting/provardx-cli",
     "source": "github"
   },
-  "version": "1.5.0",
+  "version": "1.5.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@provartesting/provardx-cli",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -35,6 +35,33 @@ import { registerAllNitroXTools } from './tools/nitroXTools.js';
 import { registerAllTestCaseStepTools } from './tools/testCaseStepTools.js';
 import { registerAllConnectionTools } from './tools/connectionTools.js';
 import { registerAllPrompts } from './prompts/index.js';
+import { desc } from './tools/descHelper.js';
+
+// ── Tool group registry ───────────────────────────────────────────────────────
+// Groups are keyed in lowercase so they match the lowercased env var values.
+const TOOL_GROUPS: Record<string, Array<(server: McpServer, config: ServerConfig) => void>> = {
+  nitrox: [registerAllNitroXTools],
+  automation: [registerAllAutomationTools],
+  qualityhub: [registerAllQualityHubTools, registerAllQualityHubApiTools, registerAllDefectTools],
+  validation: [
+    registerProjectValidateFromPath,
+    registerAllAntTools,
+    registerAllPropertiesTools,
+    registerTestCaseValidate,
+    registerTestSuiteValidate,
+    registerTestPlanValidate,
+    registerPageObjectValidate,
+  ],
+  authoring: [
+    registerTestCaseGenerate,
+    registerPageObjectGenerate,
+    registerAllTestCaseStepTools,
+    registerAllTestPlanTools,
+  ],
+  inspect: [registerProjectInspect],
+  connection: [registerAllConnectionTools],
+  rca: [registerAllRcaTools],
+};
 
 export interface ServerConfig {
   allowedPaths: string[];
@@ -43,6 +70,17 @@ export interface ServerConfig {
     latestVersion: string | null;
     updateCommand: string | null;
   };
+}
+
+export function parseActiveGroups(): Set<string> | null {
+  const env = process.env['PROVAR_MCP_TOOLS'];
+  if (!env?.trim()) return null;
+  return new Set(
+    env
+      .split(',')
+      .map((g) => g.trim().toLowerCase())
+      .filter(Boolean)
+  );
 }
 
 export function createProvarMcpServer(config: ServerConfig): McpServer {
@@ -58,8 +96,10 @@ export function createProvarMcpServer(config: ServerConfig): McpServer {
     'provardx_ping',
     {
       title: 'Ping MCP Server',
-      description:
+      description: desc(
         'Sanity-check tool. Echoes back a message with a timestamp. Use this to verify the MCP server is reachable before calling other tools.',
+        'Echo message back with timestamp; verify MCP server is reachable.'
+      ),
       inputSchema: {
         message: z.string().optional().default('ping').describe('Optional message to echo back'),
       },
@@ -81,25 +121,14 @@ export function createProvarMcpServer(config: ServerConfig): McpServer {
   );
 
   // ── Provar tools ─────────────────────────────────────────────────────────────
-  registerProjectInspect(server, config);
-  registerPageObjectGenerate(server, config);
-  registerPageObjectValidate(server, config);
-  registerTestCaseGenerate(server, config);
-  registerTestCaseValidate(server, config);
-  registerTestSuiteValidate(server);
-  registerTestPlanValidate(server);
-  registerProjectValidateFromPath(server, config);
-  registerAllPropertiesTools(server, config);
-  registerAllQualityHubTools(server);
-  registerAllQualityHubApiTools(server);
-  registerAllAutomationTools(server, config);
-  registerAllDefectTools(server);
-  registerAllAntTools(server, config);
-  registerAllRcaTools(server, config);
-  registerAllTestPlanTools(server, config);
-  registerAllNitroXTools(server, config);
-  registerAllTestCaseStepTools(server, config);
-  registerAllConnectionTools(server, config);
+  const activeGroups = parseActiveGroups();
+  for (const [group, registrars] of Object.entries(TOOL_GROUPS)) {
+    if (activeGroups === null || activeGroups.has(group)) {
+      for (const register of registrars) {
+        register(server, config);
+      }
+    }
+  }
 
   // ── Provar prompts ───────────────────────────────────────────────────────────
   registerAllPrompts(server);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -75,12 +75,17 @@ export interface ServerConfig {
 export function parseActiveGroups(): Set<string> | null {
   const env = process.env['PROVAR_MCP_TOOLS'];
   if (!env?.trim()) return null;
-  return new Set(
+  const groups = new Set(
     env
       .split(',')
       .map((g) => g.trim().toLowerCase())
       .filter(Boolean)
   );
+  if (groups.size === 0) {
+    log('warn', 'PROVAR_MCP_TOOLS was set but contained no valid group names — activating all groups', { raw: env });
+    return null;
+  }
+  return groups;
 }
 
 export function createProvarMcpServer(config: ServerConfig): McpServer {
@@ -101,7 +106,11 @@ export function createProvarMcpServer(config: ServerConfig): McpServer {
         'Echo message back with timestamp; verify MCP server is reachable.'
       ),
       inputSchema: {
-        message: z.string().optional().default('ping').describe('Optional message to echo back'),
+        message: z
+          .string()
+          .optional()
+          .default('ping')
+          .describe(desc('Optional message to echo back', 'message to echo')),
       },
     },
     ({ message }) => {

--- a/src/mcp/tools/antTools.ts
+++ b/src/mcp/tools/antTools.ts
@@ -15,6 +15,7 @@ import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { makeError, makeRequestId, type ValidationIssue } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
+import { desc } from './descHelper.js';
 
 // ── Sub-schemas ───────────────────────────────────────────────────────────────
 
@@ -70,72 +71,109 @@ export function registerAntGenerate(server: McpServer, config: ServerConfig): vo
     'provar_ant_generate',
     {
       title: 'Generate ANT Build File',
-      description: [
-        'Generate a Provar ANT build.xml file.',
-        'Produces the standard <project> skeleton with Provar-Compile and Run-Test-Case tasks.',
-        'Supports targeting tests by project folder, plan folder, or specific .testcase files via filesets.',
-        'Returns XML content. Writes to disk only when dry_run=false.',
-      ].join(' '),
+      description: desc(
+        [
+          'Generate a Provar ANT build.xml file.',
+          'Produces the standard <project> skeleton with Provar-Compile and Run-Test-Case tasks.',
+          'Supports targeting tests by project folder, plan folder, or specific .testcase files via filesets.',
+          'Returns XML content. Writes to disk only when dry_run=false.',
+        ].join(' '),
+        'Generate a Provar ANT build.xml with Provar-Compile and Run-Test-Case tasks.'
+      ),
       inputSchema: {
         // ── Core paths ──────────────────────────────────────────────────────────
         provar_home: z
           .string()
           .describe(
-            'Absolute path to the Provar installation directory (e.g. "C:/Program Files/Provar/"). Used for provar.home property and ant taskdef classpaths.'
+            desc(
+              'Absolute path to the Provar installation directory (e.g. "C:/Program Files/Provar/"). Used for provar.home property and ant taskdef classpaths.',
+              'string, absolute path to Provar installation'
+            )
           ),
         project_path: z
           .string()
           .default('..')
-          .describe('Path to the Provar test project root. Defaults to ".." (parent of the ANT folder).'),
+          .describe(
+            desc(
+              'Path to the Provar test project root. Defaults to ".." (parent of the ANT folder).',
+              'string, path to project root'
+            )
+          ),
         results_path: z
           .string()
           .default('../ANT/Results')
-          .describe('Path where test results are written. Defaults to "../ANT/Results".'),
+          .describe(
+            desc('Path where test results are written. Defaults to "../ANT/Results".', 'string, path for test results')
+          ),
         project_cache_path: z
           .string()
           .optional()
           .describe(
-            'Path to the .provarCaches directory. Defaults to "../../.provarCaches" relative to the ANT folder.'
+            desc(
+              'Path to the .provarCaches directory. Defaults to "../../.provarCaches" relative to the ANT folder.',
+              'string, optional; path to .provarCaches'
+            )
           ),
         license_path: z
           .string()
           .optional()
-          .describe('Path to the Provar .licenses directory (e.g. "${env.PROVAR_HOME}/.licenses").'),
+          .describe(
+            desc(
+              'Path to the Provar .licenses directory (e.g. "${env.PROVAR_HOME}/.licenses").',
+              'string, optional; path to .licenses dir'
+            )
+          ),
         smtp_path: z
           .string()
           .optional()
-          .describe('Path to the Provar .smtp directory (e.g. "${env.PROVAR_HOME}/.smtp").'),
+          .describe(
+            desc(
+              'Path to the Provar .smtp directory (e.g. "${env.PROVAR_HOME}/.smtp").',
+              'string, optional; path to .smtp dir'
+            )
+          ),
 
         // ── Test selection ──────────────────────────────────────────────────────
         filesets: z
           .array(FilesetSchema)
           .min(1)
           .describe(
-            'One or more filesets defining which tests to run. ' +
-              'To run all tests under a folder: { dir: "../tests" }. ' +
-              'To run a plan: { id: "testplan", dir: "../plans/MyPlan" }. ' +
-              'To run specific test cases: { dir: "../tests/Suite", includes: ["MyTest.testcase"] }.'
+            desc(
+              'One or more filesets defining which tests to run. ' +
+                'To run all tests under a folder: { dir: "../tests" }. ' +
+                'To run a plan: { id: "testplan", dir: "../plans/MyPlan" }. ' +
+                'To run specific test cases: { dir: "../tests/Suite", includes: ["MyTest.testcase"] }.',
+              'array, min 1; filesets defining which tests to run'
+            )
           ),
 
         // ── Browser / environment ───────────────────────────────────────────────
         web_browser: z
           .enum(['Chrome', 'Chrome_Headless', 'Firefox', 'Edge', 'Edge_Legacy', 'Safari', 'IE'])
           .default('Chrome')
-          .describe('Web browser to use for test execution.'),
+          .describe(
+            desc('Web browser to use for test execution.', 'enum Chrome|Chrome_Headless|Firefox|Edge|Safari|IE')
+          ),
         web_browser_configuration: z
           .string()
           .default('Full Screen')
-          .describe('Browser window configuration (e.g. "Full Screen").'),
-        web_browser_provider_name: z.string().default('Desktop').describe('Browser provider name (e.g. "Desktop").'),
+          .describe(desc('Browser window configuration (e.g. "Full Screen").', 'string, browser window config')),
+        web_browser_provider_name: z
+          .string()
+          .default('Desktop')
+          .describe(desc('Browser provider name (e.g. "Desktop").', 'string, browser provider name')),
         web_browser_device_name: z
           .string()
           .default('Full Screen')
-          .describe('Browser device name (e.g. "Full Screen").'),
+          .describe(desc('Browser device name (e.g. "Full Screen").', 'string, browser device name')),
         test_environment: z
           .string()
           .default('')
           .describe(
-            'Named test environment to use (must match a connection in the project). Empty string uses default.'
+            desc(
+              'Named test environment to use (must match a connection in the project). Empty string uses default.',
+              'string, optional; named test environment'
+            )
           ),
 
         // ── Cache / metadata ────────────────────────────────────────────────────
@@ -143,7 +181,10 @@ export function registerAntGenerate(server: McpServer, config: ServerConfig): vo
           .enum(['Reuse', 'Refresh', 'Reload'])
           .default('Reuse')
           .describe(
-            'Salesforce metadata cache strategy: Reuse (fastest, uses cached), Refresh (re-downloads), Reload (clears and re-downloads).'
+            desc(
+              'Salesforce metadata cache strategy: Reuse (fastest, uses cached), Refresh (re-downloads), Reload (clears and re-downloads).',
+              'enum Reuse|Refresh|Reload'
+            )
           ),
 
         // ── Output / logging ────────────────────────────────────────────────────
@@ -151,79 +192,132 @@ export function registerAntGenerate(server: McpServer, config: ServerConfig): vo
           .enum(['Increment', 'Replace', 'Reuse'])
           .default('Increment')
           .describe(
-            'How to handle the results folder when it already exists: Increment (new subfolder), Replace (overwrite), Reuse (append).'
+            desc(
+              'How to handle the results folder when it already exists: Increment (new subfolder), Replace (overwrite), Reuse (append).',
+              'enum Increment|Replace|Reuse'
+            )
           ),
         test_output_level: z
           .enum(['BASIC', 'WARNING', 'DEBUG'])
           .default('BASIC')
-          .describe('Verbosity level for test output logs.'),
+          .describe(desc('Verbosity level for test output logs.', 'enum BASIC|WARNING|DEBUG')),
         plugin_output_level: z
           .enum(['BASIC', 'WARNING', 'DEBUG'])
           .default('WARNING')
-          .describe('Verbosity level for plugin output logs.'),
+          .describe(desc('Verbosity level for plugin output logs.', 'enum BASIC|WARNING|DEBUG')),
 
         // ── Execution behaviour ─────────────────────────────────────────────────
         stop_test_run_on_error: z
           .boolean()
           .default(false)
-          .describe('Abort the entire test run when any test case fails.'),
+          .describe(desc('Abort the entire test run when any test case fails.', 'bool, optional; abort on failure')),
         exclude_callable_test_cases: z
           .boolean()
           .default(true)
-          .describe('Skip test cases marked as callable (library/helper) when true.'),
+          .describe(
+            desc(
+              'Skip test cases marked as callable (library/helper) when true.',
+              'bool, optional; skip callable tests'
+            )
+          ),
         dont_fail_build: z
           .boolean()
           .optional()
           .describe(
-            'When true, the ANT build does not fail even if tests fail. Useful for CI pipelines that collect results separately.'
+            desc(
+              'When true, the ANT build does not fail even if tests fail. Useful for CI pipelines that collect results separately.',
+              'bool, optional; skip build failure on test fail'
+            )
           ),
-        invoke_test_run_monitor: z.boolean().default(true).describe('Enable the Provar test run monitor.'),
+        invoke_test_run_monitor: z
+          .boolean()
+          .default(true)
+          .describe(desc('Enable the Provar test run monitor.', 'bool, optional; enable test run monitor')),
 
         // ── Secrets / security ──────────────────────────────────────────────────
         secrets_password: z
           .string()
           .default('${env.ProvarSecretsPassword}')
           .describe(
-            'Encryption key used to decrypt the Provar .secrets file (the password string itself, not a file path). Defaults to reading from the ProvarSecretsPassword environment variable.'
+            desc(
+              'Encryption key used to decrypt the Provar .secrets file (the password string itself, not a file path). Defaults to reading from the ProvarSecretsPassword environment variable.',
+              'string, NOT a file path; encryption key for .secrets'
+            )
           ),
         test_environment_secrets_password: z
           .string()
           .optional()
           .describe(
-            'Per-environment secrets password. Defaults to reading from the ProvarSecretsPassword_EnvName environment variable.'
+            desc(
+              'Per-environment secrets password. Defaults to reading from the ProvarSecretsPassword_EnvName environment variable.',
+              'string, optional; per-environment secrets key'
+            )
           ),
 
         // ── Test Cycle ──────────────────────────────────────────────────────────
-        test_cycle_path: z.string().optional().describe('Path to a TestCycle folder (used with test cycle reporting).'),
+        test_cycle_path: z
+          .string()
+          .optional()
+          .describe(
+            desc(
+              'Path to a TestCycle folder (used with test cycle reporting).',
+              'string, optional; path to TestCycle folder'
+            )
+          ),
         test_cycle_run_type: z
           .enum(['ALL', 'FAILED', 'NEW'])
           .optional()
-          .describe('Which tests in the cycle to run (ALL, FAILED, NEW).'),
+          .describe(desc('Which tests in the cycle to run (ALL, FAILED, NEW).', 'enum ALL|FAILED|NEW, optional')),
 
         // ── Plan features ───────────────────────────────────────────────────────
         plan_features: z
           .array(PlanFeatureSchema)
           .optional()
           .describe(
-            'Output and notification features to enable/disable (e.g. PDF, PIECHART, EMAIL). ' +
-              'Only meaningful when running by test plan.'
+            desc(
+              'Output and notification features to enable/disable (e.g. PDF, PIECHART, EMAIL). ' +
+                'Only meaningful when running by test plan.',
+              'array, optional; plan output/notification features'
+            )
           ),
 
         // ── Email / attachment reporting ────────────────────────────────────────
         email_properties: EmailPropertiesSchema.optional().describe(
-          'Email notification settings. Omit to exclude <emailProperties> from the XML.'
+          desc(
+            'Email notification settings. Omit to exclude <emailProperties> from the XML.',
+            'object, optional; email notification settings'
+          )
         ),
         attachment_properties: AttachmentPropertiesSchema.optional().describe(
-          'Attachment/report content settings. Omit to exclude <attachmentProperties> from the XML.'
+          desc(
+            'Attachment/report content settings. Omit to exclude <attachmentProperties> from the XML.',
+            'object, optional; attachment/report content settings'
+          )
         ),
 
         // ── File output ─────────────────────────────────────────────────────────
         output_path: z
           .string()
           .optional()
-          .describe('Where to write the build.xml file (returned in response). Required when dry_run=false.'),
-        overwrite: z.boolean().default(false).describe('Overwrite output_path if the file already exists.'),
-        dry_run: z.boolean().default(true).describe('true = return XML only (default); false = write to output_path.'),
+          .describe(
+            desc(
+              'Where to write the build.xml file (returned in response). Required when dry_run=false.',
+              'string, optional; absolute path for build.xml output'
+            )
+          ),
+        overwrite: z
+          .boolean()
+          .default(false)
+          .describe(desc('Overwrite output_path if the file already exists.', 'bool, optional; overwrite if exists')),
+        dry_run: z
+          .boolean()
+          .default(true)
+          .describe(
+            desc(
+              'true = return XML only (default); false = write to output_path.',
+              'bool, optional; true=return only, false=write'
+            )
+          ),
       },
     },
     (input) => {
@@ -299,15 +393,24 @@ export function registerAntValidate(server: McpServer, config: ServerConfig): vo
     'provar_ant_validate',
     {
       title: 'Validate ANT Build File',
-      description: [
-        'Validate a Provar ANT build.xml for structural correctness.',
-        'Checks XML well-formedness, required <taskdef> declarations, <Provar-Compile> step,',
-        '<Run-Test-Case> with required attributes (provarHome, projectPath, resultsPath),',
-        'and at least one <fileset> child. Returns is_valid, issues list, and a validity_score.',
-      ].join(' '),
+      description: desc(
+        [
+          'Validate a Provar ANT build.xml for structural correctness.',
+          'Checks XML well-formedness, required <taskdef> declarations, <Provar-Compile> step,',
+          '<Run-Test-Case> with required attributes (provarHome, projectPath, resultsPath),',
+          'and at least one <fileset> child. Returns is_valid, issues list, and a validity_score.',
+        ].join(' '),
+        'Validate a Provar ANT build.xml for structural correctness.'
+      ),
       inputSchema: {
-        content: z.string().optional().describe('XML content to validate directly'),
-        file_path: z.string().optional().describe('Path to the build.xml file to validate'),
+        content: z
+          .string()
+          .optional()
+          .describe(desc('XML content to validate directly', 'string, optional; inline XML')),
+        file_path: z
+          .string()
+          .optional()
+          .describe(desc('Path to the build.xml file to validate', 'string, optional; absolute path to build.xml')),
       },
     },
     ({ content, file_path }) => {

--- a/src/mcp/tools/automationTools.ts
+++ b/src/mcp/tools/automationTools.ts
@@ -17,6 +17,7 @@ import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { parseJUnitResults } from './antTools.js';
 import { runSfCommand } from './sfSpawn.js';
+import { desc } from './descHelper.js';
 
 // Re-export sf resolution helpers so existing test imports from automationTools continue to work
 export { getSfCommonPaths, needsWindowsShell, setSfPathCacheForTesting, setSfPlatformForTesting } from './sfSpawn.js';
@@ -46,20 +47,33 @@ export function registerAutomationConfigLoad(server: McpServer, config: ServerCo
     'provar_automation_config_load',
     {
       title: 'Load Automation Config',
-      description: [
-        'Register a provardx-properties.json file as the active Provar configuration.',
-        'Invokes `sf provar automation config load --properties-file <path>`, writing the path to ~/.sf/config.json.',
-        'REQUIRED before provar_automation_compile or provar_automation_testrun — without this step those commands fail with MISSING_FILE.',
-        'Typical workflow: provar_automation_config_load → provar_automation_compile → provar_automation_testrun.',
-      ].join(' '),
+      description: desc(
+        [
+          'Register a provardx-properties.json file as the active Provar configuration.',
+          'Invokes `sf provar automation config load --properties-file <path>`, writing the path to ~/.sf/config.json.',
+          'REQUIRED before provar_automation_compile or provar_automation_testrun — without this step those commands fail with MISSING_FILE.',
+          'Typical workflow: provar_automation_config_load → provar_automation_compile → provar_automation_testrun.',
+        ].join(' '),
+        'Register a provardx-properties.json as active config; required before compile/testrun.'
+      ),
       inputSchema: {
         properties_path: z
           .string()
-          .describe('Absolute path to the provardx-properties.json file to register as active configuration'),
+          .describe(
+            desc(
+              'Absolute path to the provardx-properties.json file to register as active configuration',
+              'string, absolute path to provardx-properties.json'
+            )
+          ),
         sf_path: z
           .string()
           .optional()
-          .describe('Path to the sf CLI executable when not in PATH (e.g. "~/.nvm/versions/node/v22.0.0/bin/sf")'),
+          .describe(
+            desc(
+              'Path to the sf CLI executable when not in PATH (e.g. "~/.nvm/versions/node/v22.0.0/bin/sf")',
+              'string, optional; path to sf CLI'
+            )
+          ),
       },
     },
     ({ properties_path, sf_path }) => {
@@ -217,26 +231,39 @@ export function registerAutomationTestRun(server: McpServer, config: ServerConfi
     'provar_automation_testrun',
     {
       title: 'Run Tests',
-      description: [
-        'Trigger a LOCAL Provar automation test run using installed Provar binaries. Invokes `sf provar automation test run`.',
-        'PREREQUISITE: Run provar_automation_config_load first to register a provardx-properties.json — without this the command fails with MISSING_FILE.',
-        'Requires Provar to be installed locally and provarHome set correctly in the properties file.',
-        'Use provar_automation_setup first if Provar is not yet installed.',
-        'For grid/CI execution via Provar Quality Hub instead of running locally, use provar_qualityhub_testrun.',
-        'Output buffer: a 50 MB maxBuffer is set so ENOBUFS on verbose Provar runs is now rare.',
-        'If ENOBUFS still occurs (extremely verbose logging), run `sf provar automation test run --json` directly in the terminal and pipe or tail the output instead of retrying this tool.',
-        'Typical local AI loop: config.load → compile → testrun → inspect results.',
-      ].join(' '),
+      description: desc(
+        [
+          'Trigger a LOCAL Provar automation test run using installed Provar binaries. Invokes `sf provar automation test run`.',
+          'PREREQUISITE: Run provar_automation_config_load first to register a provardx-properties.json — without this the command fails with MISSING_FILE.',
+          'Requires Provar to be installed locally and provarHome set correctly in the properties file.',
+          'Use provar_automation_setup first if Provar is not yet installed.',
+          'For grid/CI execution via Provar Quality Hub instead of running locally, use provar_qualityhub_testrun.',
+          'Output buffer: a 50 MB maxBuffer is set so ENOBUFS on verbose Provar runs is now rare.',
+          'If ENOBUFS still occurs (extremely verbose logging), run `sf provar automation test run --json` directly in the terminal and pipe or tail the output instead of retrying this tool.',
+          'Typical local AI loop: config.load → compile → testrun → inspect results.',
+        ].join(' '),
+        'Run local Provar tests via sf CLI; requires config_load first.'
+      ),
       inputSchema: {
         flags: z
           .array(z.string())
           .optional()
           .default([])
-          .describe('Raw CLI flags to forward (e.g. ["--project-path", "/path/to/project"])'),
+          .describe(
+            desc(
+              'Raw CLI flags to forward (e.g. ["--project-path", "/path/to/project"])',
+              'array, optional; raw CLI flags'
+            )
+          ),
         sf_path: z
           .string()
           .optional()
-          .describe('Path to the sf CLI executable when not in PATH (e.g. "~/.nvm/versions/node/v22.0.0/bin/sf")'),
+          .describe(
+            desc(
+              'Path to the sf CLI executable when not in PATH (e.g. "~/.nvm/versions/node/v22.0.0/bin/sf")',
+              'string, optional; path to sf CLI'
+            )
+          ),
       },
     },
     ({ flags, sf_path }) => {
@@ -296,21 +323,34 @@ export function registerAutomationCompile(server: McpServer): void {
     'provar_automation_compile',
     {
       title: 'Compile Test Assets',
-      description: [
-        'Compile a Provar automation project. Invokes `sf provar automation project compile`.',
-        'PREREQUISITE: Run provar_automation_config_load first to register a provardx-properties.json — without this the command fails with MISSING_FILE.',
-        'Run this before triggering a test run after modifying test cases.',
-      ].join(' '),
+      description: desc(
+        [
+          'Compile a Provar automation project. Invokes `sf provar automation project compile`.',
+          'PREREQUISITE: Run provar_automation_config_load first to register a provardx-properties.json — without this the command fails with MISSING_FILE.',
+          'Run this before triggering a test run after modifying test cases.',
+        ].join(' '),
+        'Compile a Provar project; requires config_load first.'
+      ),
       inputSchema: {
         flags: z
           .array(z.string())
           .optional()
           .default([])
-          .describe('Raw CLI flags to forward (e.g. ["--project-path", "/path/to/project"])'),
+          .describe(
+            desc(
+              'Raw CLI flags to forward (e.g. ["--project-path", "/path/to/project"])',
+              'array, optional; raw CLI flags'
+            )
+          ),
         sf_path: z
           .string()
           .optional()
-          .describe('Path to the sf CLI executable when not in PATH (e.g. "~/.nvm/versions/node/v22.0.0/bin/sf")'),
+          .describe(
+            desc(
+              'Path to the sf CLI executable when not in PATH (e.g. "~/.nvm/versions/node/v22.0.0/bin/sf")',
+              'string, optional; path to sf CLI'
+            )
+          ),
       },
     },
     ({ flags, sf_path }) => {
@@ -355,27 +395,38 @@ export function registerAutomationMetadataDownload(server: McpServer): void {
     'provar_automation_metadata_download',
     {
       title: 'Download Salesforce Metadata',
-      description: [
-        'Download Salesforce metadata for one or more connections into a Provar project.',
-        'Invokes `sf provar automation metadata download`.',
-        'PREREQUISITE: Call provar_automation_config_load first — without it the command fails with MISSING_FILE.',
-        'Use the -c flag to specify connections: flags: ["-c", "ConnectionName1,ConnectionName2"].',
-        'Connection names are case-sensitive and must match the names defined in the Provar project.',
-        'If the download fails with [DOWNLOAD_ERROR], this is almost always a Salesforce authentication issue —',
-        'check that the credentials in the project .secrets file are current and that any referenced scratch orgs have not expired.',
-      ].join(' '),
+      description: desc(
+        [
+          'Download Salesforce metadata for one or more connections into a Provar project.',
+          'Invokes `sf provar automation metadata download`.',
+          'PREREQUISITE: Call provar_automation_config_load first — without it the command fails with MISSING_FILE.',
+          'Use the -c flag to specify connections: flags: ["-c", "ConnectionName1,ConnectionName2"].',
+          'Connection names are case-sensitive and must match the names defined in the Provar project.',
+          'If the download fails with [DOWNLOAD_ERROR], this is almost always a Salesforce authentication issue —',
+          'check that the credentials in the project .secrets file are current and that any referenced scratch orgs have not expired.',
+        ].join(' '),
+        'Download Salesforce metadata for project connections; requires config_load first.'
+      ),
       inputSchema: {
         flags: z
           .array(z.string())
           .optional()
           .default([])
           .describe(
-            'Raw CLI flags to forward. Use ["-c", "Name1,Name2"] (or the equivalent --connections form) to target specific connections. Example: ["-c", "MyOrg,SandboxOrg"]'
+            desc(
+              'Raw CLI flags to forward. Use ["-c", "Name1,Name2"] (or the equivalent --connections form) to target specific connections. Example: ["-c", "MyOrg,SandboxOrg"]',
+              'array, optional; raw CLI flags e.g. ["-c", "ConnName"]'
+            )
           ),
         sf_path: z
           .string()
           .optional()
-          .describe('Path to the sf CLI executable when not in PATH (e.g. "~/.nvm/versions/node/v22.0.0/bin/sf")'),
+          .describe(
+            desc(
+              'Path to the sf CLI executable when not in PATH (e.g. "~/.nvm/versions/node/v22.0.0/bin/sf")',
+              'string, optional; path to sf CLI'
+            )
+          ),
       },
     },
     ({ flags, sf_path }) => {
@@ -503,32 +554,48 @@ export function registerAutomationSetup(server: McpServer): void {
     'provar_automation_setup',
     {
       title: 'Install Provar Automation',
-      description: [
-        'Download and install Provar Automation binaries locally. Invokes `sf provar automation setup`.',
-        'Before downloading, checks for existing Provar installations in:',
-        '  • PROVAR_HOME environment variable',
-        '  • ./ProvarHome (default CLI install location)',
-        '  • C:\\Program Files\\Provar* (Windows system installs)',
-        '  • /Applications/Provar* (macOS app installs)',
-        'If an existing installation is found, returns its path so you can set provarHome in the properties file — skipping the download unless force is true.',
-        'After a successful install, update the provarHome property in provardx-properties.json to the returned install_path using provar_properties_set.',
-      ].join(' '),
+      description: desc(
+        [
+          'Download and install Provar Automation binaries locally. Invokes `sf provar automation setup`.',
+          'Before downloading, checks for existing Provar installations in:',
+          '  • PROVAR_HOME environment variable',
+          '  • ./ProvarHome (default CLI install location)',
+          '  • C:\\Program Files\\Provar* (Windows system installs)',
+          '  • /Applications/Provar* (macOS app installs)',
+          'If an existing installation is found, returns its path so you can set provarHome in the properties file — skipping the download unless force is true.',
+          'After a successful install, update the provarHome property in provardx-properties.json to the returned install_path using provar_properties_set.',
+        ].join(' '),
+        'Download and install Provar Automation binaries; skips if already installed.'
+      ),
       inputSchema: {
         version: z
           .string()
           .optional()
           .describe(
-            'Specific Provar Automation version to install, e.g. "2.12.0". Omit to install the latest release.'
+            desc(
+              'Specific Provar Automation version to install, e.g. "2.12.0". Omit to install the latest release.',
+              'string, optional; version to install e.g. "2.12.0"'
+            )
           ),
         force: z
           .boolean()
           .optional()
           .default(false)
-          .describe('Force a fresh download even if an existing installation is already detected (default: false).'),
+          .describe(
+            desc(
+              'Force a fresh download even if an existing installation is already detected (default: false).',
+              'bool, optional; force re-download'
+            )
+          ),
         sf_path: z
           .string()
           .optional()
-          .describe('Path to the sf CLI executable when not in PATH (e.g. "~/.nvm/versions/node/v22.0.0/bin/sf")'),
+          .describe(
+            desc(
+              'Path to the sf CLI executable when not in PATH (e.g. "~/.nvm/versions/node/v22.0.0/bin/sf")',
+              'string, optional; path to sf CLI'
+            )
+          ),
       },
     },
     ({ version, force, sf_path }) => {

--- a/src/mcp/tools/connectionTools.ts
+++ b/src/mcp/tools/connectionTools.ts
@@ -15,6 +15,7 @@ import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
+import { desc } from './descHelper.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -135,17 +136,25 @@ export function registerConnectionList(server: McpServer, config: ServerConfig):
     'provar_connection_list',
     {
       title: 'List Connections',
-      description: [
-        'List all connections and named environments defined in the .testproject file.',
-        'Use this before generating test cases or page objects to get the correct connection names.',
-        'Returns connections (name, type, url, sso_configured) and environments (name, connection, url).',
-        'Prerequisite: the project must have a .testproject file — run provar_project_validate first if unsure.',
-        'Security: only connection names, types, and URLs are returned — credential values from .secrets are never included.',
-      ].join(' '),
+      description: desc(
+        [
+          'List all connections and named environments defined in the .testproject file.',
+          'Use this before generating test cases or page objects to get the correct connection names.',
+          'Returns connections (name, type, url, sso_configured) and environments (name, connection, url).',
+          'Prerequisite: the project must have a .testproject file — run provar_project_validate first if unsure.',
+          'Security: only connection names, types, and URLs are returned — credential values from .secrets are never included.',
+        ].join(' '),
+        'List connections and environments from the .testproject file.'
+      ),
       inputSchema: {
         project_path: z
           .string()
-          .describe('Absolute or relative path to the Provar project root directory (must be within --allowed-paths)'),
+          .describe(
+            desc(
+              'Absolute or relative path to the Provar project root directory (must be within --allowed-paths)',
+              'string, absolute path to project root'
+            )
+          ),
       },
     },
     ({ project_path }) => {

--- a/src/mcp/tools/defectTools.ts
+++ b/src/mcp/tools/defectTools.ts
@@ -11,6 +11,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
 import { runSfCommand, soqlEscape } from './sfSpawn.js';
+import { desc } from './descHelper.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -257,29 +258,47 @@ export function registerQualityHubDefectCreate(server: McpServer): void {
     'provar_qualityhub_defect_create',
     {
       title: 'Create Defects',
-      description: [
-        'Create Defect__c records in Quality Hub for failed test executions in a given run.',
-        'Queries the run by Tracking_Id__c, finds failed Test_Execution__c records, creates a',
-        'Defect__c per failure (with description, step, browser, environment, tester), and links',
-        'it via Test_Case_Defect__c and Test_Execution_Defect__c junction records.',
-        'If Jira or ADO sync is configured in Quality Hub, defects sync to those systems automatically.',
-      ].join(' '),
+      description: desc(
+        [
+          'Create Defect__c records in Quality Hub for failed test executions in a given run.',
+          'Queries the run by Tracking_Id__c, finds failed Test_Execution__c records, creates a',
+          'Defect__c per failure (with description, step, browser, environment, tester), and links',
+          'it via Test_Case_Defect__c and Test_Execution_Defect__c junction records.',
+          'If Jira or ADO sync is configured in Quality Hub, defects sync to those systems automatically.',
+        ].join(' '),
+        'Create Defect__c records for failed Quality Hub test executions.'
+      ),
       inputSchema: {
-        run_id: z.string().describe('Test run Tracking_Id__c value returned by provar_qualityhub_testrun'),
-        target_org: z.string().describe('SF org alias or username for the Quality Hub org'),
+        run_id: z
+          .string()
+          .describe(
+            desc(
+              'Test run Tracking_Id__c value returned by provar_qualityhub_testrun',
+              'string, tracking ID from qualityhub_testrun'
+            )
+          ),
+        target_org: z
+          .string()
+          .describe(desc('SF org alias or username for the Quality Hub org', 'string, SF org alias or username')),
         failed_tests: z
           .array(z.string())
           .optional()
           .describe(
-            'Optional filter — list of Test_Case__c record ID substrings to restrict defect creation to specific failures'
+            desc(
+              'Optional filter — list of Test_Case__c record ID substrings to restrict defect creation to specific failures',
+              'array of strings, optional; filter by TC ID substring'
+            )
           ),
         sf_path: z
           .string()
           .optional()
           .describe(
-            'Path to the sf CLI executable when not in PATH ' +
-              '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
-              'Leave unset to use auto-discovery.'
+            desc(
+              'Path to the sf CLI executable when not in PATH ' +
+                '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
+                'Leave unset to use auto-discovery.',
+              'string, optional; path to sf CLI executable'
+            )
           ),
       },
     },

--- a/src/mcp/tools/descHelper.ts
+++ b/src/mcp/tools/descHelper.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024 Provar Limited.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.md file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Returns `compact` when PROVAR_MCP_SCHEMA_MODE=compact, otherwise `standard`.
+ * Reads the env var on each call so tests can set it without resetting module cache.
+ */
+export function desc(standard: string, compact: string): string {
+  return process.env['PROVAR_MCP_SCHEMA_MODE'] === 'compact' ? compact : standard;
+}

--- a/src/mcp/tools/nitroXTools.ts
+++ b/src/mcp/tools/nitroXTools.ts
@@ -18,6 +18,7 @@ import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { makeError, makeRequestId, type ValidationIssue } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
+import { desc } from './descHelper.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -487,29 +488,39 @@ export function registerNitroXDiscover(server: McpServer): void {
     'provar_nitrox_discover',
     {
       title: 'Discover NitroX Components',
-      description: [
-        'Discover Provar projects containing NitroX (Hybrid Model) page objects.',
-        'Scans directories for .testproject marker files, then inventories nitroX/ and nitroXPackages/ directories.',
-        "NitroX is Provar's Hybrid Model for locators — component-based page objects for LWC,",
-        'Screen Flow, Industry Components, Experience Cloud, and HTML5 components.',
-        'Results provide file paths and package info for use with provar_nitrox_read, validate, and generate.',
-      ].join(' '),
+      description: desc(
+        [
+          'Discover Provar projects containing NitroX (Hybrid Model) page objects.',
+          'Scans directories for .testproject marker files, then inventories nitroX/ and nitroXPackages/ directories.',
+          "NitroX is Provar's Hybrid Model for locators — component-based page objects for LWC,",
+          'Screen Flow, Industry Components, Experience Cloud, and HTML5 components.',
+          'Results provide file paths and package info for use with provar_nitrox_read, validate, and generate.',
+        ].join(' '),
+        'Discover Provar projects with NitroX Hybrid Model page objects.'
+      ),
       inputSchema: {
         search_roots: z
           .array(z.string())
           .optional()
-          .describe('Directories to scan (default: cwd; if empty, falls back to ~/git and ~/Provar)'),
+          .describe(
+            desc(
+              'Directories to scan (default: cwd; if empty, falls back to ~/git and ~/Provar)',
+              'array of strings, optional; dirs to scan'
+            )
+          ),
         max_depth: z
           .number()
           .int()
           .min(1)
           .max(20)
           .default(6)
-          .describe('Maximum directory depth for .testproject search'),
+          .describe(desc('Maximum directory depth for .testproject search', 'int 1–20, optional; max scan depth')),
         include_packages: z
           .boolean()
           .default(true)
-          .describe('Include nitroXPackages/ package.json metadata in results'),
+          .describe(
+            desc('Include nitroXPackages/ package.json metadata in results', 'bool, optional; include package metadata')
+          ),
       },
     },
     ({ search_roots, max_depth, include_packages }) => {
@@ -589,24 +600,42 @@ export function registerNitroXRead(server: McpServer, config: ServerConfig): voi
     'provar_nitrox_read',
     {
       title: 'Read NitroX Files',
-      description: [
-        'Read one or more NitroX .po.json (Hybrid Model page object) files and return their parsed content.',
-        'Use this to load examples before generating or validating.',
-        "Provide file_paths for specific files, or project_path to read all .po.json files from a project's nitroX/ directory.",
-      ].join(' '),
+      description: desc(
+        [
+          'Read one or more NitroX .po.json (Hybrid Model page object) files and return their parsed content.',
+          'Use this to load examples before generating or validating.',
+          "Provide file_paths for specific files, or project_path to read all .po.json files from a project's nitroX/ directory.",
+        ].join(' '),
+        'Read NitroX .po.json files and return parsed content.'
+      ),
       inputSchema: {
-        file_paths: z.array(z.string()).optional().describe('Specific .po.json file paths to read'),
+        file_paths: z
+          .array(z.string())
+          .optional()
+          .describe(
+            desc('Specific .po.json file paths to read', 'array of strings, optional; specific .po.json paths')
+          ),
         project_path: z
           .string()
           .optional()
-          .describe('Provar project path — reads all .po.json files from nitroX/ directory'),
+          .describe(
+            desc(
+              'Provar project path — reads all .po.json files from nitroX/ directory',
+              'string, optional; project path to read all nitroX files'
+            )
+          ),
         max_files: z
           .number()
           .int()
           .min(1)
           .max(100)
           .default(20)
-          .describe('Maximum number of files to return (prevents context overflow)'),
+          .describe(
+            desc(
+              'Maximum number of files to return (prevents context overflow)',
+              'int 1–100, optional; max files returned'
+            )
+          ),
       },
     },
     ({ file_paths, project_path, max_files }) => {
@@ -690,17 +719,28 @@ export function registerNitroXValidate(server: McpServer, config: ServerConfig):
     'provar_nitrox_validate',
     {
       title: 'Validate NitroX Component',
-      description: [
-        'Validate a NitroX .po.json (Hybrid Model component page object) against schema rules.',
-        'Works for any NitroX-mapped component type: LWC, Screen Flow, Industry Components, Experience Cloud, HTML5.',
-        'Runs two validation passes sequentially: hardcoded semantic rules (NX001–NX010) then JSON schema validation (NX_SCHEMA_* rule IDs).',
-        'Schema issues catch structural errors not covered by NX rules: wrong property types, extra properties, enum violations.',
-        'Returns a quality score (0–100) and a combined list of issues with rule IDs, severity, and suggestions.',
-        'Score formula: 100 − (20 × errors) − (5 × warnings) − (1 × infos).',
-      ].join(' '),
+      description: desc(
+        [
+          'Validate a NitroX .po.json (Hybrid Model component page object) against schema rules.',
+          'Works for any NitroX-mapped component type: LWC, Screen Flow, Industry Components, Experience Cloud, HTML5.',
+          'Runs two validation passes sequentially: hardcoded semantic rules (NX001–NX010) then JSON schema validation (NX_SCHEMA_* rule IDs).',
+          'Schema issues catch structural errors not covered by NX rules: wrong property types, extra properties, enum violations.',
+          'Returns a quality score (0–100) and a combined list of issues with rule IDs, severity, and suggestions.',
+          'Score formula: 100 − (20 × errors) − (5 × warnings) − (1 × infos).',
+        ].join(' '),
+        'Validate a NitroX .po.json against NX001–NX010 and JSON schema rules.'
+      ),
       inputSchema: {
-        content: z.string().optional().describe('JSON string of the .po.json content to validate'),
-        file_path: z.string().optional().describe('Path to a .po.json file to validate'),
+        content: z
+          .string()
+          .optional()
+          .describe(
+            desc('JSON string of the .po.json content to validate', 'string, optional; JSON content to validate')
+          ),
+        file_path: z
+          .string()
+          .optional()
+          .describe(desc('Path to a .po.json file to validate', 'string, optional; path to .po.json file')),
       },
     },
     ({ content, file_path }) => {
@@ -779,26 +819,58 @@ export function registerNitroXGenerate(server: McpServer, config: ServerConfig):
     'provar_nitrox_generate',
     {
       title: 'Generate NitroX Components',
-      description: [
-        'Generate a new NitroX .po.json (Hybrid Model page object) from a component description.',
-        "Applicable to any component type supported by Provar's Hybrid Model:",
-        'LWC, Screen Flow, Industry Components, Experience Cloud, HTML5.',
-        'Read the provar-nitrox-component-catalog resource first to understand available component types,',
-        'tagName conventions, interaction titles, and attribute patterns from shipped base packages.',
-        'All componentId fields are assigned fresh UUIDs. Returns JSON content;',
-        'writes to disk only when dry_run=false.',
-      ].join(' '),
+      description: desc(
+        [
+          'Generate a new NitroX .po.json (Hybrid Model page object) from a component description.',
+          "Applicable to any component type supported by Provar's Hybrid Model:",
+          'LWC, Screen Flow, Industry Components, Experience Cloud, HTML5.',
+          'Read the provar-nitrox-component-catalog resource first to understand available component types,',
+          'tagName conventions, interaction titles, and attribute patterns from shipped base packages.',
+          'All componentId fields are assigned fresh UUIDs. Returns JSON content;',
+          'writes to disk only when dry_run=false.',
+        ].join(' '),
+        'Generate a NitroX .po.json Hybrid Model page object with fresh UUIDs.'
+      ),
       inputSchema: {
-        name: z.string().describe('Path-like component name, e.g. /com/force/myapp/ButtonComponent'),
-        tag_name: z.string().describe('LWC or HTML tag name, e.g. lightning-button or c-my-component'),
-        type: z.enum(['Block', 'Page']).default('Block').describe('Component type'),
-        page_structure_element: z.boolean().default(true).describe('Whether this is a page structure element'),
-        field_details_element: z.boolean().default(false).describe('Whether this is a field details element'),
-        parameters: z.array(ParameterInputSchema).optional().describe('Component parameters/qualifiers'),
-        elements: z.array(ElementInputSchema).optional().describe('Child elements'),
-        output_path: z.string().optional().describe('File path to write (requires dry_run=false)'),
-        overwrite: z.boolean().default(false).describe('Overwrite if output_path already exists'),
-        dry_run: z.boolean().default(true).describe('Return JSON without writing to disk (default)'),
+        name: z
+          .string()
+          .describe(
+            desc('Path-like component name, e.g. /com/force/myapp/ButtonComponent', 'string, path-like component name')
+          ),
+        tag_name: z
+          .string()
+          .describe(
+            desc('LWC or HTML tag name, e.g. lightning-button or c-my-component', 'string, LWC or HTML tag name')
+          ),
+        type: z.enum(['Block', 'Page']).default('Block').describe(desc('Component type', 'enum Block|Page')),
+        page_structure_element: z
+          .boolean()
+          .default(true)
+          .describe(desc('Whether this is a page structure element', 'bool, optional; default true')),
+        field_details_element: z
+          .boolean()
+          .default(false)
+          .describe(desc('Whether this is a field details element', 'bool, optional; default false')),
+        parameters: z
+          .array(ParameterInputSchema)
+          .optional()
+          .describe(desc('Component parameters/qualifiers', 'array, optional; component parameters')),
+        elements: z
+          .array(ElementInputSchema)
+          .optional()
+          .describe(desc('Child elements', 'array, optional; child elements')),
+        output_path: z
+          .string()
+          .optional()
+          .describe(desc('File path to write (requires dry_run=false)', 'string, optional; output file path')),
+        overwrite: z
+          .boolean()
+          .default(false)
+          .describe(desc('Overwrite if output_path already exists', 'bool, optional; overwrite if exists')),
+        dry_run: z
+          .boolean()
+          .default(true)
+          .describe(desc('Return JSON without writing to disk (default)', 'bool, optional; default true, skip write')),
       },
     },
     (input) => {
@@ -861,22 +933,42 @@ export function registerNitroXPatch(server: McpServer, config: ServerConfig): vo
     'provar_nitrox_patch',
     {
       title: 'Patch NitroX Component',
-      description: [
-        'Apply a JSON merge-patch (RFC 7396) to an existing NitroX .po.json file.',
-        'Reads the file, merges the patch (null values remove keys, other values replace or recurse into objects),',
-        'optionally validates the merged result, and writes back.',
-        'Use dry_run=true (default) to preview the merged output without writing.',
-      ].join(' '),
+      description: desc(
+        [
+          'Apply a JSON merge-patch (RFC 7396) to an existing NitroX .po.json file.',
+          'Reads the file, merges the patch (null values remove keys, other values replace or recurse into objects),',
+          'optionally validates the merged result, and writes back.',
+          'Use dry_run=true (default) to preview the merged output without writing.',
+        ].join(' '),
+        'Apply a JSON merge-patch (RFC 7396) to an existing NitroX .po.json file.'
+      ),
       inputSchema: {
-        file_path: z.string().describe('Path to the existing .po.json file to patch'),
+        file_path: z
+          .string()
+          .describe(desc('Path to the existing .po.json file to patch', 'string, absolute path to .po.json file')),
         patch: z
           .record(z.unknown())
-          .describe('JSON merge-patch to apply (RFC 7396: null removes key, any other value replaces)'),
-        dry_run: z.boolean().default(true).describe('Return merged result without writing to disk (default)'),
+          .describe(
+            desc(
+              'JSON merge-patch to apply (RFC 7396: null removes key, any other value replaces)',
+              'object, RFC 7396 merge-patch'
+            )
+          ),
+        dry_run: z
+          .boolean()
+          .default(true)
+          .describe(
+            desc('Return merged result without writing to disk (default)', 'bool, optional; default true, skip write')
+          ),
         validate_after: z
           .boolean()
           .default(true)
-          .describe('Run NX validation on merged result; blocks write if errors found'),
+          .describe(
+            desc(
+              'Run NX validation on merged result; blocks write if errors found',
+              'bool, optional; default true, validate before write'
+            )
+          ),
       },
     },
     ({ file_path, patch, dry_run, validate_after }) => {

--- a/src/mcp/tools/pageObjectGenerate.ts
+++ b/src/mcp/tools/pageObjectGenerate.ts
@@ -14,6 +14,7 @@ import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
+import { desc } from './descHelper.js';
 
 const VALID_LOCATOR_STRATEGIES = [
   'xpath',
@@ -105,48 +106,97 @@ export function registerPageObjectGenerate(server: McpServer, config: ServerConf
     'provar_pageobject_generate',
     {
       title: 'Generate Page Object',
-      description: [
-        'Generate a Provar Java Page Object skeleton with @Page/@SalesforcePage annotation, standard imports, and @FindBy WebElement fields.',
-        'Returns Java source. Writes to disk only when dry_run=false.',
-        'SSO support: set sso_class to also generate an ILoginPage implementation stub for non-SF SSO pages.',
-        'Example: sso_class="LoginPageSso" generates a LoginPageSso.java that implements ILoginPage with loginAs() and logout() stubs.',
-        'The ILoginPage stub is written to the same directory as output_path when dry_run=false.',
-      ].join(' '),
+      description: desc(
+        [
+          'Generate a Provar Java Page Object skeleton with @Page/@SalesforcePage annotation, standard imports, and @FindBy WebElement fields.',
+          'Returns Java source. Writes to disk only when dry_run=false.',
+          'SSO support: set sso_class to also generate an ILoginPage implementation stub for non-SF SSO pages.',
+          'Example: sso_class="LoginPageSso" generates a LoginPageSso.java that implements ILoginPage with loginAs() and logout() stubs.',
+          'The ILoginPage stub is written to the same directory as output_path when dry_run=false.',
+        ].join(' '),
+        'Generate a Provar Java Page Object skeleton with @Page/@FindBy fields.'
+      ),
       inputSchema: {
-        class_name: z.string().describe('PascalCase class name, e.g. AccountDetailPage'),
+        class_name: z
+          .string()
+          .describe(desc('PascalCase class name, e.g. AccountDetailPage', 'string, PascalCase class name')),
         package_name: z
           .string()
           .default('pageobjects')
-          .describe('Java package, e.g. pageobjects or pageobjects.accounts'),
+          .describe(
+            desc('Java package, e.g. pageobjects or pageobjects.accounts', 'string, optional; Java package name')
+          ),
         page_type: z
           .enum(['standard', 'salesforce'])
           .default('standard')
-          .describe('@Page (standard) or @SalesforcePage (salesforce)'),
-        title: z.string().optional().describe('Page title attribute; defaults to class_name if omitted'),
+          .describe(desc('@Page (standard) or @SalesforcePage (salesforce)', 'enum standard|salesforce')),
+        title: z
+          .string()
+          .optional()
+          .describe(
+            desc('Page title attribute; defaults to class_name if omitted', 'string, optional; page title attribute')
+          ),
         connection_name: z
           .string()
           .optional()
-          .describe('Salesforce connection name (required when page_type=salesforce)'),
+          .describe(
+            desc(
+              'Salesforce connection name (required when page_type=salesforce)',
+              'string, optional; SF connection name'
+            )
+          ),
         salesforce_page_attribute: z
           .enum(['page', 'auraComponent', 'object', 'lightningWebComponent'])
           .optional()
-          .describe('Page type attribute for @SalesforcePage'),
-        fields: z.array(FieldSchema).default([]).describe('WebElement fields to generate'),
+          .describe(
+            desc('Page type attribute for @SalesforcePage', 'enum page|auraComponent|object|lightningWebComponent')
+          ),
+        fields: z
+          .array(FieldSchema)
+          .default([])
+          .describe(desc('WebElement fields to generate', 'array, optional; WebElement fields')),
         sso_class: z
           .string()
           .optional()
           .describe(
-            'PascalCase class name for an ILoginPage implementation stub (non-SF SSO pages). ' +
-              'When provided, an additional Java class implementing ILoginPage is generated alongside the page object. ' +
-              'Example: "LoginPageSso" → LoginPageSso.java with loginAs() and logout() method stubs.'
+            desc(
+              'PascalCase class name for an ILoginPage implementation stub (non-SF SSO pages). ' +
+                'When provided, an additional Java class implementing ILoginPage is generated alongside the page object. ' +
+                'Example: "LoginPageSso" → LoginPageSso.java with loginAs() and logout() method stubs.',
+              'string, optional; PascalCase class name for ILoginPage SSO stub'
+            )
           ),
-        output_path: z.string().optional().describe('Suggested file path for the .java file (returned in response)'),
-        overwrite: z.boolean().default(false).describe('Overwrite existing file when dry_run=false'),
+        output_path: z
+          .string()
+          .optional()
+          .describe(
+            desc(
+              'Suggested file path for the .java file (returned in response)',
+              'string, optional; output .java file path'
+            )
+          ),
+        overwrite: z
+          .boolean()
+          .default(false)
+          .describe(desc('Overwrite existing file when dry_run=false', 'bool, optional; overwrite if exists')),
         dry_run: z
           .boolean()
           .default(true)
-          .describe('true = return source only (default); false = write to output_path'),
-        idempotency_key: z.string().optional().describe('Caller-provided key echoed back for deduplication tracking'),
+          .describe(
+            desc(
+              'true = return source only (default); false = write to output_path',
+              'bool, optional; default true, skip write'
+            )
+          ),
+        idempotency_key: z
+          .string()
+          .optional()
+          .describe(
+            desc(
+              'Caller-provided key echoed back for deduplication tracking',
+              'string, optional; deduplication key echoed in response'
+            )
+          ),
       },
     },
     (input) => {

--- a/src/mcp/tools/pageObjectValidate.ts
+++ b/src/mcp/tools/pageObjectValidate.ts
@@ -15,21 +15,35 @@ import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { makeError, makeRequestId, type ValidationIssue } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
+import { desc } from './descHelper.js';
 
 export function registerPageObjectValidate(server: McpServer, config: ServerConfig): void {
   server.registerTool(
     'provar_pageobject_validate',
     {
       title: 'Validate Page Object',
-      description:
+      description: desc(
         'Validate a Provar Java Page Object against naming conventions, locator best practices, and structural requirements. Returns quality score (0–100) and list of issues.',
+        'Validate a Provar Java Page Object for naming, locators, and structure.'
+      ),
       inputSchema: {
-        content: z.string().optional().describe('Java source code to validate directly'),
-        file_path: z.string().optional().describe('Path to .java Page Object file'),
+        content: z
+          .string()
+          .optional()
+          .describe(desc('Java source code to validate directly', 'string, optional; Java source to validate')),
+        file_path: z
+          .string()
+          .optional()
+          .describe(desc('Path to .java Page Object file', 'string, optional; path to .java file')),
         expected_class_name: z
           .string()
           .optional()
-          .describe('Expected class name for PO_006 check; inferred from file_path when omitted'),
+          .describe(
+            desc(
+              'Expected class name for PO_006 check; inferred from file_path when omitted',
+              'string, optional; expected class name for PO_006 check'
+            )
+          ),
       },
     },
     ({ content, file_path, expected_class_name }) => {

--- a/src/mcp/tools/projectInspect.ts
+++ b/src/mcp/tools/projectInspect.ts
@@ -14,26 +14,37 @@ import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
+import { desc } from './descHelper.js';
 
 export function registerProjectInspect(server: McpServer, config: ServerConfig): void {
   server.registerTool(
     'provar_project_inspect',
     {
       title: 'Inspect Project',
-      description: [
-        'Inspect a Provar project folder and return a structured inventory.',
-        'Returns: provardx-properties.json config files (for ProvarDX CLI runs),',
-        'ANT build files (build.xml etc in ANT/ dirs, for CLI/pipeline runs),',
-        'source page object directories with Java file counts (src/pageobjects — compiled bin/ dirs excluded),',
-        '.testcase files found recursively under tests/,',
-        'count of custom test step files in src/customapis/,',
-        'count of data source files (CSV/XLSX/JSON) in data/ and templates/ dirs,',
-        'test plan coverage showing which test cases are covered vs uncovered,',
-        'and connection + environment overview parsed from the .testproject file',
-        '(Salesforce, UI Testing, Web Services, Quality Hub, Database, and other connection types).',
-      ].join(' '),
+      description: desc(
+        [
+          'Inspect a Provar project folder and return a structured inventory.',
+          'Returns: provardx-properties.json config files (for ProvarDX CLI runs),',
+          'ANT build files (build.xml etc in ANT/ dirs, for CLI/pipeline runs),',
+          'source page object directories with Java file counts (src/pageobjects — compiled bin/ dirs excluded),',
+          '.testcase files found recursively under tests/,',
+          'count of custom test step files in src/customapis/,',
+          'count of data source files (CSV/XLSX/JSON) in data/ and templates/ dirs,',
+          'test plan coverage showing which test cases are covered vs uncovered,',
+          'and connection + environment overview parsed from the .testproject file',
+          '(Salesforce, UI Testing, Web Services, Quality Hub, Database, and other connection types).',
+        ].join(' '),
+        'Inspect a Provar project and return inventory of files, plans, and connections.'
+      ),
       inputSchema: {
-        project_path: z.string().describe('Absolute or relative path to the Provar project root directory'),
+        project_path: z
+          .string()
+          .describe(
+            desc(
+              'Absolute or relative path to the Provar project root directory',
+              'string, absolute path to project root'
+            )
+          ),
       },
     },
     ({ project_path }) => {

--- a/src/mcp/tools/projectValidateFromPath.ts
+++ b/src/mcp/tools/projectValidateFromPath.ts
@@ -14,6 +14,7 @@ import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
 import { validateProjectFromPath, ProjectValidationError } from '../../services/projectValidation.js';
 import type { ProjectValidationResult, ValidatedPlan } from '../../services/projectValidation.js';
+import { desc } from './descHelper.js';
 
 // ── Response shaping ──────────────────────────────────────────────────────────
 
@@ -110,50 +111,76 @@ export function registerProjectValidateFromPath(server: McpServer, config: Serve
     'provar_project_validate',
     {
       title: 'Validate Project',
-      description: [
-        'Validate a Provar project directly from its directory on disk.',
-        'Reads the plan/suite/testinstance hierarchy from the plans/ directory,',
-        'resolves test case XML from the tests/ directory, extracts project context',
-        '(connections, environments, secrets) from the .testproject file, then runs',
-        'the full validation rule set.',
-        'Returns a compact quality score, violation summary, and per-plan/suite scores.',
-        'By default returns a slim summary response to avoid token explosion.',
-        'Pass include_plan_details:true to get full per-suite and per-test-case data.',
-        'By default saves a QH-compatible JSON report to',
-        '{project_path}/provardx/validation/ (created if absent).',
-        'Plan integrity: if any plan or suite directory is missing a .planitem file, the response includes a plan_integrity_warnings array.',
-        'Test instances in those directories are silently ignored by the Provar runner — fix these before running tests.',
-        'IMPORTANT: Use this tool for whole-project validation —',
-        'DO NOT read individual test case files and pass XML content inline.',
-        'Pass a project_path and let this tool handle all file reading.',
-      ].join(' '),
+      description: desc(
+        [
+          'Validate a Provar project directly from its directory on disk.',
+          'Reads the plan/suite/testinstance hierarchy from the plans/ directory,',
+          'resolves test case XML from the tests/ directory, extracts project context',
+          '(connections, environments, secrets) from the .testproject file, then runs',
+          'the full validation rule set.',
+          'Returns a compact quality score, violation summary, and per-plan/suite scores.',
+          'By default returns a slim summary response to avoid token explosion.',
+          'Pass include_plan_details:true to get full per-suite and per-test-case data.',
+          'By default saves a QH-compatible JSON report to',
+          '{project_path}/provardx/validation/ (created if absent).',
+          'Plan integrity: if any plan or suite directory is missing a .planitem file, the response includes a plan_integrity_warnings array.',
+          'Test instances in those directories are silently ignored by the Provar runner — fix these before running tests.',
+          'IMPORTANT: Use this tool for whole-project validation —',
+          'DO NOT read individual test case files and pass XML content inline.',
+          'Pass a project_path and let this tool handle all file reading.',
+        ].join(' '),
+        'Validate a Provar project from disk; returns quality score and violation summary.'
+      ),
       inputSchema: {
         project_path: z
           .string()
-          .describe('Absolute path to the Provar project root (the directory containing the .testproject file)'),
+          .describe(
+            desc(
+              'Absolute path to the Provar project root (the directory containing the .testproject file)',
+              'string, absolute path to project root'
+            )
+          ),
         quality_threshold: z
           .number()
           .min(0)
           .max(100)
           .optional()
           .default(80)
-          .describe('Minimum quality score for a test case to be considered valid (default: 80)'),
+          .describe(
+            desc(
+              'Minimum quality score for a test case to be considered valid (default: 80)',
+              'int 0–100, optional; minimum quality score threshold'
+            )
+          ),
         save_results: z
           .boolean()
           .optional()
           .default(true)
-          .describe('Write a QH-compatible JSON report to provardx/validation/ (default: true)'),
+          .describe(
+            desc(
+              'Write a QH-compatible JSON report to provardx/validation/ (default: true)',
+              'bool, optional; default true, write report to disk'
+            )
+          ),
         results_dir: z
           .string()
           .optional()
-          .describe('Override the output directory for the saved report (default: {project_path}/provardx/validation)'),
+          .describe(
+            desc(
+              'Override the output directory for the saved report (default: {project_path}/provardx/validation)',
+              'string, optional; override report output dir'
+            )
+          ),
         include_plan_details: z
           .boolean()
           .optional()
           .default(false)
           .describe(
-            'When true, include full per-suite and per-test-case violation data in the response. ' +
-              'Default false to keep response small. Use only when you need to inspect specific test case failures.'
+            desc(
+              'When true, include full per-suite and per-test-case violation data in the response. ' +
+                'Default false to keep response small. Use only when you need to inspect specific test case failures.',
+              'bool, optional; default false, include full per-suite violation data'
+            )
           ),
         max_uncovered: z
           .number()
@@ -162,7 +189,10 @@ export function registerProjectValidateFromPath(server: McpServer, config: Serve
           .optional()
           .default(20)
           .describe(
-            'Maximum number of uncovered test case paths to include in the response (default: 20). Set to 0 for none, or a large number for all.'
+            desc(
+              'Maximum number of uncovered test case paths to include in the response (default: 20). Set to 0 for none, or a large number for all.',
+              'int ≥0, optional; max uncovered test case paths returned'
+            )
           ),
         max_violations: z
           .number()
@@ -171,7 +201,10 @@ export function registerProjectValidateFromPath(server: McpServer, config: Serve
           .optional()
           .default(50)
           .describe(
-            'When include_plan_details:true, caps project_violations returned (default: 50). Ignored in slim mode where violations are grouped by rule_id instead.'
+            desc(
+              'When include_plan_details:true, caps project_violations returned (default: 50). Ignored in slim mode where violations are grouped by rule_id instead.',
+              'int ≥0, optional; max violations returned in detail mode'
+            )
           ),
       },
     },

--- a/src/mcp/tools/projectValidateFromPath.ts
+++ b/src/mcp/tools/projectValidateFromPath.ts
@@ -149,7 +149,7 @@ export function registerProjectValidateFromPath(server: McpServer, config: Serve
           .describe(
             desc(
               'Minimum quality score for a test case to be considered valid (default: 80)',
-              'int 0–100, optional; minimum quality score threshold'
+              'number 0–100, optional; minimum quality score threshold'
             )
           ),
         save_results: z

--- a/src/mcp/tools/propertiesTools.ts
+++ b/src/mcp/tools/propertiesTools.ts
@@ -16,6 +16,7 @@ import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
+import { desc } from './descHelper.js';
 
 // ── Validation helpers ────────────────────────────────────────────────────────
 
@@ -163,23 +164,50 @@ export function registerPropertiesGenerate(server: McpServer, config: ServerConf
     'provar_properties_generate',
     {
       title: 'Generate ProvarDX Properties File',
-      description: [
-        'Generate a provardx-properties.json file from the standard template.',
-        'Optionally pre-fills projectPath and provarHome if provided.',
-        'The generated file uses ${PLACEHOLDER} values that must be replaced before running tests.',
-        'Use provar_properties_set afterwards to update specific fields.',
-      ].join(' '),
+      description: desc(
+        [
+          'Generate a provardx-properties.json file from the standard template.',
+          'Optionally pre-fills projectPath and provarHome if provided.',
+          'The generated file uses ${PLACEHOLDER} values that must be replaced before running tests.',
+          'Use provar_properties_set afterwards to update specific fields.',
+        ].join(' '),
+        'Generate a provardx-properties.json from the standard template.'
+      ),
       inputSchema: {
-        output_path: z.string().describe('Where to write the file (e.g. /path/to/project/provardx-properties.json)'),
-        project_path: z.string().optional().describe('Pre-fill the projectPath field with this value'),
-        provar_home: z.string().optional().describe('Pre-fill the provarHome field with this value'),
-        results_path: z.string().optional().describe('Pre-fill the resultsPath field with this value'),
+        output_path: z
+          .string()
+          .describe(
+            desc(
+              'Where to write the file (e.g. /path/to/project/provardx-properties.json)',
+              'string, absolute path for output .json file'
+            )
+          ),
+        project_path: z
+          .string()
+          .optional()
+          .describe(desc('Pre-fill the projectPath field with this value', 'string, optional; pre-fill projectPath')),
+        provar_home: z
+          .string()
+          .optional()
+          .describe(desc('Pre-fill the provarHome field with this value', 'string, optional; pre-fill provarHome')),
+        results_path: z
+          .string()
+          .optional()
+          .describe(desc('Pre-fill the resultsPath field with this value', 'string, optional; pre-fill resultsPath')),
         overwrite: z
           .boolean()
           .optional()
           .default(false)
-          .describe('Overwrite the file if it already exists (default: false)'),
-        dry_run: z.boolean().optional().default(false).describe('Return the content without writing (default: false)'),
+          .describe(
+            desc('Overwrite the file if it already exists (default: false)', 'bool, optional; overwrite if exists')
+          ),
+        dry_run: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            desc('Return the content without writing (default: false)', 'bool, optional; default false, skip write')
+          ),
       },
     },
     ({ output_path, project_path, provar_home, results_path, overwrite, dry_run }) => {
@@ -326,10 +354,16 @@ export function registerPropertiesRead(server: McpServer, config: ServerConfig):
     'provar_properties_read',
     {
       title: 'Read Properties File',
-      description:
+      description: desc(
         'Read and parse a provardx-properties.json file. Returns the parsed content so you can inspect current settings before making changes with provar_properties_set.',
+        'Read and parse a provardx-properties.json file.'
+      ),
       inputSchema: {
-        file_path: z.string().describe('Path to the provardx-properties.json file'),
+        file_path: z
+          .string()
+          .describe(
+            desc('Path to the provardx-properties.json file', 'string, absolute path to provardx-properties.json')
+          ),
       },
     },
     ({ file_path }) => {
@@ -483,15 +517,25 @@ export function registerPropertiesSet(server: McpServer, config: ServerConfig): 
     'provar_properties_set',
     {
       title: 'Set Property Value',
-      description: [
-        'Update one or more fields in a provardx-properties.json file.',
-        'Only the provided fields are changed — all other fields are preserved.',
-        'Object fields (environment, metadata) are deep-merged.',
-        'Array fields (testCase, testPlan, connectionOverride) replace the existing value entirely.',
-        'Use provar_properties_read first to inspect the current state.',
-      ].join(' '),
+      description: desc(
+        [
+          'Update one or more fields in a provardx-properties.json file.',
+          'Only the provided fields are changed — all other fields are preserved.',
+          'Object fields (environment, metadata) are deep-merged.',
+          'Array fields (testCase, testPlan, connectionOverride) replace the existing value entirely.',
+          'Use provar_properties_read first to inspect the current state.',
+        ].join(' '),
+        'Update fields in a provardx-properties.json; other fields preserved.'
+      ),
       inputSchema: {
-        file_path: z.string().describe('Path to the provardx-properties.json file to update'),
+        file_path: z
+          .string()
+          .describe(
+            desc(
+              'Path to the provardx-properties.json file to update',
+              'string, absolute path to provardx-properties.json'
+            )
+          ),
         updates: updatesSchema,
       },
     },
@@ -576,14 +620,33 @@ export function registerPropertiesValidate(server: McpServer, config: ServerConf
     'provar_properties_validate',
     {
       title: 'Validate ProvarDX Properties File',
-      description: [
-        'Validate a provardx-properties.json file against the ProvarDX schema.',
-        'Checks required fields, valid enum values, and warns about unfilled placeholder values.',
-        'Accepts either a file path or inline JSON content.',
-      ].join(' '),
+      description: desc(
+        [
+          'Validate a provardx-properties.json file against the ProvarDX schema.',
+          'Checks required fields, valid enum values, and warns about unfilled placeholder values.',
+          'Accepts either a file path or inline JSON content.',
+        ].join(' '),
+        'Validate a provardx-properties.json against required fields and enum values.'
+      ),
       inputSchema: {
-        file_path: z.string().optional().describe('Path to the provardx-properties.json file to validate'),
-        content: z.string().optional().describe('Inline JSON string to validate (alternative to file_path)'),
+        file_path: z
+          .string()
+          .optional()
+          .describe(
+            desc(
+              'Path to the provardx-properties.json file to validate',
+              'string, optional; path to provardx-properties.json'
+            )
+          ),
+        content: z
+          .string()
+          .optional()
+          .describe(
+            desc(
+              'Inline JSON string to validate (alternative to file_path)',
+              'string, optional; inline JSON to validate'
+            )
+          ),
       },
     },
     ({ file_path, content }) => {

--- a/src/mcp/tools/qualityHubApiTools.ts
+++ b/src/mcp/tools/qualityHubApiTools.ts
@@ -18,6 +18,7 @@ import {
   QualityHubRateLimitError,
   REQUEST_ACCESS_URL,
 } from '../../services/qualityHub/client.js';
+import { desc } from './descHelper.js';
 
 const CORPUS_FALLBACK_HINT =
   'Fallback: read the provar://docs/step-reference MCP resource for step types and attribute formats, then continue.';
@@ -49,27 +50,33 @@ export function registerCorpusExamplesRetrieve(server: McpServer): void {
     'provar_qualityhub_examples_retrieve',
     {
       title: 'Retrieve Corpus Examples',
-      description: [
-        'Retrieve N similar Provar test case examples from the Quality Hub corpus (1000+ tests in Bedrock KB).',
-        'Use this BEFORE writing any Provar .testcase XML — whether via provar_testcase_generate, Write, or Edit.',
-        'Pass a user story, requirement, source test file content, or step type keywords as the query.',
-        'Returns up to N example Provar XML test cases ordered by similarity score.',
-        'If retrieval fails (no auth, network error, rate limit), returns empty examples with a warning — the',
-        'generation workflow can still continue without grounding. Never hard-errors on API failure.',
-        '',
-        'For org-specific field metadata: first call getObjectSchema from the Salesforce Hosted MCP',
-        '(platform/sobject-reads — https://api.salesforce.com/platform/mcp/v1/platform/sobject-reads),',
-        'then include key field names in your query (e.g. "Opportunity: CloseDate, Amount, StageName").',
-        '',
-        'Requires a Provar API key (sf provar auth login). Without a key, returns empty examples with onboarding instructions.',
-      ].join('\n'),
+      description: desc(
+        [
+          'Retrieve N similar Provar test case examples from the Quality Hub corpus (1000+ tests in Bedrock KB).',
+          'Use this BEFORE writing any Provar .testcase XML — whether via provar_testcase_generate, Write, or Edit.',
+          'Pass a user story, requirement, source test file content, or step type keywords as the query.',
+          'Returns up to N example Provar XML test cases ordered by similarity score.',
+          'If retrieval fails (no auth, network error, rate limit), returns empty examples with a warning — the',
+          'generation workflow can still continue without grounding. Never hard-errors on API failure.',
+          '',
+          'For org-specific field metadata: first call getObjectSchema from the Salesforce Hosted MCP',
+          '(platform/sobject-reads — https://api.salesforce.com/platform/mcp/v1/platform/sobject-reads),',
+          'then include key field names in your query (e.g. "Opportunity: CloseDate, Amount, StageName").',
+          '',
+          'Requires a Provar API key (sf provar auth login). Without a key, returns empty examples with onboarding instructions.',
+        ].join('\n'),
+        'Retrieve similar Provar test case examples from the Quality Hub corpus.'
+      ),
       inputSchema: {
         query: z
           .string()
           .describe(
-            'Text to search against the corpus — a user story, requirement description, or source test file content. ' +
-              'Longer is better: include Salesforce object names, field names, and action descriptions. ' +
-              'Truncated server-side at 2000 characters.'
+            desc(
+              'Text to search against the corpus — a user story, requirement description, or source test file content. ' +
+                'Longer is better: include Salesforce object names, field names, and action descriptions. ' +
+                'Truncated server-side at 2000 characters.',
+              'string, user story or requirement text; include SF object/field names'
+            )
           ),
         n: z
           .number()
@@ -78,18 +85,26 @@ export function registerCorpusExamplesRetrieve(server: McpServer): void {
           .max(10)
           .optional()
           .default(5)
-          .describe('Number of examples to return. Default 5, max 10.'),
+          .describe(desc('Number of examples to return. Default 5, max 10.', 'int 1–10, optional; examples to return')),
         app_filter: z
           .string()
           .optional()
           .describe(
-            'Optional Salesforce cloud filter to bias results (e.g. "SalesCloud", "ServiceCloud", "HealthCloud").'
+            desc(
+              'Optional Salesforce cloud filter to bias results (e.g. "SalesCloud", "ServiceCloud", "HealthCloud").',
+              'string, optional; SF cloud filter e.g. SalesCloud'
+            )
           ),
         prefer_high_quality: z
           .boolean()
           .optional()
           .default(true)
-          .describe('When true (default), favours tier4/tier3 corpus examples. Set false to include all tiers.'),
+          .describe(
+            desc(
+              'When true (default), favours tier4/tier3 corpus examples. Set false to include all tiers.',
+              'bool, optional; default true, prefer high-quality corpus examples'
+            )
+          ),
       },
     },
     async ({ query, n, app_filter, prefer_high_quality }) => {

--- a/src/mcp/tools/qualityHubTools.ts
+++ b/src/mcp/tools/qualityHubTools.ts
@@ -11,6 +11,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
 import { runSfCommand } from './sfSpawn.js';
+import { desc } from './descHelper.js';
 
 function handleSpawnError(
   err: unknown,
@@ -37,22 +38,31 @@ export function registerQualityHubConnect(server: McpServer): void {
     'provar_qualityhub_connect',
     {
       title: 'Connect to Quality Hub',
-      description:
+      description: desc(
         'Connect to a Provar Quality Hub org. Invokes `sf provar quality-hub connect` with the supplied flags.',
+        'Connect to a Provar Quality Hub org via sf CLI.'
+      ),
       inputSchema: {
-        target_org: z.string().describe('SF org alias or username to connect as'),
+        target_org: z
+          .string()
+          .describe(desc('SF org alias or username to connect as', 'string, SF org alias or username')),
         flags: z
           .array(z.string())
           .optional()
           .default([])
-          .describe('Additional raw CLI flags to forward (e.g. ["--json"])'),
+          .describe(
+            desc('Additional raw CLI flags to forward (e.g. ["--json"])', 'array of strings, optional; extra CLI flags')
+          ),
         sf_path: z
           .string()
           .optional()
           .describe(
-            'Path to the sf CLI executable when not in PATH ' +
-              '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
-              'Leave unset to use auto-discovery.'
+            desc(
+              'Path to the sf CLI executable when not in PATH ' +
+                '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
+                'Leave unset to use auto-discovery.',
+              'string, optional; path to sf CLI executable'
+            )
           ),
       },
     },
@@ -94,17 +104,32 @@ export function registerQualityHubDisplay(server: McpServer): void {
     'provar_qualityhub_display',
     {
       title: 'Display Quality Hub Info',
-      description: 'Display connected Quality Hub org info. Invokes `sf provar quality-hub display`.',
+      description: desc(
+        'Display connected Quality Hub org info. Invokes `sf provar quality-hub display`.',
+        'Display connected Quality Hub org info via sf CLI.'
+      ),
       inputSchema: {
-        target_org: z.string().optional().describe('SF org alias or username (uses default if omitted)'),
-        flags: z.array(z.string()).optional().default([]).describe('Additional raw CLI flags to forward'),
+        target_org: z
+          .string()
+          .optional()
+          .describe(
+            desc('SF org alias or username (uses default if omitted)', 'string, optional; SF org alias or username')
+          ),
+        flags: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe(desc('Additional raw CLI flags to forward', 'array of strings, optional; extra CLI flags')),
         sf_path: z
           .string()
           .optional()
           .describe(
-            'Path to the sf CLI executable when not in PATH ' +
-              '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
-              'Leave unset to use auto-discovery.'
+            desc(
+              'Path to the sf CLI executable when not in PATH ' +
+                '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
+                'Leave unset to use auto-discovery.',
+              'string, optional; path to sf CLI executable'
+            )
           ),
       },
     },
@@ -162,25 +187,33 @@ export function registerQualityHubTestRun(server: McpServer): void {
     'provar_qualityhub_testrun',
     {
       title: 'Trigger Quality Hub Test Run',
-      description:
+      description: desc(
         'Trigger a Quality Hub test run. Invokes `sf provar quality-hub test run`. ' +
-        'Warning: wildcard characters (* or ?) in flag values will cause QH plan-level reporting to be skipped — use exact plan names.',
+          'Warning: wildcard characters (* or ?) in flag values will cause QH plan-level reporting to be skipped — use exact plan names.',
+        'Trigger a Quality Hub test run via sf CLI; use exact plan names.'
+      ),
       inputSchema: {
-        target_org: z.string().describe('SF org alias or username'),
+        target_org: z.string().describe(desc('SF org alias or username', 'string, SF org alias or username')),
         flags: z
           .array(z.string())
           .optional()
           .default([])
           .describe(
-            'Additional raw CLI flags (e.g. ["--plan-name", "SmokeTests"]). Avoid wildcards in --plan-name values — they skip QH plan-level reporting.'
+            desc(
+              'Additional raw CLI flags (e.g. ["--plan-name", "SmokeTests"]). Avoid wildcards in --plan-name values — they skip QH plan-level reporting.',
+              'array of strings, optional; extra CLI flags; avoid wildcards in --plan-name'
+            )
           ),
         sf_path: z
           .string()
           .optional()
           .describe(
-            'Path to the sf CLI executable when not in PATH ' +
-              '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
-              'Leave unset to use auto-discovery.'
+            desc(
+              'Path to the sf CLI executable when not in PATH ' +
+                '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
+                'Leave unset to use auto-discovery.',
+              'string, optional; path to sf CLI executable'
+            )
           ),
       },
     },
@@ -232,18 +265,32 @@ export function registerQualityHubTestRunReport(server: McpServer): void {
     'provar_qualityhub_testrun_report',
     {
       title: 'Poll Quality Hub Test Run',
-      description: 'Poll the status of a Quality Hub test run. Invokes `sf provar quality-hub test run report`.',
+      description: desc(
+        'Poll the status of a Quality Hub test run. Invokes `sf provar quality-hub test run report`.',
+        'Poll a Quality Hub test run status via sf CLI.'
+      ),
       inputSchema: {
-        target_org: z.string().describe('SF org alias or username'),
-        run_id: z.string().describe('Test run ID returned by provar_qualityhub_testrun'),
-        flags: z.array(z.string()).optional().default([]).describe('Additional raw CLI flags'),
+        target_org: z.string().describe(desc('SF org alias or username', 'string, SF org alias or username')),
+        run_id: z
+          .string()
+          .describe(
+            desc('Test run ID returned by provar_qualityhub_testrun', 'string, run ID from qualityhub_testrun')
+          ),
+        flags: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe(desc('Additional raw CLI flags', 'array of strings, optional; extra CLI flags')),
         sf_path: z
           .string()
           .optional()
           .describe(
-            'Path to the sf CLI executable when not in PATH ' +
-              '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
-              'Leave unset to use auto-discovery.'
+            desc(
+              'Path to the sf CLI executable when not in PATH ' +
+                '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
+                'Leave unset to use auto-discovery.',
+              'string, optional; path to sf CLI executable'
+            )
           ),
       },
     },
@@ -304,18 +351,28 @@ export function registerQualityHubTestRunAbort(server: McpServer): void {
     'provar_qualityhub_testrun_abort',
     {
       title: 'Abort Quality Hub Test Run',
-      description: 'Abort an in-progress Quality Hub test run. Invokes `sf provar quality-hub test run abort`.',
+      description: desc(
+        'Abort an in-progress Quality Hub test run. Invokes `sf provar quality-hub test run abort`.',
+        'Abort an in-progress Quality Hub test run via sf CLI.'
+      ),
       inputSchema: {
-        target_org: z.string().describe('SF org alias or username'),
-        run_id: z.string().describe('Test run ID to abort'),
-        flags: z.array(z.string()).optional().default([]).describe('Additional raw CLI flags'),
+        target_org: z.string().describe(desc('SF org alias or username', 'string, SF org alias or username')),
+        run_id: z.string().describe(desc('Test run ID to abort', 'string, run ID to abort')),
+        flags: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe(desc('Additional raw CLI flags', 'array of strings, optional; extra CLI flags')),
         sf_path: z
           .string()
           .optional()
           .describe(
-            'Path to the sf CLI executable when not in PATH ' +
-              '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
-              'Leave unset to use auto-discovery.'
+            desc(
+              'Path to the sf CLI executable when not in PATH ' +
+                '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
+                'Leave unset to use auto-discovery.',
+              'string, optional; path to sf CLI executable'
+            )
           ),
       },
     },
@@ -357,22 +414,32 @@ export function registerQualityHubTestcaseRetrieve(server: McpServer): void {
     'provar_qualityhub_testcase_retrieve',
     {
       title: 'Retrieve Quality Hub Test Cases',
-      description:
+      description: desc(
         'Retrieve Quality Hub test cases by user story or component. Invokes `sf provar quality-hub testcase retrieve`.',
+        'Retrieve Quality Hub test cases by user story or component via sf CLI.'
+      ),
       inputSchema: {
-        target_org: z.string().describe('SF org alias or username'),
+        target_org: z.string().describe(desc('SF org alias or username', 'string, SF org alias or username')),
         flags: z
           .array(z.string())
           .optional()
           .default([])
-          .describe('Additional raw CLI flags (e.g. ["--user-story", "US-123"])'),
+          .describe(
+            desc(
+              'Additional raw CLI flags (e.g. ["--user-story", "US-123"])',
+              'array of strings, optional; extra CLI flags e.g. --user-story'
+            )
+          ),
         sf_path: z
           .string()
           .optional()
           .describe(
-            'Path to the sf CLI executable when not in PATH ' +
-              '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
-              'Leave unset to use auto-discovery.'
+            desc(
+              'Path to the sf CLI executable when not in PATH ' +
+                '(e.g. "C:\\\\Program Files\\\\sf\\\\bin\\\\sf.cmd" for the Windows standalone installer). ' +
+                'Leave unset to use auto-discovery.',
+              'string, optional; path to sf CLI executable'
+            )
           ),
       },
     },

--- a/src/mcp/tools/rcaTools.ts
+++ b/src/mcp/tools/rcaTools.ts
@@ -16,6 +16,7 @@ import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
+import { desc } from './descHelper.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -395,24 +396,39 @@ export function registerTestRunLocate(server: McpServer): void {
     'provar_testrun_report_locate',
     {
       title: 'Locate Test Report',
-      description: [
-        'Resolve exactly where Provar test run artifacts were written, without parsing them.',
-        'Returns the results directory, paths to JUnit.xml and Index.html if they exist,',
-        'paths to per-test HTML reports, and any validation JSON files.',
-        'Supports explicit results_path override or auto-detection from sf config, provardx properties file, or ANT build.xml.',
-      ].join(' '),
+      description: desc(
+        [
+          'Resolve exactly where Provar test run artifacts were written, without parsing them.',
+          'Returns the results directory, paths to JUnit.xml and Index.html if they exist,',
+          'paths to per-test HTML reports, and any validation JSON files.',
+          'Supports explicit results_path override or auto-detection from sf config, provardx properties file, or ANT build.xml.',
+        ].join(' '),
+        'Resolve Provar test run artifact locations without parsing them.'
+      ),
       inputSchema: {
-        project_path: z.string().describe('Absolute path to the Provar project root'),
+        project_path: z
+          .string()
+          .describe(desc('Absolute path to the Provar project root', 'string, absolute path to project root')),
         results_path: z
           .string()
           .optional()
-          .describe('Explicit override for the results base directory; if provided, skip auto-detection'),
+          .describe(
+            desc(
+              'Explicit override for the results base directory; if provided, skip auto-detection',
+              'string, optional; explicit results base dir override'
+            )
+          ),
         run_index: z
           .number()
           .int()
           .positive()
           .optional()
-          .describe('Which Increment run to target (default: latest); must be a positive integer'),
+          .describe(
+            desc(
+              'Which Increment run to target (default: latest); must be a positive integer',
+              'int >0, optional; Increment run index'
+            )
+          ),
       },
     },
     (input) => {
@@ -675,38 +691,61 @@ export function registerTestRunRca(server: McpServer, config: ServerConfig): voi
     'provar_testrun_rca',
     {
       title: 'Root Cause Analysis',
-      description: [
-        'Parse a completed Provar test run and produce a structured Root Cause Analysis (RCA) report.',
-        'Resolves the results directory, parses JUnit.xml, classifies each failure by category,',
-        'and produces recommendations. Use locate_only=true to skip parsing and just resolve artifact locations.',
-        'Use mode="failures" to get a lightweight array of failed test cases',
-        '([{ testItemId, title, errorMessage }]) without the full RCA classification — useful when you',
-        'need failure names quickly without loading the HTML report.',
-      ].join(' '),
+      description: desc(
+        [
+          'Parse a completed Provar test run and produce a structured Root Cause Analysis (RCA) report.',
+          'Resolves the results directory, parses JUnit.xml, classifies each failure by category,',
+          'and produces recommendations. Use locate_only=true to skip parsing and just resolve artifact locations.',
+          'Use mode="failures" to get a lightweight array of failed test cases',
+          '([{ testItemId, title, errorMessage }]) without the full RCA classification — useful when you',
+          'need failure names quickly without loading the HTML report.',
+        ].join(' '),
+        'Parse a Provar test run JUnit.xml and produce an RCA report with failure classification.'
+      ),
       inputSchema: {
-        project_path: z.string().describe('Absolute path to the Provar project root'),
+        project_path: z
+          .string()
+          .describe(desc('Absolute path to the Provar project root', 'string, absolute path to project root')),
         results_path: z
           .string()
           .optional()
-          .describe('Explicit override for the results base directory; must be within --allowed-paths if provided'),
+          .describe(
+            desc(
+              'Explicit override for the results base directory; must be within --allowed-paths if provided',
+              'string, optional; explicit results base dir override'
+            )
+          ),
         run_index: z
           .number()
           .int()
           .positive()
           .optional()
-          .describe('Which Increment run to target (default: latest); must be a positive integer'),
+          .describe(
+            desc(
+              'Which Increment run to target (default: latest); must be a positive integer',
+              'int >0, optional; Increment run index'
+            )
+          ),
         locate_only: z
           .boolean()
           .optional()
           .default(false)
-          .describe('If true, skip parsing and return just artifact locations'),
+          .describe(
+            desc(
+              'If true, skip parsing and return just artifact locations',
+              'bool, optional; default false, skip parsing'
+            )
+          ),
         mode: z
           .enum(['rca', 'failures'])
           .optional()
           .default('rca')
           .describe(
-            '"rca" (default): full root-cause analysis with classification and recommendations. ' +
-              '"failures": lightweight array of failed test cases [{ testItemId, title, errorMessage }].'
+            desc(
+              '"rca" (default): full root-cause analysis with classification and recommendations. ' +
+                '"failures": lightweight array of failed test cases [{ testItemId, title, errorMessage }].',
+              'enum rca|failures; default rca'
+            )
           ),
       },
     },

--- a/src/mcp/tools/testCaseGenerate.ts
+++ b/src/mcp/tools/testCaseGenerate.ts
@@ -16,6 +16,7 @@ import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
 import { validateTestCase } from './testCaseValidate.js';
+import { desc } from './descHelper.js';
 
 // ── Shorthand → fully-qualified API ID map ────────────────────────────────────
 // Provar runtime requires fully-qualified IDs. Shorthand forms are accepted here
@@ -158,31 +159,70 @@ export function registerTestCaseGenerate(server: McpServer, config: ServerConfig
     'provar_testcase_generate',
     {
       title: 'Generate Test Case',
-      description: TOOL_DESCRIPTION,
+      description: desc(
+        TOOL_DESCRIPTION,
+        'Generate a Provar XML test case skeleton with UUID guids and steps structure.'
+      ),
       inputSchema: {
-        test_case_name: z.string().describe('Test case name (human-readable label)'),
-        steps: z.array(StepSchema).default([]).describe('Ordered list of test steps'),
+        test_case_name: z.string().describe(desc('Test case name (human-readable label)', 'string, test case name')),
+        steps: z
+          .array(StepSchema)
+          .default([])
+          .describe(desc('Ordered list of test steps', 'array, optional; ordered test steps')),
         target_uri: z
           .string()
           .optional()
           .describe(
-            'Page object URI that determines the XML nesting structure. ' +
-              'Omit or use "sf:ui:target" for Salesforce targets (flat structure). ' +
-              'Use "ui:pageobject:target?pageId=pageobjects.PageClass" for non-SF page objects — ' +
-              'steps are wrapped in a UiWithScreen element targeting that class.'
+            desc(
+              'Page object URI that determines the XML nesting structure. ' +
+                'Omit or use "sf:ui:target" for Salesforce targets (flat structure). ' +
+                'Use "ui:pageobject:target?pageId=pageobjects.PageClass" for non-SF page objects — ' +
+                'steps are wrapped in a UiWithScreen element targeting that class.',
+              'string, optional; sf:ui:target (SF) or ui:pageobject:target?pageId=... (non-SF)'
+            )
           ),
-        output_path: z.string().optional().describe('Suggested file path for the .xml file (returned in response)'),
-        overwrite: z.boolean().default(false).describe('Overwrite if output_path file already exists'),
-        dry_run: z.boolean().default(true).describe('true = return XML only (default); false = write to output_path'),
+        output_path: z
+          .string()
+          .optional()
+          .describe(
+            desc(
+              'Suggested file path for the .xml file (returned in response)',
+              'string, optional; output .xml file path'
+            )
+          ),
+        overwrite: z
+          .boolean()
+          .default(false)
+          .describe(desc('Overwrite if output_path file already exists', 'bool, optional; overwrite if exists')),
+        dry_run: z
+          .boolean()
+          .default(true)
+          .describe(
+            desc(
+              'true = return XML only (default); false = write to output_path',
+              'bool, optional; default true, skip write'
+            )
+          ),
         validate_after_edit: z
           .boolean()
           .default(true)
           .describe(
-            'Run structural validation after generation (default: true). ' +
-              'Returns TESTCASE_INVALID error if the generated XML fails validation. ' +
-              'Set false to skip validation and omit the validation field from the response.'
+            desc(
+              'Run structural validation after generation (default: true). ' +
+                'Returns TESTCASE_INVALID error if the generated XML fails validation. ' +
+                'Set false to skip validation and omit the validation field from the response.',
+              'bool, optional; default true, validate after generation'
+            )
           ),
-        idempotency_key: z.string().optional().describe('Caller-provided key echoed back for deduplication tracking'),
+        idempotency_key: z
+          .string()
+          .optional()
+          .describe(
+            desc(
+              'Caller-provided key echoed back for deduplication tracking',
+              'string, optional; deduplication key echoed in response'
+            )
+          ),
       },
     },
     (input) => {

--- a/src/mcp/tools/testCaseStepTools.ts
+++ b/src/mcp/tools/testCaseStepTools.ts
@@ -16,6 +16,7 @@ import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
 import { validateTestCase } from './testCaseValidate.js';
+import { desc } from './descHelper.js';
 
 // ── XML parse / build config ──────────────────────────────────────────────────
 
@@ -86,42 +87,72 @@ export function registerTestCaseStepEdit(server: McpServer, config: ServerConfig
     'provar_testcase_step_edit',
     {
       title: 'Edit Test Case Step',
-      description: [
-        'Add or remove a single step (apiCall) in a Provar XML test case file.',
-        'Uses write-to-temp-then-rename to minimise partial-write risk.',
-        'Prerequisites: the test case must exist and be valid XML.',
-        'For mode=remove: supply test_item_id of the step to remove.',
-        'For mode=add: supply test_item_id of the anchor step, position (before|after, default after),',
-        'and step_xml (the <apiCall ...>...</apiCall> XML fragment for the new step; must contain exactly one <apiCall>).',
-        'A backup is written to <test_case_path>.bak before any mutation and restored automatically if',
-        'the post-edit validation fails.',
-        'Returns STEP_NOT_FOUND (with all_test_item_ids list) when the target step is absent.',
-        'Returns INVALID_STEP_XML when step_xml cannot be parsed or contains ≠1 <apiCall> elements.',
-        'Returns INVALID_XML_AFTER_EDIT (backup restored) when the mutated file fails validation.',
-        'Grounding for step_xml: call provar_qualityhub_examples_retrieve for corpus examples of the step type you need; if the response has count: 0 with a warning field, fall back: read the provar://docs/step-reference MCP resource.',
-      ].join(' '),
+      description: desc(
+        [
+          'Add or remove a single step (apiCall) in a Provar XML test case file.',
+          'Uses write-to-temp-then-rename to minimise partial-write risk.',
+          'Prerequisites: the test case must exist and be valid XML.',
+          'For mode=remove: supply test_item_id of the step to remove.',
+          'For mode=add: supply test_item_id of the anchor step, position (before|after, default after),',
+          'and step_xml (the <apiCall ...>...</apiCall> XML fragment for the new step; must contain exactly one <apiCall>).',
+          'A backup is written to <test_case_path>.bak before any mutation and restored automatically if',
+          'the post-edit validation fails.',
+          'Returns STEP_NOT_FOUND (with all_test_item_ids list) when the target step is absent.',
+          'Returns INVALID_STEP_XML when step_xml cannot be parsed or contains ≠1 <apiCall> elements.',
+          'Returns INVALID_XML_AFTER_EDIT (backup restored) when the mutated file fails validation.',
+          'Grounding for step_xml: call provar_qualityhub_examples_retrieve for corpus examples of the step type you need; if the response has count: 0 with a warning field, fall back: read the provar://docs/step-reference MCP resource.',
+        ].join(' '),
+        'Add or remove a single apiCall step in a Provar XML test case file.'
+      ),
       inputSchema: {
-        test_case_path: z.string().describe('Absolute path to the .testcase XML file; must be within --allowed-paths'),
-        mode: z.enum(['remove', 'add']).describe('"remove" to delete a step; "add" to insert a new step'),
+        test_case_path: z
+          .string()
+          .describe(
+            desc(
+              'Absolute path to the .testcase XML file; must be within --allowed-paths',
+              'string, absolute path to .testcase file'
+            )
+          ),
+        mode: z
+          .enum(['remove', 'add'])
+          .describe(desc('"remove" to delete a step; "add" to insert a new step', 'enum remove|add')),
         test_item_id: z
           .string()
-          .describe('For mode=remove: testItemId of the step to delete. For mode=add: testItemId of the anchor step.'),
+          .describe(
+            desc(
+              'For mode=remove: testItemId of the step to delete. For mode=add: testItemId of the anchor step.',
+              'string, testItemId of target or anchor step'
+            )
+          ),
         position: z
           .enum(['before', 'after'])
           .optional()
           .default('after')
-          .describe('Where to insert relative to the anchor step (mode=add only; default: after)'),
+          .describe(
+            desc(
+              'Where to insert relative to the anchor step (mode=add only; default: after)',
+              'enum before|after; default after'
+            )
+          ),
         step_xml: z
           .string()
           .optional()
           .describe(
-            'The <apiCall ...>...</apiCall> XML fragment for the new step (mode=add only). Must be well-formed XML.'
+            desc(
+              'The <apiCall ...>...</apiCall> XML fragment for the new step (mode=add only). Must be well-formed XML.',
+              'string, optional; <apiCall> XML fragment for new step'
+            )
           ),
         validate_after_edit: z
           .boolean()
           .optional()
           .default(true)
-          .describe('Run provar_testcase_validate after the mutation; restores backup on failure (default: true)'),
+          .describe(
+            desc(
+              'Run provar_testcase_validate after the mutation; restores backup on failure (default: true)',
+              'bool, optional; default true, validate after edit'
+            )
+          ),
       },
     },
     (input) => {

--- a/src/mcp/tools/testCaseValidate.ts
+++ b/src/mcp/tools/testCaseValidate.ts
@@ -24,6 +24,7 @@ import {
   REQUEST_ACCESS_URL,
 } from '../../services/qualityHub/client.js';
 import { runBestPractices } from './bestPracticesEngine.js';
+import { desc } from './descHelper.js';
 
 const ONBOARDING_MESSAGE =
   'Quality Hub validation unavailable — running local validation only (structural rules, no quality scoring).\n' +
@@ -46,12 +47,20 @@ export function registerTestCaseValidate(server: McpServer, config: ServerConfig
     'provar_testcase_validate',
     {
       title: 'Validate Test Case',
-      description:
+      description: desc(
         'Validate a Provar XML test case for structural correctness and quality. Checks XML declaration, root element, required attributes (guid UUID v4, testItemId integer), <steps> presence, and applies best-practice rules. When a Provar API key is configured (via sf provar auth login or PROVAR_API_KEY env var), calls the Quality Hub API for full 170-rule scoring. Falls back to local validation if no key is set or the API is unavailable. Returns validity_score (schema compliance), quality_score (best practices, 0–100), and validation_source indicating which ruleset was applied. When structural errors are returned, consult the provar://docs/step-reference MCP resource for correct step attribute schemas.',
+        'Validate a Provar XML test case: structure, UUIDs, steps, and quality scoring.'
+      ),
       inputSchema: {
-        content: z.string().optional().describe('XML content to validate directly (alias: xml)'),
-        xml: z.string().optional().describe('XML content to validate — API-compatible alias for content'),
-        file_path: z.string().optional().describe('Path to .xml test case file'),
+        content: z
+          .string()
+          .optional()
+          .describe(desc('XML content to validate directly (alias: xml)', 'string, inline content')),
+        xml: z
+          .string()
+          .optional()
+          .describe(desc('XML content to validate — API-compatible alias for content', 'string, inline content')),
+        file_path: z.string().optional().describe(desc('Path to .xml test case file', 'string, path to file')),
       },
     },
     async ({ content, xml, file_path }) => {

--- a/src/mcp/tools/testPlanTools.ts
+++ b/src/mcp/tools/testPlanTools.ts
@@ -15,6 +15,7 @@ import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
+import { desc } from './descHelper.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -64,26 +65,48 @@ export function registerTestPlanCreate(server: McpServer, config: ServerConfig):
     'provar_testplan_create',
     {
       title: 'Create Test Plan',
-      description: [
-        'Create a new Provar test plan: makes the plans/{plan_name}/ directory and writes the root .planitem file.',
-        'Use this before provar_testplan_create-suite or provar_testplan_add-instance, which both require the plan to already exist.',
-        'Returns the guid assigned to the new plan, the plan directory path, and the .planitem path written.',
-      ].join(' '),
+      description: desc(
+        [
+          'Create a new Provar test plan: makes the plans/{plan_name}/ directory and writes the root .planitem file.',
+          'Use this before provar_testplan_create-suite or provar_testplan_add-instance, which both require the plan to already exist.',
+          'Returns the guid assigned to the new plan, the plan directory path, and the .planitem path written.',
+        ].join(' '),
+        'Create a new Provar test plan directory with a root .planitem file.'
+      ),
       inputSchema: {
         project_path: z
           .string()
-          .describe('Absolute path to the Provar project root (must contain a .testproject file)'),
-        plan_name: z.string().describe('Name of the new test plan (becomes the directory name under plans/)'),
+          .describe(
+            desc(
+              'Absolute path to the Provar project root (must contain a .testproject file)',
+              'string, absolute path to project root'
+            )
+          ),
+        plan_name: z
+          .string()
+          .describe(
+            desc('Name of the new test plan (becomes the directory name under plans/)', 'string, test plan name')
+          ),
         overwrite: z
           .boolean()
           .optional()
           .default(false)
-          .describe('Overwrite the .planitem file if the plan directory already exists (default: false)'),
+          .describe(
+            desc(
+              'Overwrite the .planitem file if the plan directory already exists (default: false)',
+              'bool, optional; overwrite .planitem if exists'
+            )
+          ),
         dry_run: z
           .boolean()
           .optional()
           .default(false)
-          .describe('Return what would be created without writing to disk (default: false)'),
+          .describe(
+            desc(
+              'Return what would be created without writing to disk (default: false)',
+              'bool, optional; default false, skip write'
+            )
+          ),
       },
     },
     ({ project_path, plan_name, overwrite, dry_run }) => {
@@ -203,33 +226,60 @@ export function registerTestPlanAddInstance(server: McpServer, config: ServerCon
     'provar_testplan_add-instance',
     {
       title: 'Add Test Plan Instance',
-      description: [
-        'Add a .testinstance file to an existing Provar test plan suite directory.',
-        'The plan directory and suite directory must already exist.',
-        'test_case_path is relative to the project root (e.g. "tests/MyTest.testcase").',
-        'suite_path is the path within the plan (e.g. "MySuite" or "MySuite/SubSuite").',
-        'Returns the guid assigned to the new instance and the path where it was written.',
-      ].join(' '),
+      description: desc(
+        [
+          'Add a .testinstance file to an existing Provar test plan suite directory.',
+          'The plan directory and suite directory must already exist.',
+          'test_case_path is relative to the project root (e.g. "tests/MyTest.testcase").',
+          'suite_path is the path within the plan (e.g. "MySuite" or "MySuite/SubSuite").',
+          'Returns the guid assigned to the new instance and the path where it was written.',
+        ].join(' '),
+        'Add a .testinstance file to an existing test plan suite directory.'
+      ),
       inputSchema: {
-        project_path: z.string().describe('Absolute path to the Provar project root'),
+        project_path: z
+          .string()
+          .describe(desc('Absolute path to the Provar project root', 'string, absolute path to project root')),
         test_case_path: z
           .string()
-          .describe('Path to the .testcase file, relative to project root (e.g. "tests/MyTest.testcase")'),
-        plan_name: z.string().describe('Name of the test plan (directory under plans/)'),
+          .describe(
+            desc(
+              'Path to the .testcase file, relative to project root (e.g. "tests/MyTest.testcase")',
+              'string, relative path to .testcase file'
+            )
+          ),
+        plan_name: z
+          .string()
+          .describe(desc('Name of the test plan (directory under plans/)', 'string, test plan name')),
         suite_path: z
           .string()
           .optional()
-          .describe('Path within the plan to place the instance (e.g. "MySuite" or "MySuite/SubSuite")'),
+          .describe(
+            desc(
+              'Path within the plan to place the instance (e.g. "MySuite" or "MySuite/SubSuite")',
+              'string, optional; suite path within plan'
+            )
+          ),
         overwrite: z
           .boolean()
           .optional()
           .default(false)
-          .describe('Overwrite the .testinstance file if it already exists (default: false)'),
+          .describe(
+            desc(
+              'Overwrite the .testinstance file if it already exists (default: false)',
+              'bool, optional; overwrite if exists'
+            )
+          ),
         dry_run: z
           .boolean()
           .optional()
           .default(false)
-          .describe('Return what would be written without writing to disk (default: false)'),
+          .describe(
+            desc(
+              'Return what would be written without writing to disk (default: false)',
+              'bool, optional; default false, skip write'
+            )
+          ),
       },
     },
     ({ project_path, test_case_path, plan_name, suite_path, overwrite, dry_run }) => {
@@ -423,25 +473,44 @@ export function registerTestPlanCreateSuite(server: McpServer, config: ServerCon
     'provar_testplan_create-suite',
     {
       title: 'Create Test Plan Suite',
-      description: [
-        'Create a new suite directory inside a Provar test plan.',
-        'The plan directory must already exist with a .planitem file at its root.',
-        'Writes a new .planitem file into the created suite directory.',
-        'Returns the guid assigned to the new suite.',
-      ].join(' '),
+      description: desc(
+        [
+          'Create a new suite directory inside a Provar test plan.',
+          'The plan directory must already exist with a .planitem file at its root.',
+          'Writes a new .planitem file into the created suite directory.',
+          'Returns the guid assigned to the new suite.',
+        ].join(' '),
+        'Create a new suite directory with a .planitem inside a test plan.'
+      ),
       inputSchema: {
-        project_path: z.string().describe('Absolute path to the Provar project root'),
-        plan_name: z.string().describe('Name of the test plan (directory under plans/)'),
-        suite_name: z.string().describe('Name of the new suite directory to create'),
+        project_path: z
+          .string()
+          .describe(desc('Absolute path to the Provar project root', 'string, absolute path to project root')),
+        plan_name: z
+          .string()
+          .describe(desc('Name of the test plan (directory under plans/)', 'string, test plan name')),
+        suite_name: z
+          .string()
+          .describe(desc('Name of the new suite directory to create', 'string, new suite directory name')),
         parent_suite_path: z
           .string()
           .optional()
-          .describe('Path of the parent suite within the plan (e.g. "MySuite"). Omit to create at plan root.'),
+          .describe(
+            desc(
+              'Path of the parent suite within the plan (e.g. "MySuite"). Omit to create at plan root.',
+              'string, optional; parent suite path within plan'
+            )
+          ),
         dry_run: z
           .boolean()
           .optional()
           .default(false)
-          .describe('Return what would be created without writing to disk (default: false)'),
+          .describe(
+            desc(
+              'Return what would be created without writing to disk (default: false)',
+              'bool, optional; default false, skip write'
+            )
+          ),
       },
     },
     ({ project_path, plan_name, suite_name, parent_suite_path, dry_run }) => {
@@ -571,19 +640,36 @@ export function registerTestPlanRemoveInstance(server: McpServer, config: Server
     'provar_testplan_remove-instance',
     {
       title: 'Remove Test Plan Instance',
-      description: [
-        'Remove a .testinstance file from a Provar test plan.',
-        'instance_path is relative to the project root.',
-        'Returns the path of the removed file.',
-      ].join(' '),
+      description: desc(
+        [
+          'Remove a .testinstance file from a Provar test plan.',
+          'instance_path is relative to the project root.',
+          'Returns the path of the removed file.',
+        ].join(' '),
+        'Remove a .testinstance file from a Provar test plan.'
+      ),
       inputSchema: {
-        project_path: z.string().describe('Absolute path to the Provar project root'),
-        instance_path: z.string().describe('Path to the .testinstance file, relative to project root'),
+        project_path: z
+          .string()
+          .describe(desc('Absolute path to the Provar project root', 'string, absolute path to project root')),
+        instance_path: z
+          .string()
+          .describe(
+            desc(
+              'Path to the .testinstance file, relative to project root',
+              'string, relative path to .testinstance file'
+            )
+          ),
         dry_run: z
           .boolean()
           .optional()
           .default(false)
-          .describe('Return what would be removed without deleting (default: false)'),
+          .describe(
+            desc(
+              'Return what would be removed without deleting (default: false)',
+              'bool, optional; default false, skip delete'
+            )
+          ),
       },
     },
     ({ project_path, instance_path, dry_run }) => {

--- a/src/mcp/tools/testPlanValidate.ts
+++ b/src/mcp/tools/testPlanValidate.ts
@@ -11,6 +11,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
 import { validatePlan, buildHierarchySummary, type TestPlanInput } from './hierarchyValidate.js';
+import { desc } from './descHelper.js';
 
 // ── Zod schemas ───────────────────────────────────────────────────────────────
 
@@ -75,25 +76,35 @@ export function registerTestPlanValidate(server: McpServer): void {
     'provar_testplan_validate',
     {
       title: 'Validate Test Plan',
-      description:
+      description: desc(
         'Validate a Provar test plan: checks for empty plans, duplicate suite names, oversized plans (>20 suites), plan completeness (objectives, scope, methodology, environments, acceptance criteria, test data strategy, risk assessment), and naming consistency. Recursively validates child suites and test cases. Returns quality score, plan-level violations, and full hierarchy results.',
+        'Validate a Provar test plan: naming, size, completeness, and per-suite quality.'
+      ),
       inputSchema: {
-        plan_name: z.string().describe('Name of the test plan'),
-        test_suites: z.array(suiteSchema).optional().describe('Test suites belonging to this plan'),
-        test_cases: z.array(testCaseSchema).optional().describe('Test cases directly in this plan (not in a suite)'),
+        plan_name: z.string().describe(desc('Name of the test plan', 'string')),
+        test_suites: z
+          .array(suiteSchema)
+          .optional()
+          .describe(desc('Test suites belonging to this plan', 'object[], optional')),
+        test_cases: z
+          .array(testCaseSchema)
+          .optional()
+          .describe(desc('Test cases directly in this plan (not in a suite)', 'object[], optional')),
         test_suite_count: z
           .number()
           .int()
           .min(0)
           .optional()
-          .describe('Explicit suite count for size check (overrides counting test_suites)'),
+          .describe(desc('Explicit suite count for size check (overrides counting test_suites)', 'int ≥0, optional')),
         metadata: metadataSchema,
         quality_threshold: z
           .number()
           .min(0)
           .max(100)
           .optional()
-          .describe('Minimum quality score for a test case to be considered valid (default: 80)'),
+          .describe(
+            desc('Minimum quality score for a test case to be considered valid (default: 80)', 'number 0–100, optional')
+          ),
       },
     },
     ({ plan_name, test_suites, test_cases, test_suite_count, metadata, quality_threshold }) => {

--- a/src/mcp/tools/testSuiteValidate.ts
+++ b/src/mcp/tools/testSuiteValidate.ts
@@ -11,6 +11,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
 import { validateSuite, buildHierarchySummary, type TestSuiteInput } from './hierarchyValidate.js';
+import { desc } from './descHelper.js';
 
 // ── Zod schemas ───────────────────────────────────────────────────────────────
 
@@ -47,27 +48,36 @@ export function registerTestSuiteValidate(server: McpServer): void {
     'provar_testsuite_validate',
     {
       title: 'Validate Test Suite',
-      description:
+      description: desc(
         'Validate a Provar test suite: checks for empty suites, duplicate names, oversized suites (>75 tests), and naming convention consistency. Recursively validates child suites and individual test case XML. Returns quality score, suite-level violations, and per-test-case results.',
+        'Validate a Provar test suite: naming, size, duplicates, and per-test-case quality.'
+      ),
       inputSchema: {
-        suite_name: z.string().describe('Name of the test suite'),
-        test_cases: z.array(testCaseSchema).optional().describe('Test cases directly in this suite'),
+        suite_name: z.string().describe(desc('Name of the test suite', 'string')),
+        test_cases: z
+          .array(testCaseSchema)
+          .optional()
+          .describe(desc('Test cases directly in this suite', 'object[], optional')),
         child_suites: z
           .array(childSuiteSchema)
           .optional()
-          .describe('Child test suites (supports up to 2 levels of nesting)'),
+          .describe(desc('Child test suites (supports up to 2 levels of nesting)', 'object[], optional')),
         test_case_count: z
           .number()
           .int()
           .min(0)
           .optional()
-          .describe('Explicit total test case count for size check (overrides counting test_cases)'),
+          .describe(
+            desc('Explicit total test case count for size check (overrides counting test_cases)', 'int ≥0, optional')
+          ),
         quality_threshold: z
           .number()
           .min(0)
           .max(100)
           .optional()
-          .describe('Minimum quality score for a test case to be considered valid (default: 80)'),
+          .describe(
+            desc('Minimum quality score for a test case to be considered valid (default: 80)', 'number 0–100, optional')
+          ),
       },
     },
     ({ suite_name, test_cases, child_suites, test_case_count, quality_threshold }) => {

--- a/test/unit/mcp/startupTuning.test.ts
+++ b/test/unit/mcp/startupTuning.test.ts
@@ -9,6 +9,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it, afterEach } from 'mocha';
 import { parseActiveGroups } from '../../../src/mcp/server.js';
+import { desc } from '../../../src/mcp/tools/descHelper.js';
 import { registerTestSuiteValidate } from '../../../src/mcp/tools/testSuiteValidate.js';
 import { registerAllNitroXTools } from '../../../src/mcp/tools/nitroXTools.js';
 import { registerProjectInspect } from '../../../src/mcp/tools/projectInspect.js';
@@ -26,6 +27,28 @@ class MockMcpServer {
 }
 
 const MOCK_CONFIG = { allowedPaths: ['/tmp'] };
+
+// ── PDX-468: desc() helper ────────────────────────────────────────────────────
+
+describe('desc() helper (PDX-468)', () => {
+  afterEach(() => {
+    delete process.env['PROVAR_MCP_SCHEMA_MODE'];
+  });
+
+  it('returns standard string when PROVAR_MCP_SCHEMA_MODE is unset', () => {
+    assert.equal(desc('standard text', 'compact text'), 'standard text');
+  });
+
+  it('returns compact string when PROVAR_MCP_SCHEMA_MODE=compact', () => {
+    process.env['PROVAR_MCP_SCHEMA_MODE'] = 'compact';
+    assert.equal(desc('standard text', 'compact text'), 'compact text');
+  });
+
+  it('returns standard string for any value other than "compact"', () => {
+    process.env['PROVAR_MCP_SCHEMA_MODE'] = 'verbose';
+    assert.equal(desc('standard text', 'compact text'), 'standard text');
+  });
+});
 
 // ── PDX-468: compact descriptions in registered tools ─────────────────────────
 
@@ -121,6 +144,16 @@ describe('parseActiveGroups() (PDX-469)', () => {
     assert.ok(groups instanceof Set);
     assert.equal(groups.size, 1);
     assert.ok(groups.has('nitrox'));
+  });
+
+  it('returns null when env var is only a comma (no valid group names)', () => {
+    process.env['PROVAR_MCP_TOOLS'] = ',';
+    assert.equal(parseActiveGroups(), null);
+  });
+
+  it('returns null when env var is only commas (no valid group names)', () => {
+    process.env['PROVAR_MCP_TOOLS'] = ',,';
+    assert.equal(parseActiveGroups(), null);
   });
 });
 

--- a/test/unit/mcp/startupTuning.test.ts
+++ b/test/unit/mcp/startupTuning.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2024 Provar Limited.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.md file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-disable camelcase */
+import { strict as assert } from 'node:assert';
+import { describe, it, afterEach } from 'mocha';
+import { parseActiveGroups } from '../../../src/mcp/server.js';
+import { registerTestSuiteValidate } from '../../../src/mcp/tools/testSuiteValidate.js';
+import { registerAllNitroXTools } from '../../../src/mcp/tools/nitroXTools.js';
+import { registerProjectInspect } from '../../../src/mcp/tools/projectInspect.js';
+
+// ── Minimal McpServer mock ─────────────────────────────────────────────────────
+
+type ToolConfig = { title?: string; description: string; inputSchema: unknown };
+
+class MockMcpServer {
+  public readonly registered = new Map<string, ToolConfig>();
+
+  public registerTool(name: string, config: ToolConfig): void {
+    this.registered.set(name, config);
+  }
+}
+
+const MOCK_CONFIG = { allowedPaths: ['/tmp'] };
+
+// ── PDX-468: compact descriptions in registered tools ─────────────────────────
+
+describe('compact tool descriptions (PDX-468)', () => {
+  afterEach(() => {
+    delete process.env['PROVAR_MCP_SCHEMA_MODE'];
+  });
+
+  it('registers standard description when PROVAR_MCP_SCHEMA_MODE is unset', () => {
+    const mock = new MockMcpServer();
+    registerTestSuiteValidate(mock as never);
+    const cfg = mock.registered.get('provar_testsuite_validate');
+    assert.ok(cfg, 'provar_testsuite_validate should be registered');
+    assert.ok(cfg.description.length > 50, 'standard description should be multi-sentence (>50 chars)');
+    assert.ok(cfg.description.includes('checks for empty suites'), 'standard description should include detail text');
+  });
+
+  it('registers compact description when PROVAR_MCP_SCHEMA_MODE=compact', () => {
+    process.env['PROVAR_MCP_SCHEMA_MODE'] = 'compact';
+    const mock = new MockMcpServer();
+    registerTestSuiteValidate(mock as never);
+    const cfg = mock.registered.get('provar_testsuite_validate');
+    assert.ok(cfg, 'provar_testsuite_validate should be registered');
+    assert.ok(
+      cfg.description.length <= 100,
+      `compact description should be short (≤100 chars), got ${cfg.description.length}`
+    );
+    assert.ok(
+      !cfg.description.includes('checks for empty suites'),
+      'compact description should not contain prose detail'
+    );
+  });
+
+  it('reverts to standard description when PROVAR_MCP_SCHEMA_MODE is unrecognised', () => {
+    process.env['PROVAR_MCP_SCHEMA_MODE'] = 'verbose';
+    const mock = new MockMcpServer();
+    registerTestSuiteValidate(mock as never);
+    const cfg = mock.registered.get('provar_testsuite_validate');
+    assert.ok(cfg, 'provar_testsuite_validate should be registered');
+    assert.ok(cfg.description.includes('checks for empty suites'), 'should fall back to standard for unknown mode');
+  });
+});
+
+// ── PDX-469: parseActiveGroups() ──────────────────────────────────────────────
+
+describe('parseActiveGroups() (PDX-469)', () => {
+  afterEach(() => {
+    delete process.env['PROVAR_MCP_TOOLS'];
+  });
+
+  it('returns null when env var is unset (all groups active)', () => {
+    assert.equal(parseActiveGroups(), null);
+  });
+
+  it('returns null when env var is empty string', () => {
+    process.env['PROVAR_MCP_TOOLS'] = '';
+    assert.equal(parseActiveGroups(), null);
+  });
+
+  it('returns null when env var is whitespace only', () => {
+    process.env['PROVAR_MCP_TOOLS'] = '   ';
+    assert.equal(parseActiveGroups(), null);
+  });
+
+  it('returns a Set with a single group name (lowercased)', () => {
+    process.env['PROVAR_MCP_TOOLS'] = 'nitroX';
+    const groups = parseActiveGroups();
+    assert.ok(groups instanceof Set);
+    assert.equal(groups.size, 1);
+    assert.ok(groups.has('nitrox'));
+  });
+
+  it('returns a Set with multiple group names (lowercased)', () => {
+    process.env['PROVAR_MCP_TOOLS'] = 'nitroX,validation';
+    const groups = parseActiveGroups();
+    assert.ok(groups instanceof Set);
+    assert.equal(groups.size, 2);
+    assert.ok(groups.has('nitrox'));
+    assert.ok(groups.has('validation'));
+  });
+
+  it('trims whitespace around group names', () => {
+    process.env['PROVAR_MCP_TOOLS'] = ' nitroX , validation ';
+    const groups = parseActiveGroups();
+    assert.ok(groups instanceof Set);
+    assert.ok(groups.has('nitrox'));
+    assert.ok(groups.has('validation'));
+  });
+
+  it('ignores empty segments from trailing commas', () => {
+    process.env['PROVAR_MCP_TOOLS'] = 'nitroX,';
+    const groups = parseActiveGroups();
+    assert.ok(groups instanceof Set);
+    assert.equal(groups.size, 1);
+    assert.ok(groups.has('nitrox'));
+  });
+});
+
+// ── PDX-469: tool profile registration ────────────────────────────────────────
+
+describe('tool profile registration (PDX-469)', () => {
+  afterEach(() => {
+    delete process.env['PROVAR_MCP_TOOLS'];
+  });
+
+  it('registers nitroX tools when profile includes nitrox', () => {
+    process.env['PROVAR_MCP_TOOLS'] = 'nitroX';
+    const mock = new MockMcpServer();
+    registerAllNitroXTools(mock as never, MOCK_CONFIG);
+    assert.ok(mock.registered.has('provar_nitrox_discover'), 'nitrox tools should be registered');
+    assert.ok(mock.registered.has('provar_nitrox_generate'), 'nitrox generate should be registered');
+  });
+
+  it('registers inspect tools independently of profile (direct call)', () => {
+    process.env['PROVAR_MCP_TOOLS'] = 'nitrox';
+    const mock = new MockMcpServer();
+    registerProjectInspect(mock as never, MOCK_CONFIG);
+    assert.ok(mock.registered.has('provar_project_inspect'));
+  });
+
+  it('provardx_ping group is not in parseActiveGroups — it is always registered separately', () => {
+    process.env['PROVAR_MCP_TOOLS'] = 'nitrox';
+    const groups = parseActiveGroups();
+    assert.ok(groups !== null, 'groups should be a Set when PROVAR_MCP_TOOLS is set');
+    assert.ok(!groups.has('ping'), 'ping is not a filterable group');
+  });
+});


### PR DESCRIPTION
## Summary

- **PDX-468**: `PROVAR_MCP_SCHEMA_MODE=compact` — when set, every tool description switches to a short summary via a new `desc(standard, compact)` helper. All 19 tool files wrapped (220 call sites). Saves hundreds of tokens per tool at handshake time.
- **PDX-469**: `PROVAR_MCP_TOOLS=group1,group2` — comma-separated list of tool groups to register at startup. `provardx_ping` always registered. Groups: nitrox, automation, qualityhub, validation, authoring, inspect, connection, rca.

## Changes

- `src/mcp/tools/descHelper.ts` — new `desc(standard, compact)` helper
- `src/mcp/server.ts` — TOOL_GROUPS registry, parseActiveGroups() export, group-loop registration
- 19 tool files — all descriptions and z.describe() calls wrapped with desc()
- `test/unit/mcp/startupTuning.test.ts` — 13 unit tests (compact mode + group filtering)
- `docs/mcp.md` — env var table updated + new Agent performance tuning section

## Test plan

- [ ] mocha startupTuning.test.ts → 13 passing
- [ ] mcp-smoke.cjs → 54/54 PASS (default config)
- [ ] tsc --noEmit → clean
- [ ] Set PROVAR_MCP_SCHEMA_MODE=compact and inspect tool description — should be short
- [ ] Set PROVAR_MCP_TOOLS=nitrox — only NitroX tools + ping visible

Generated with Claude Code