### PR TITLE
PDX-0: docs(mcp) — scrub internal ticket refs from customer docs

### DIFF
--- a/docs/mcp-pilot-guide.md
+++ b/docs/mcp-pilot-guide.md
@@ -443,7 +443,7 @@ NitroX is Provar's Hybrid Model for locators — it maps Salesforce component-ba
 
 **Goal:** Confirm the AI authors a multi-scenario test case by passing the full step tree to `provar_testcase_generate` in **one** call — not by generating an empty skeleton and looping `provar_testcase_step_edit` per step.
 
-**Background:** A regression in 1.5.0 (PDX-479) traced to authoring guidance that steered LLMs toward a per-step construction pattern. Multi-call construction drops scenario numbers (e.g. Scenario 1 → Scenario 3, no Scenario 2), flattens asserts that should be nested inside `UiWithScreen` clauses, and produces inconsistent assert API IDs across the case. This scenario exists so the regression class is exercised in pilot evaluation and cannot recur silently.
+**Background:** A previously observed regression traced to authoring guidance that steered LLMs toward a per-step construction pattern. Multi-call construction drops scenario numbers (e.g. Scenario 1 → Scenario 3, no Scenario 2), flattens asserts that should be nested inside `UiWithScreen` clauses, and produces inconsistent assert API IDs across the case. This scenario exists so the regression class is exercised in pilot evaluation and cannot recur silently.
 
 **Prompt:**
 
@@ -469,7 +469,7 @@ NitroX is Provar's Hybrid Model for locators — it maps Salesforce component-ba
 - A call to `provar_testcase_generate` with `steps: []` followed by `provar_testcase_step_edit` calls
 - The generated case skips a scenario number, mixes assert API IDs for similar assertions, or emits asserts as flat siblings rather than nested inside the screen wrapper
 
-If any FAIL indicator appears, file against PDX-479 (or its successor) with the prompt and the generated XML attached.
+If any FAIL indicator appears, report it to the Provar team with the prompt and the generated XML attached.
 
 ---
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -2102,7 +2102,7 @@ Version metadata for the bundled NitroX component catalog and JSON schemas. Retu
 }
 ```
 
-`commitSha` and `fetchedAt` are `null` when the release build could not reach the internal source (fallback catalog in use). `schemasUpdated` is `true` when both `FactComponent.schema` and `FactPackage.schema` were successfully fetched from the same internal revision and bundled into this release; `false` when the schema fetch failed and the previously committed schemas are in use; `null` when the catalog source was not generated (dev build or pre-PDX-464 release).
+`commitSha` and `fetchedAt` are `null` when the release build could not reach the internal source (fallback catalog in use). `schemasUpdated` is `true` when both `FactComponent.schema` and `FactPackage.schema` were successfully fetched from the same internal revision and bundled into this release; `false` when the schema fetch failed and the previously committed schemas are in use; `null` when the catalog source was not generated (dev build or an older release that predates this metadata).
 
 ---
 


### PR DESCRIPTION
## Summary

Doc-only cleanup. Removes internal Jira ticket references (PDX-XXX) and an internal-only version label from the customer-facing MCP guides on `develop` so the next release → main doesn't leak them.

Found via grep of `PDX-\d+` against `docs/*.md` after the PR #172 release-prep audit.

## Changes

- **`docs/mcp.md`** (catalog-source resource note, ~L2105) — replace `"(dev build or pre-PDX-464 release)"` with `"(dev build or an older release that predates this metadata)"`.
- **`docs/mcp-pilot-guide.md`** (Scenario 12 Background, ~L446) — drop `"in 1.5.0 (PDX-479)"`; describe the regression as `"previously observed"` without citing ticket or version.
- **`docs/mcp-pilot-guide.md`** (Scenario 12 FAIL action, ~L472) — replace `"file against PDX-479 (or its successor)"` with `"report it to the Provar team"`.

No tool, schema, smoke, or behaviour changes.

## Verification

```
rg "PDX-\d+" docs/*.md   # 0 matches
```

## Test plan

- [ ] `rg "PDX-\d+" docs/*.md` returns no hits on this branch
- [ ] Scenario 12 (Background + FAIL action) still reads coherently without the ticket reference
- [ ] `docs/mcp.md` catalog-source description still accurately explains when `commitSha`/`fetchedAt`/`schemasUpdated` are `null`
- [ ] CI (lint, compile, tests) green — should be a no-op since this is markdown only

## Out of scope

- Public-facing `docs/provar-mcp-public-docs.md` and `docs/university-of-provar-mcp-course.md` are maintained separately by the Provar team (per CLAUDE.md) — flagging here for manual review but not modified by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)