### PR TITLE
PDX-478: fix(mcp): parse .testproject connections and resolve env via associations

### DIFF
--- a/src/mcp/tools/connectionTools.ts
+++ b/src/mcp/tools/connectionTools.ts
@@ -59,7 +59,12 @@ const TP_PARSER = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: '@_',
   parseAttributeValue: false,
-  isArray: (name): boolean => name === 'connectionClass' || name === 'connection' || name === 'environment',
+  isArray: (name): boolean =>
+    name === 'connectionClass' ||
+    name === 'connection' ||
+    name === 'environment' ||
+    name === 'connectionUrl' ||
+    name === 'association',
 });
 
 class XmlParseError extends Error {
@@ -77,32 +82,72 @@ function parseTestProjectXml(content: string): Record<string, unknown> {
   return raw !== null && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
 }
 
-function parseConnectionList(content: string): ConnectionEntry[] {
-  const tp = parseTestProjectXml(content);
+interface ConnectionInfo {
+  name: string;
+  className: string;
+  defaultUrl?: string;
+  urlsByEnvId: Map<string, string>;
+}
+
+function buildConnectionMap(tp: Record<string, unknown>): Map<string, ConnectionInfo> {
+  const map = new Map<string, ConnectionInfo>();
   const cc = tp['connectionClasses'];
-  if (!cc || typeof cc !== 'object') return [];
+  if (!cc || typeof cc !== 'object') return map;
 
   const classesRaw = (cc as Record<string, unknown>)['connectionClass'];
-  if (!classesRaw) return [];
-  const classes = classesRaw as Array<Record<string, unknown>>;
+  if (!Array.isArray(classesRaw)) return map;
 
-  const connections: ConnectionEntry[] = [];
-  for (const cls of classes) {
+  for (const cls of classesRaw as Array<Record<string, unknown>>) {
     const className = cls['@_name'] as string | undefined;
     if (!className) continue;
-    const connsRaw = cls['connection'];
-    if (!connsRaw) continue;
+    // Real .testproject XML nests each <connection> inside a <connections> wrapper.
+    const connsWrap = cls['connections'] as Record<string, unknown> | undefined;
+    const connsRaw = connsWrap?.['connection'];
+    if (!Array.isArray(connsRaw)) continue;
     for (const conn of connsRaw as Array<Record<string, unknown>>) {
-      const connName = conn['@_name'] as string | undefined;
-      if (!connName) continue;
-      const url = conn['@_url'] as string | undefined;
-      connections.push({
-        name: connName,
-        type: classToType(className),
-        ...(url ? { url } : {}),
-        sso_configured: className === 'sso',
-      });
+      const id = conn['@_id'] as string | undefined;
+      const name = conn['@_name'] as string | undefined;
+      if (!name) continue;
+
+      let defaultUrl: string | undefined;
+      const urlsByEnvId = new Map<string, string>();
+      const urlsWrap = conn['connectionUrls'] as Record<string, unknown> | undefined;
+      const urlsRaw = urlsWrap?.['connectionUrl'];
+      if (Array.isArray(urlsRaw)) {
+        for (const u of urlsRaw as Array<Record<string, unknown>>) {
+          const url = u['@_url'] as string | undefined;
+          if (!url) continue;
+          const envId = u['@_envId'] as string | undefined;
+          // The base entry (no @_envId) is the connection's default URL;
+          // entries with @_envId are environment-specific overrides keyed by env GUID.
+          if (envId) urlsByEnvId.set(envId, url);
+          else if (defaultUrl === undefined) defaultUrl = url;
+        }
+      }
+
+      const info: ConnectionInfo = { name, className, defaultUrl, urlsByEnvId };
+      if (id) map.set(id, info);
+      // Also key by name so name-based lookups (e.g. legacy callers) still work.
+      map.set(`name:${name}`, info);
     }
+  }
+  return map;
+}
+
+function parseConnectionList(content: string): ConnectionEntry[] {
+  const tp = parseTestProjectXml(content);
+  const map = buildConnectionMap(tp);
+  const connections: ConnectionEntry[] = [];
+  const seen = new Set<ConnectionInfo>();
+  for (const info of map.values()) {
+    if (seen.has(info)) continue;
+    seen.add(info);
+    connections.push({
+      name: info.name,
+      type: classToType(info.className),
+      ...(info.defaultUrl ? { url: info.defaultUrl } : {}),
+      sso_configured: info.className === 'sso',
+    });
   }
   return connections;
 }
@@ -113,18 +158,38 @@ function parseEnvironmentList(content: string): EnvironmentEntry[] {
   if (!envSection || typeof envSection !== 'object') return [];
 
   const envsRaw = (envSection as Record<string, unknown>)['environment'];
-  if (!envsRaw) return [];
+  if (!Array.isArray(envsRaw)) return [];
 
+  const connectionMap = buildConnectionMap(tp);
   const environments: EnvironmentEntry[] = [];
   for (const env of envsRaw as Array<Record<string, unknown>>) {
     const name = env['@_name'] as string | undefined;
     if (!name) continue;
-    const connection = env['@_connectionName'] as string | undefined;
-    const url = env['@_url'] as string | undefined;
+    const envGuid = env['@_guid'] as string | undefined;
+
+    let connectionName = '';
+    let envUrl: string | undefined;
+    // associations may be missing, an empty string (no associations), or an object wrapping an array.
+    const assocs = env['associations'];
+    if (assocs !== null && typeof assocs === 'object') {
+      const assocsRaw = (assocs as Record<string, unknown>)['association'];
+      if (Array.isArray(assocsRaw) && assocsRaw.length > 0) {
+        const first = assocsRaw[0] as Record<string, unknown>;
+        const connId = first['@_connectionId'] as string | undefined;
+        if (connId) {
+          const info = connectionMap.get(connId);
+          if (info) {
+            connectionName = info.name;
+            if (envGuid) envUrl = info.urlsByEnvId.get(envGuid);
+          }
+        }
+      }
+    }
+
     environments.push({
       name,
-      connection: connection ?? '',
-      ...(url ? { url } : {}),
+      connection: connectionName,
+      ...(envUrl ? { url: envUrl } : {}),
     });
   }
   return environments;

--- a/test/unit/mcp/connectionTools.test.ts
+++ b/test/unit/mcp/connectionTools.test.ts
@@ -53,27 +53,62 @@ function writeTestProject(dir: string, content: string): void {
 
 // ── .testproject fixture content ──────────────────────────────────────────────
 
+// Mirrors the real .testproject XML shape:
+//   connectionClass → connections → connection → connectionUrls → connectionUrl
+//   environment → associations → association[@connectionId]
+// The pre-PDX-478 fixture used a flattened shape that did not exist in real
+// projects, which is how the parser bugs slipped through CI.
 const BASIC_TEST_PROJECT = `<?xml version="1.0" encoding="UTF-8"?>
 <testProject>
   <connectionClasses>
     <connectionClass name="sf">
-      <connection name="MyOrg" url="sfdc://user@example.com;environment=SANDBOX">
-      </connection>
-      <connection name="AdminOrg" url="sfdc://admin@example.com;environment=PROD_DEV">
-      </connection>
+      <connections>
+        <connection id="conn-myorg" name="MyOrg">
+          <connectionUrls>
+            <connectionUrl url="sfdc://user@example.com;environment=SANDBOX" />
+            <connectionUrl envId="env-qa" envName="QA" url="sfdc://user@example.com.qa;environment=SANDBOX" />
+          </connectionUrls>
+        </connection>
+        <connection id="conn-adminorg" name="AdminOrg">
+          <connectionUrls>
+            <connectionUrl url="sfdc://admin@example.com;environment=PROD_DEV" />
+          </connectionUrls>
+        </connection>
+      </connections>
     </connectionClass>
     <connectionClass name="ui">
-      <connection name="Chrome" url="selenium://chrome">
-      </connection>
+      <connections>
+        <connection id="conn-chrome" name="Chrome">
+          <connectionUrls>
+            <connectionUrl url="selenium://chrome" />
+          </connectionUrls>
+        </connection>
+      </connections>
     </connectionClass>
     <connectionClass name="sso">
-      <connection name="OktaSso" url="sso://okta.example.com">
-      </connection>
+      <connections>
+        <connection id="conn-okta" name="OktaSso">
+          <connectionUrls>
+            <connectionUrl url="sso://okta.example.com" />
+          </connectionUrls>
+        </connection>
+      </connections>
     </connectionClass>
   </connectionClasses>
   <environments>
-    <environment name="QA" connectionName="MyOrg" url="https://qa.example.com" />
-    <environment name="UAT" connectionName="AdminOrg" />
+    <environment guid="env-qa" name="QA">
+      <associations>
+        <association assocationType="TM.ENVIRONMENT" connectionId="conn-myorg" />
+      </associations>
+    </environment>
+    <environment guid="env-uat" name="UAT">
+      <associations>
+        <association assocationType="TM.ENVIRONMENT" connectionId="conn-adminorg" />
+      </associations>
+    </environment>
+    <environment guid="env-noassoc" name="NoAssoc">
+      <associations></associations>
+    </environment>
   </environments>
 </testProject>
 `;
@@ -151,25 +186,53 @@ describe('provar_connection_list', () => {
       assert.equal(sfConn['sso_configured'], false);
     });
 
-    it('returns environments with name, connection, and url', () => {
+    it('resolves environment.connection via associations[@connectionId]', () => {
       writeTestProject(tmpDir, BASIC_TEST_PROJECT);
       const result = server.call('provar_connection_list', { project_path: tmpDir });
       const environments = parseText(result)['environments'] as Array<Record<string, unknown>>;
       assert.ok(Array.isArray(environments));
-      assert.equal(environments.length, 2);
+      assert.equal(environments.length, 3);
       const qa = environments.find((e) => e['name'] === 'QA');
       assert.ok(qa);
       assert.equal(qa['connection'], 'MyOrg');
-      assert.equal(qa['url'], 'https://qa.example.com');
     });
 
-    it('returns environment without url when not present', () => {
+    it('returns environment-specific url when a connectionUrl has @envId matching env @guid', () => {
+      writeTestProject(tmpDir, BASIC_TEST_PROJECT);
+      const result = server.call('provar_connection_list', { project_path: tmpDir });
+      const environments = parseText(result)['environments'] as Array<Record<string, unknown>>;
+      const qa = environments.find((e) => e['name'] === 'QA');
+      assert.ok(qa);
+      assert.equal(qa['url'], 'sfdc://user@example.com.qa;environment=SANDBOX');
+    });
+
+    it('omits url on environment when no per-env connectionUrl exists', () => {
       writeTestProject(tmpDir, BASIC_TEST_PROJECT);
       const result = server.call('provar_connection_list', { project_path: tmpDir });
       const environments = parseText(result)['environments'] as Array<Record<string, unknown>>;
       const uat = environments.find((e) => e['name'] === 'UAT');
       assert.ok(uat);
-      assert.equal(uat['url'], undefined, 'UAT has no url attribute');
+      assert.equal(uat['url'], undefined, 'UAT has no @envId-matched connectionUrl');
+    });
+
+    it("handles environments with empty <associations> gracefully (no crash, connection='')", () => {
+      writeTestProject(tmpDir, BASIC_TEST_PROJECT);
+      const result = server.call('provar_connection_list', { project_path: tmpDir });
+      assert.equal(isError(result), false);
+      const environments = parseText(result)['environments'] as Array<Record<string, unknown>>;
+      const noAssoc = environments.find((e) => e['name'] === 'NoAssoc');
+      assert.ok(noAssoc);
+      assert.equal(noAssoc['connection'], '');
+      assert.equal(noAssoc['url'], undefined);
+    });
+
+    it('connection.url uses the default connectionUrl (entry without @envId)', () => {
+      writeTestProject(tmpDir, BASIC_TEST_PROJECT);
+      const result = server.call('provar_connection_list', { project_path: tmpDir });
+      const connections = parseText(result)['connections'] as Array<Record<string, unknown>>;
+      const myOrg = connections.find((c) => c['name'] === 'MyOrg');
+      assert.ok(myOrg);
+      assert.equal(myOrg['url'], 'sfdc://user@example.com;environment=SANDBOX');
     });
 
     it('returns summary with correct counts', () => {
@@ -177,7 +240,7 @@ describe('provar_connection_list', () => {
       const result = server.call('provar_connection_list', { project_path: tmpDir });
       const summary = parseText(result)['summary'] as Record<string, number>;
       assert.equal(summary['connection_count'], 4);
-      assert.equal(summary['environment_count'], 2);
+      assert.equal(summary['environment_count'], 3);
     });
 
     it('returns empty arrays for project with no connections or environments', () => {


### PR DESCRIPTION
## Summary

Fixes both parser bugs in `src/mcp/tools/connectionTools.ts` that made `provar_connection_list` effectively non-functional on every real Provar project.

- **`parseConnectionList`** now traverses `connectionClass.connections.connection[]` (the real XML shape) instead of `connectionClass.connection[]`
- **`parseEnvironmentList`** now resolves the environment's connection by walking `associations.association[].@connectionId` and looking up the name from the connection ID map. Environment-specific URLs are matched by environment `@guid` against `connectionUrl.@envId`
- Empty `<associations></associations>` (real-world edge case from `TrialProject`) is handled gracefully — returns `connection: ''` without crashing

Linked: [PDX-478](https://provartesting.atlassian.net/browse/PDX-478)

## Why this was missed

The existing test fixture used a flattened XML shape (`<connectionClass><connection name=... url=.../></connectionClass>` and `<environment connectionName=... url=.../>`) that did not exist in any real Provar `.testproject` file — but exactly matched the buggy parser code. The fixture has been rewritten to mirror the real XML produced by Provar Desktop, including the `<connections>` wrapper, `<connectionUrls><connectionUrl @envId=.../>` per-env URL list, and `<associations><association @connectionId=.../>` environment-to-connection link.

## Impact (pre-fix baseline)

Surveyed 7 real Provar projects — every one returned 0 connections:

| Project | connectionClass / connection count | `connection_list` returned |
|---|---|---|
| provar-manager-regression | 6 / 12 | 0 |
| Agentforce | 4 / 16 | 0 |
| ExperienceCloud | 4 / 15 | 0 |
| FinancialServices | 2 / 9 | 0 |
| PQP | 5 / 11 | 0 |
| ProvarDXGrid | 2 / 2 | 0 |
| TrialProject | 2 / 2 | 0 |

Post-fix: every project returns its full connection list and environment-to-connection links resolve correctly.

## Test plan

- [x] `yarn compile` clean
- [x] `yarn lint` clean
- [x] Full unit suite passes — **1109 passing**, 0 failing (bypassed wireit cache)
- [x] `node scripts/mcp-smoke.cjs` — **54/54 PASS**
- [x] Manual e2e verified across 7 real projects (see table above) — all return non-zero connection counts post-fix
- [x] Sub-field stripping from PDX-472 (`fields=connections.name,connections.type`) verified end-to-end on real data — previously vacuous due to empty connection arrays
- [x] Empty-`<associations>` edge case (TrialProject) handled without crash

## Test coverage added

New assertions in `test/unit/mcp/connectionTools.test.ts`:
- env→connection resolved via `associations[@connectionId]`
- env-specific URL when `connectionUrl.@envId` matches env `@guid`
- env URL omitted when no per-env URL exists
- empty `<associations>` returns `connection: ''` without crashing
- connection `url` uses default `connectionUrl` (entry without `@envId`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PDX-478]: https://provartesting.atlassian.net/browse/PDX-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ