### PR TITLE
PDX-485: chore(mcp) — shared warningCodes.ts enum

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -78,6 +78,7 @@ The Provar DX CLI ships with a built-in **Model Context Protocol (MCP) server** 
 - [Quality scores explained](#quality-scores-explained)
 - [API compatibility — `xml` vs `xml_content`](#api-compatibility--xml-vs-xml_content)
 - [Performance Tuning](#performance-tuning)
+- [Warning codes](#warning-codes)
 
 ---
 
@@ -528,6 +529,23 @@ All file-system operations (read, write, generate) are restricted to the paths s
 Symlinks are resolved via `fs.realpathSync` before the containment check, so a symlink inside an allowed directory that points outside it cannot bypass the restriction. For tools that accept multiple path inputs (such as `provar_ant_generate`'s `provar_home`, `project_path`, and `results_path`), all path fields are validated before any file operation occurs — not just the output path.
 
 On **Windows**, path comparisons are performed case-insensitively to account for the fact that `fs.realpathSync` does not always canonicalize drive-letter case (e.g. `c:\` vs `C:\`). This means `C:\Projects\my-project` and `c:\projects\my-project` are treated as equivalent when checking against `--allowed-paths`.
+
+---
+
+## Warning codes
+
+Cross-cutting warning codes surfaced by validation, configuration, and run tooling. These complement the per-tool `rule_id` codes (e.g. `TC_001`, `VAR-REF-001`) documented under [Available tools](#available-tools). Subsequent revisions will refine the meanings as the relevant tool surfaces stabilise.
+
+| Code             | Surfaced by                             | Meaning                                                                   |
+| ---------------- | --------------------------------------- | ------------------------------------------------------------------------- |
+| `PROVARHOME-001` | properties / automation tooling         | `provarHome` is missing, blank, or does not point to a Provar install     |
+| `DATA-001`       | `provar_testcase_validate`              | `<dataTable>` iteration is silently ignored in CLI standalone execution   |
+| `PARALLEL-001`   | automation / run tooling                | Parallel-mode cache mismatch between properties and active runtime config |
+| `SCHEMA-001`     | strict properties / config validators   | Unknown or misspelled key in a JSON / properties schema (typo guard)      |
+| `RUN-001`        | `provar_automation_testrun` and friends | Test run produced no executable results — check input selection           |
+| `JUNIT-001`      | report / RCA tooling                    | JUnit results file is missing, empty, or not parseable                    |
+
+Warnings emitted programmatically follow the shape `WARNING [<CODE>]: <message>` — and when a typo is detected, the message is suffixed with `Did you mean '<suggestion>'?`. See `src/mcp/utils/warningCodes.ts` for the canonical enum.
 
 ---
 

--- a/src/mcp/utils/warningCodes.ts
+++ b/src/mcp/utils/warningCodes.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Provar Limited.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.md file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export const WARNING_CODES = {
+  PROVARHOME_001: 'PROVARHOME-001',
+  DATA_001: 'DATA-001',
+  PARALLEL_001: 'PARALLEL-001',
+  SCHEMA_001: 'SCHEMA-001',
+  RUN_001: 'RUN-001',
+  JUNIT_001: 'JUNIT-001',
+} as const;
+
+export type WarningCode = (typeof WARNING_CODES)[keyof typeof WARNING_CODES];
+
+export function formatWarning(code: WarningCode, message: string, suggestion?: string): string {
+  const base = `WARNING [${code}]: ${message}`;
+  return suggestion ? `${base} Did you mean '${suggestion}'?` : base;
+}

--- a/test/unit/mcp/utils/warningCodes.test.ts
+++ b/test/unit/mcp/utils/warningCodes.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Provar Limited.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.md file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'mocha';
+import { WARNING_CODES, formatWarning } from '../../../../src/mcp/utils/warningCodes.js';
+
+describe('WARNING_CODES', () => {
+  it('maps each key to its expected wire string', () => {
+    const expected: Record<string, string> = {
+      PROVARHOME_001: 'PROVARHOME-001',
+      DATA_001: 'DATA-001',
+      PARALLEL_001: 'PARALLEL-001',
+      SCHEMA_001: 'SCHEMA-001',
+      RUN_001: 'RUN-001',
+      JUNIT_001: 'JUNIT-001',
+    };
+    for (const [key, value] of Object.entries(expected)) {
+      assert.equal(
+        (WARNING_CODES as Record<string, string>)[key],
+        value,
+        `WARNING_CODES.${key} should equal '${value}'`
+      );
+    }
+  });
+});
+
+describe('formatWarning', () => {
+  it('returns the prefixed message exactly when no suggestion is provided', () => {
+    assert.equal(
+      formatWarning(WARNING_CODES.PROVARHOME_001, 'provarHome is missing'),
+      'WARNING [PROVARHOME-001]: provarHome is missing'
+    );
+  });
+
+  it('appends the "Did you mean" suffix exactly when a suggestion is provided', () => {
+    assert.equal(
+      formatWarning(WARNING_CODES.SCHEMA_001, "unknown key 'parralelMode'", 'parallelMode'),
+      "WARNING [SCHEMA-001]: unknown key 'parralelMode' Did you mean 'parallelMode'?"
+    );
+  });
+
+  it('omits the suffix when suggestion is an empty string', () => {
+    assert.equal(
+      formatWarning(WARNING_CODES.DATA_001, 'data-table iteration not bound', ''),
+      'WARNING [DATA-001]: data-table iteration not bound'
+    );
+  });
+});

--- a/test/unit/mcp/utils/warningCodes.test.ts
+++ b/test/unit/mcp/utils/warningCodes.test.ts
@@ -10,15 +10,16 @@ import { describe, it } from 'mocha';
 import { WARNING_CODES, formatWarning } from '../../../../src/mcp/utils/warningCodes.js';
 
 describe('WARNING_CODES', () => {
+  const expected: Record<string, string> = {
+    PROVARHOME_001: 'PROVARHOME-001',
+    DATA_001: 'DATA-001',
+    PARALLEL_001: 'PARALLEL-001',
+    SCHEMA_001: 'SCHEMA-001',
+    RUN_001: 'RUN-001',
+    JUNIT_001: 'JUNIT-001',
+  };
+
   it('maps each key to its expected wire string', () => {
-    const expected: Record<string, string> = {
-      PROVARHOME_001: 'PROVARHOME-001',
-      DATA_001: 'DATA-001',
-      PARALLEL_001: 'PARALLEL-001',
-      SCHEMA_001: 'SCHEMA-001',
-      RUN_001: 'RUN-001',
-      JUNIT_001: 'JUNIT-001',
-    };
     for (const [key, value] of Object.entries(expected)) {
       assert.equal(
         (WARNING_CODES as Record<string, string>)[key],
@@ -26,6 +27,16 @@ describe('WARNING_CODES', () => {
         `WARNING_CODES.${key} should equal '${value}'`
       );
     }
+  });
+
+  // Guards against silent enum drift: a new code added without updating this test,
+  // or an accidentally-removed code, must fail the build.
+  it('contains exactly the expected key set (no additions, no omissions)', () => {
+    assert.deepEqual(Object.keys(WARNING_CODES).sort(), Object.keys(expected).sort());
+  });
+
+  it('contains exactly the expected value set (no additions, no omissions)', () => {
+    assert.deepEqual(Object.values(WARNING_CODES).sort(), Object.values(expected).sort());
   });
 });
 


### PR DESCRIPTION
## Context

Part of the Provar MCP thread-prep work (PDX-485). Six sibling thread PRs (validation, properties, automation, RCA, JUnit, parallel-mode tuning) will each surface warning text. Today each thread emits ad-hoc prefixes (`WARNING:`, `[provarHome]`, `WARN —`), producing inconsistent output for downstream AI agents and making cross-tool "Did you mean...?" guidance hard to standardise.

This is the small, focused infrastructure PR that lands first so the six sibling PRs can import from a single source.

## Why

- **Stable warning surface.** One enum, one formatter — sibling PRs can't drift on prefix or punctuation.
- **Cross-thread typo guidance.** `formatWarning(code, message, suggestion?)` standardises the `Did you mean '<suggestion>'?` suffix.
- **Minimal surface area, zero call-site churn.** No existing code is rewired in this PR — that's intentional. Sibling thread PRs adopt at their own pace without merge conflicts here.

## What's in the diff

- `src/mcp/utils/warningCodes.ts` — `WARNING_CODES` const (PROVARHOME-001, DATA-001, PARALLEL-001, SCHEMA-001, RUN-001, JUNIT-001), `WarningCode` type, `formatWarning(code, message, suggestion?)`.
- `test/unit/mcp/utils/warningCodes.test.ts` — code-value parity table, `formatWarning` with and without suggestion, empty-string suggestion edge case.
- `docs/mcp.md` — new "Warning codes" reference table + TOC entry. Per-row meanings are intentionally placeholders that subsequent thread PRs will refine as each surface stabilises.

## Out of scope (per the coordination plan)

- No `package.json` / `server.json` version bump (handled in a sweeper PR).
- No existing tool is rewired to use the new enum. Sibling thread PRs do that.

## Test plan

- [x] `yarn compile` — clean
- [x] `yarn lint` — clean (incl. script-name lint)
- [x] `yarn test:only` (bypassed wireit cache via `node_modules/.bin/nyc node_modules/.bin/mocha "test/**/*.test.ts"`) — **1159 passing, 0 failing**
- [x] New unit tests cover every enum value, both formatter branches, and the empty-suggestion edge case

Refs: PDX-485