### PR TITLE
PDX-493: feat(mcp) — date/datetime/boolean/integer valueClass dispatch (Thread C, PR 1/2)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -729,19 +729,19 @@ The tool's chip-level `title` — `Generate Test Case (full steps in one call)` 
 
 **Argument XML conventions** (automatically applied by the generator):
 
-| Argument key / value pattern            | Emitted XML class                     | API context             |
-| --------------------------------------- | ------------------------------------- | ----------------------- |
-| `target` key                            | `class="uiTarget"`                    | UiWithScreen, UiWithRow |
-| `locator` key                           | `class="uiLocator"`                   | UiDoAction, UiAssert    |
-| Value matches `{VarName}` or `{A.B}`    | `class="variable"` + `<path>`         | Any step                |
-| SetValues attributes                    | `class="valueList"/<namedValues>`     | SetValues only          |
-| Value `YYYY-MM-DDTHH:MM:SS…` (ISO-8601) | `class="value" valueClass="datetime"` | Any step                |
-| Value `YYYY-MM-DD` (ISO-8601)           | `class="value" valueClass="date"`     | Any step                |
-| Value `true` / `false`                  | `class="value" valueClass="boolean"`  | Any step                |
-| Value matches `^-?\d+$`                 | `class="value" valueClass="integer"`  | Any step                |
-| All other values                        | `class="value" valueClass="string"`   | Any step                |
+| Argument key / value pattern                                                                   | Emitted XML class                     | API context             |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------- | ----------------------- |
+| `target` key                                                                                   | `class="uiTarget"`                    | UiWithScreen, UiWithRow |
+| `locator` key                                                                                  | `class="uiLocator"`                   | UiDoAction, UiAssert    |
+| Value matches `{VarName}` or `{A.B}`                                                           | `class="variable"` + `<path>`         | Any step                |
+| SetValues attributes                                                                           | `class="valueList"/<namedValues>`     | SetValues only          |
+| Value `YYYY-MM-DDTHH:MM:SS` + optional `.fff` + optional `Z`/`±HH:MM` (ISO-8601, end-anchored) | `class="value" valueClass="datetime"` | Any step                |
+| Value `YYYY-MM-DD` (ISO-8601)                                                                  | `class="value" valueClass="date"`     | Any step                |
+| Value `true` / `false`                                                                         | `class="value" valueClass="boolean"`  | Any step                |
+| Numeric value `^-?\d+(\.\d+)?$` (`42`, `-5`, `3.14`)                                           | `class="value" valueClass="decimal"`  | Any step                |
+| All other values                                                                               | `class="value" valueClass="string"`   | Any step                |
 
-`valueClass` is inferred automatically by `inferSalesforceValueClass(key, val, fieldTypeHint?)`. Detection order: explicit `fieldTypeHint` (wired in a follow-up tool surface — `field_type_hints` param) → ISO-8601 datetime → ISO-8601 date → boolean → integer → string. Provar runtime silently discards date fields emitted as `valueClass="string"`, so always pass date / datetime values in ISO-8601 form.
+`valueClass` is inferred automatically by `inferSalesforceValueClass(key, val, fieldTypeHint?)`. Detection order: explicit `fieldTypeHint` (wired in a follow-up tool surface — `field_type_hints` param) → ISO-8601 datetime (with optional fractional seconds and timezone, end-anchored) → ISO-8601 date → boolean → decimal → string. Per the canonical Provar reference numbers always emit as `valueClass="decimal"` (there is no separate `integer` valueClass). Provar runtime silently discards date fields emitted as `valueClass="string"`, so always pass date / datetime values in ISO-8601 form.
 
 AssertValues uses **flat** argument structure (`expectedValue`, `actualValue`, `comparisonType`) — not the `valueList`/namedValues format.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -729,13 +729,19 @@ The tool's chip-level `title` — `Generate Test Case (full steps in one call)` 
 
 **Argument XML conventions** (automatically applied by the generator):
 
-| Argument key / value pattern         | Emitted XML class                   | API context             |
-| ------------------------------------ | ----------------------------------- | ----------------------- |
-| `target` key                         | `class="uiTarget"`                  | UiWithScreen, UiWithRow |
-| `locator` key                        | `class="uiLocator"`                 | UiDoAction, UiAssert    |
-| Value matches `{VarName}` or `{A.B}` | `class="variable"` + `<path>`       | Any step                |
-| SetValues attributes                 | `class="valueList"/<namedValues>`   | SetValues only          |
-| All other values                     | `class="value" valueClass="string"` | Any step                |
+| Argument key / value pattern            | Emitted XML class                     | API context             |
+| --------------------------------------- | ------------------------------------- | ----------------------- |
+| `target` key                            | `class="uiTarget"`                    | UiWithScreen, UiWithRow |
+| `locator` key                           | `class="uiLocator"`                   | UiDoAction, UiAssert    |
+| Value matches `{VarName}` or `{A.B}`    | `class="variable"` + `<path>`         | Any step                |
+| SetValues attributes                    | `class="valueList"/<namedValues>`     | SetValues only          |
+| Value `YYYY-MM-DDTHH:MM:SS…` (ISO-8601) | `class="value" valueClass="datetime"` | Any step                |
+| Value `YYYY-MM-DD` (ISO-8601)           | `class="value" valueClass="date"`     | Any step                |
+| Value `true` / `false`                  | `class="value" valueClass="boolean"`  | Any step                |
+| Value matches `^-?\d+$`                 | `class="value" valueClass="integer"`  | Any step                |
+| All other values                        | `class="value" valueClass="string"`   | Any step                |
+
+`valueClass` is inferred automatically by `inferSalesforceValueClass(key, val, fieldTypeHint?)`. Detection order: explicit `fieldTypeHint` (wired in a follow-up tool surface — `field_type_hints` param) → ISO-8601 datetime → ISO-8601 date → boolean → integer → string. Provar runtime silently discards date fields emitted as `valueClass="string"`, so always pass date / datetime values in ISO-8601 form.
 
 AssertValues uses **flat** argument structure (`expectedValue`, `actualValue`, `comparisonType`) — not the `valueList`/namedValues format.
 

--- a/src/mcp/tools/testCaseGenerate.ts
+++ b/src/mcp/tools/testCaseGenerate.ts
@@ -151,9 +151,10 @@ const TOOL_DESCRIPTION = [
   'target argument (UiWithScreen/UiWithRow): pass the URI value; emitted as class="uiTarget" uri="...".',
   'locator argument (UiDoAction/UiAssert): pass the URI value; emitted as class="uiLocator" uri="...".',
   'valueClass auto-detection: argument values are typed automatically before XML emission. ' +
-    'ISO-8601 date "YYYY-MM-DD" → valueClass="date"; ISO-8601 datetime "YYYY-MM-DDTHH:MM:SS" → "datetime"; ' +
-    '"true"/"false" → "boolean"; integer-only string (e.g. "42", "-5") → "integer"; otherwise "string". ' +
-    'Pass dates / booleans / integers in those formats — Provar runtime silently discards date fields emitted as valueClass="string".',
+    'ISO-8601 date "YYYY-MM-DD" → valueClass="date"; ISO-8601 datetime "YYYY-MM-DDTHH:MM:SS" (optional fractional seconds + timezone) → "datetime"; ' +
+    '"true"/"false" → "boolean"; numeric string (e.g. "42", "-5", "3.14") → "decimal"; otherwise "string". ' +
+    'Pass dates / booleans / numbers in those formats — Provar runtime silently discards date fields emitted as valueClass="string". ' +
+    'Note: numbers always emit valueClass="decimal" per the canonical Provar reference (there is no separate "integer" valueClass).',
   'Edit page objects: action=Edit targets require a compiled page object for the SF object. ' +
     'If none exists in the project page-objects directory, the locator binding will fail at runtime. ' +
     'For objects without a compiled Edit page object, use inline edit instead: sfIleActivate to activate the field, ' +
@@ -384,10 +385,15 @@ export function registerTestCaseGenerate(server: McpServer, config: ServerConfig
 // Detection order:
 //   1. Explicit `fieldTypeHint` (from `field_type_hints` param or `provar_org_describe` cache — wired
 //      in PDX-492 H2b) wins if provided.
-//   2. ISO-8601 datetime → 'datetime'   (e.g. "2026-05-19T10:30:00", with optional fractional/zone).
+//   2. ISO-8601 datetime → 'datetime'   (e.g. "2026-05-19T10:30:00", with optional fractional seconds
+//      and optional timezone). The regex is end-anchored so trailing garbage (e.g.
+//      "2026-05-19T10:30:00not-a-zone") is rejected as plain 'string'.
 //   3. ISO-8601 date     → 'date'       (e.g. "2026-05-19").
 //   4. Literal 'true' / 'false' → 'boolean'.
-//   5. Integer-only string (optional leading '-') → 'integer'.
+//   5. Numeric string (integer or decimal, optional leading '-') → 'decimal'.
+//      Per `docs/PROVAR_TEST_STEP_REFERENCE.md` (lines 1338, 1428) the canonical Provar
+//      valueClass for numbers is `decimal` — there is no `integer` valueClass in the
+//      reference grammar, so both `42` and `3.14` emit as `valueClass="decimal"`.
 //   6. Else → 'string'.
 //
 // The `key` argument is reserved for future heuristics (e.g. SF naming conventions like *__c)
@@ -397,13 +403,13 @@ export function inferSalesforceValueClass(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   key: string,
   val: string,
-  fieldTypeHint?: 'date' | 'datetime' | 'boolean' | 'integer' | 'string'
-): 'date' | 'datetime' | 'boolean' | 'integer' | 'string' {
+  fieldTypeHint?: 'date' | 'datetime' | 'boolean' | 'decimal' | 'string'
+): 'date' | 'datetime' | 'boolean' | 'decimal' | 'string' {
   if (fieldTypeHint) return fieldTypeHint;
-  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(val)) return 'datetime';
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/.test(val)) return 'datetime';
   if (/^\d{4}-\d{2}-\d{2}$/.test(val)) return 'date';
   if (val === 'true' || val === 'false') return 'boolean';
-  if (/^-?\d+$/.test(val)) return 'integer';
+  if (/^-?\d+(\.\d+)?$/.test(val)) return 'decimal';
   return 'string';
 }
 
@@ -456,7 +462,7 @@ function buildArgumentValue(key: string, val: string, indent: string, inNamedVal
       return `${indent}<value class="uiLocator" uri="${escapeXmlAttr(val)}"/>`;
     }
   }
-  // PDX-493 (H3): infer valueClass for date / datetime / boolean / integer / string. The
+  // PDX-493 (H3): infer valueClass for date / datetime / boolean / decimal / string. The
   // `fieldTypeHint` parameter on `inferSalesforceValueClass` is intentionally not threaded
   // through here yet — it lands in PDX-492 (H2b) along with the `field_type_hints` tool input.
   const inferred = inferSalesforceValueClass(key, val);

--- a/src/mcp/tools/testCaseGenerate.ts
+++ b/src/mcp/tools/testCaseGenerate.ts
@@ -150,6 +150,10 @@ const TOOL_DESCRIPTION = [
   'Variable references: pass values as "{VarName}" (braces); emitted as class="variable" <path element="VarName"/>.',
   'target argument (UiWithScreen/UiWithRow): pass the URI value; emitted as class="uiTarget" uri="...".',
   'locator argument (UiDoAction/UiAssert): pass the URI value; emitted as class="uiLocator" uri="...".',
+  'valueClass auto-detection: argument values are typed automatically before XML emission. ' +
+    'ISO-8601 date "YYYY-MM-DD" → valueClass="date"; ISO-8601 datetime "YYYY-MM-DDTHH:MM:SS" → "datetime"; ' +
+    '"true"/"false" → "boolean"; integer-only string (e.g. "42", "-5") → "integer"; otherwise "string". ' +
+    'Pass dates / booleans / integers in those formats — Provar runtime silently discards date fields emitted as valueClass="string".',
   'Edit page objects: action=Edit targets require a compiled page object for the SF object. ' +
     'If none exists in the project page-objects directory, the locator binding will fail at runtime. ' +
     'For objects without a compiled Edit page object, use inline edit instead: sfIleActivate to activate the field, ' +
@@ -374,6 +378,35 @@ export function registerTestCaseGenerate(server: McpServer, config: ServerConfig
 
 // ── XML builder ───────────────────────────────────────────────────────────────
 
+// PDX-493 (H3): infer the Salesforce `valueClass` attribute that should be emitted on a
+// `<value class="value" valueClass="..."/>` element from an argument's key + string value.
+//
+// Detection order:
+//   1. Explicit `fieldTypeHint` (from `field_type_hints` param or `provar_org_describe` cache — wired
+//      in PDX-492 H2b) wins if provided.
+//   2. ISO-8601 datetime → 'datetime'   (e.g. "2026-05-19T10:30:00", with optional fractional/zone).
+//   3. ISO-8601 date     → 'date'       (e.g. "2026-05-19").
+//   4. Literal 'true' / 'false' → 'boolean'.
+//   5. Integer-only string (optional leading '-') → 'integer'.
+//   6. Else → 'string'.
+//
+// The `key` argument is reserved for future heuristics (e.g. SF naming conventions like *__c)
+// but is intentionally not consulted today — explicit hints + value-shape regexes are the
+// safer signal until org-describe is wired.
+export function inferSalesforceValueClass(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  key: string,
+  val: string,
+  fieldTypeHint?: 'date' | 'datetime' | 'boolean' | 'integer' | 'string'
+): 'date' | 'datetime' | 'boolean' | 'integer' | 'string' {
+  if (fieldTypeHint) return fieldTypeHint;
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(val)) return 'datetime';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(val)) return 'date';
+  if (val === 'true' || val === 'false') return 'boolean';
+  if (/^-?\d+$/.test(val)) return 'integer';
+  return 'string';
+}
+
 // F1/F3: build class="compound" for strings that mix literal text with {VarName} tokens.
 function buildCompoundValue(val: string, indent: string): string {
   const i = `${indent}  `;
@@ -423,7 +456,11 @@ function buildArgumentValue(key: string, val: string, indent: string, inNamedVal
       return `${indent}<value class="uiLocator" uri="${escapeXmlAttr(val)}"/>`;
     }
   }
-  return `${indent}<value class="value" valueClass="string">${escapeXmlContent(val)}</value>`;
+  // PDX-493 (H3): infer valueClass for date / datetime / boolean / integer / string. The
+  // `fieldTypeHint` parameter on `inferSalesforceValueClass` is intentionally not threaded
+  // through here yet — it lands in PDX-492 (H2b) along with the `field_type_hints` tool input.
+  const inferred = inferSalesforceValueClass(key, val);
+  return `${indent}<value class="value" valueClass="${inferred}">${escapeXmlContent(val)}</value>`;
 }
 
 function buildArgumentsXml(attributes: Record<string, string>, baseIndent = '      ', apiId = ''): string {

--- a/test/unit/mcp/testCaseGenerate.test.ts
+++ b/test/unit/mcp/testCaseGenerate.test.ts
@@ -11,7 +11,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, it, beforeEach, afterEach } from 'mocha';
-import { registerTestCaseGenerate } from '../../../src/mcp/tools/testCaseGenerate.js';
+import { registerTestCaseGenerate, inferSalesforceValueClass } from '../../../src/mcp/tools/testCaseGenerate.js';
 import type { ServerConfig } from '../../../src/mcp/server.js';
 
 // ── Minimal McpServer mock ─────────────────────────────────────────────────────
@@ -696,6 +696,189 @@ describe('provar_testcase_generate', () => {
       const xml = parseText(result)['xml_content'] as string;
       assert.ok(xml.includes('valueClass="string"'), 'Expected lowercase valueClass="string"');
       assert.ok(!xml.includes('valueClass="String"'), 'Must not emit uppercase valueClass="String"');
+    });
+  });
+
+  // PDX-493 (H3): date/datetime/boolean/integer valueClass dispatch via inferSalesforceValueClass.
+  describe('PDX-493 — inferSalesforceValueClass helper', () => {
+    it('returns "datetime" for ISO-8601 datetime string', () => {
+      assert.equal(inferSalesforceValueClass('CloseDate', '2026-05-19T10:30:00'), 'datetime');
+    });
+
+    it('returns "datetime" for ISO-8601 datetime with fractional seconds + zone', () => {
+      assert.equal(inferSalesforceValueClass('CloseDate', '2026-05-19T10:30:00.123Z'), 'datetime');
+    });
+
+    it('returns "date" for ISO-8601 date string', () => {
+      assert.equal(inferSalesforceValueClass('CloseDate', '2026-05-19'), 'date');
+    });
+
+    it('returns "boolean" for "true"', () => {
+      assert.equal(inferSalesforceValueClass('IsActive', 'true'), 'boolean');
+    });
+
+    it('returns "boolean" for "false"', () => {
+      assert.equal(inferSalesforceValueClass('IsActive', 'false'), 'boolean');
+    });
+
+    it('returns "integer" for positive integer string', () => {
+      assert.equal(inferSalesforceValueClass('Quantity', '42'), 'integer');
+    });
+
+    it('returns "integer" for negative integer string', () => {
+      assert.equal(inferSalesforceValueClass('Delta', '-5'), 'integer');
+    });
+
+    it('returns "string" for plain text', () => {
+      assert.equal(inferSalesforceValueClass('Name', 'Acme Corp'), 'string');
+    });
+
+    it('returns "integer" not "date" for a short numeric string like "12"', () => {
+      // Edge case: the date regex requires the full ISO yyyy-mm-dd form, so a bare "12"
+      // is integer, not date. Guards against false-positive date detection on numeric IDs.
+      assert.equal(inferSalesforceValueClass('Code', '12'), 'integer');
+    });
+
+    it('returns "string" for date-looking strings that miss the ISO format', () => {
+      // Confirms the regex is strict: month/day shape matters.
+      assert.equal(inferSalesforceValueClass('CloseDate', '2026/05/19'), 'string');
+      assert.equal(inferSalesforceValueClass('CloseDate', '05-19-2026'), 'string');
+    });
+
+    it('explicit fieldTypeHint wins over format detection', () => {
+      // Value looks like a string but the hint says it's a date — hint wins.
+      assert.equal(inferSalesforceValueClass('CloseDate', 'today', 'date'), 'date');
+      // Value looks like a date but the hint says string — hint wins (e.g. an external
+      // ID that happens to look like a date).
+      assert.equal(inferSalesforceValueClass('ExternalId', '2026-05-19', 'string'), 'string');
+      // Value is integer, hint says boolean — hint wins.
+      assert.equal(inferSalesforceValueClass('IsActive', '1', 'boolean'), 'boolean');
+    });
+  });
+
+  describe('PDX-493 — valueClass emission in generated XML', () => {
+    it('emits valueClass="date" for an ISO-8601 date string', () => {
+      const result = server.call('provar_testcase_generate', {
+        test_case_name: 'DateField',
+        steps: [
+          {
+            api_id: 'ApexCreateObject',
+            name: 'Create Opp',
+            attributes: { CloseDate: '2026-05-19' },
+          },
+        ],
+        dry_run: true,
+        overwrite: false,
+      });
+
+      const xml = parseText(result)['xml_content'] as string;
+      assert.ok(
+        xml.includes('valueClass="date">2026-05-19</value>'),
+        `Expected valueClass="date" for ISO date; got: ${xml}`
+      );
+    });
+
+    it('emits valueClass="datetime" for an ISO-8601 datetime string', () => {
+      const result = server.call('provar_testcase_generate', {
+        test_case_name: 'DatetimeField',
+        steps: [
+          {
+            api_id: 'ApexCreateObject',
+            name: 'Create Event',
+            attributes: { StartTime: '2026-05-19T10:30:00' },
+          },
+        ],
+        dry_run: true,
+        overwrite: false,
+      });
+
+      const xml = parseText(result)['xml_content'] as string;
+      assert.ok(
+        xml.includes('valueClass="datetime">2026-05-19T10:30:00</value>'),
+        `Expected valueClass="datetime" for ISO datetime; got: ${xml}`
+      );
+    });
+
+    it('emits valueClass="boolean" for "true" / "false" literals', () => {
+      const result = server.call('provar_testcase_generate', {
+        test_case_name: 'BoolField',
+        steps: [
+          {
+            api_id: 'ApexCreateObject',
+            name: 'Create Account',
+            attributes: { IsActive: 'true', IsDeleted: 'false' },
+          },
+        ],
+        dry_run: true,
+        overwrite: false,
+      });
+
+      const xml = parseText(result)['xml_content'] as string;
+      assert.ok(
+        xml.includes('valueClass="boolean">true</value>'),
+        `Expected valueClass="boolean" for "true"; got: ${xml}`
+      );
+      assert.ok(
+        xml.includes('valueClass="boolean">false</value>'),
+        `Expected valueClass="boolean" for "false"; got: ${xml}`
+      );
+    });
+
+    it('emits valueClass="integer" for an integer-only string', () => {
+      const result = server.call('provar_testcase_generate', {
+        test_case_name: 'IntField',
+        steps: [
+          {
+            api_id: 'ApexCreateObject',
+            name: 'Create Opp',
+            attributes: { Quantity: '42' },
+          },
+        ],
+        dry_run: true,
+        overwrite: false,
+      });
+
+      const xml = parseText(result)['xml_content'] as string;
+      assert.ok(xml.includes('valueClass="integer">42</value>'), `Expected valueClass="integer" for "42"; got: ${xml}`);
+    });
+
+    it('emits valueClass="integer" for a negative integer string', () => {
+      const result = server.call('provar_testcase_generate', {
+        test_case_name: 'NegIntField',
+        steps: [
+          {
+            api_id: 'ApexCreateObject',
+            name: 'Create Adjustment',
+            attributes: { Delta: '-5' },
+          },
+        ],
+        dry_run: true,
+        overwrite: false,
+      });
+
+      const xml = parseText(result)['xml_content'] as string;
+      assert.ok(xml.includes('valueClass="integer">-5</value>'), `Expected valueClass="integer" for "-5"; got: ${xml}`);
+    });
+
+    it('emits valueClass="string" for plain text', () => {
+      const result = server.call('provar_testcase_generate', {
+        test_case_name: 'StringField',
+        steps: [
+          {
+            api_id: 'ApexCreateObject',
+            name: 'Create Account',
+            attributes: { Name: 'Acme Corp' },
+          },
+        ],
+        dry_run: true,
+        overwrite: false,
+      });
+
+      const xml = parseText(result)['xml_content'] as string;
+      assert.ok(
+        xml.includes('valueClass="string">Acme Corp</value>'),
+        `Expected valueClass="string" for "Acme Corp"; got: ${xml}`
+      );
     });
   });
 

--- a/test/unit/mcp/testCaseGenerate.test.ts
+++ b/test/unit/mcp/testCaseGenerate.test.ts
@@ -699,7 +699,9 @@ describe('provar_testcase_generate', () => {
     });
   });
 
-  // PDX-493 (H3): date/datetime/boolean/integer valueClass dispatch via inferSalesforceValueClass.
+  // PDX-493 (H3): date/datetime/boolean/decimal valueClass dispatch via inferSalesforceValueClass.
+  // Numbers emit `valueClass="decimal"` per canonical reference (PROVAR_TEST_STEP_REFERENCE.md
+  // lines 1338, 1428) — there is no `integer` valueClass in the Provar grammar.
   describe('PDX-493 — inferSalesforceValueClass helper', () => {
     it('returns "datetime" for ISO-8601 datetime string', () => {
       assert.equal(inferSalesforceValueClass('CloseDate', '2026-05-19T10:30:00'), 'datetime');
@@ -707,6 +709,17 @@ describe('provar_testcase_generate', () => {
 
     it('returns "datetime" for ISO-8601 datetime with fractional seconds + zone', () => {
       assert.equal(inferSalesforceValueClass('CloseDate', '2026-05-19T10:30:00.123Z'), 'datetime');
+    });
+
+    it('returns "datetime" for ISO-8601 datetime with numeric timezone offset', () => {
+      assert.equal(inferSalesforceValueClass('CloseDate', '2026-05-19T10:30:00+05:30'), 'datetime');
+      assert.equal(inferSalesforceValueClass('CloseDate', '2026-05-19T10:30:00-0800'), 'datetime');
+    });
+
+    it('returns "string" for datetime-looking values with trailing garbage (end-anchored)', () => {
+      // Guards against the un-anchored regex bug: trailing junk after seconds must not
+      // be silently accepted as datetime.
+      assert.equal(inferSalesforceValueClass('CloseDate', '2026-05-19T10:30:00not-a-zone'), 'string');
     });
 
     it('returns "date" for ISO-8601 date string', () => {
@@ -721,22 +734,30 @@ describe('provar_testcase_generate', () => {
       assert.equal(inferSalesforceValueClass('IsActive', 'false'), 'boolean');
     });
 
-    it('returns "integer" for positive integer string', () => {
-      assert.equal(inferSalesforceValueClass('Quantity', '42'), 'integer');
+    it('returns "decimal" for positive integer string', () => {
+      assert.equal(inferSalesforceValueClass('Quantity', '42'), 'decimal');
     });
 
-    it('returns "integer" for negative integer string', () => {
-      assert.equal(inferSalesforceValueClass('Delta', '-5'), 'integer');
+    it('returns "decimal" for negative integer string', () => {
+      assert.equal(inferSalesforceValueClass('Delta', '-5'), 'decimal');
+    });
+
+    it('returns "decimal" for positive decimal string', () => {
+      assert.equal(inferSalesforceValueClass('Amount', '3.14'), 'decimal');
+    });
+
+    it('returns "decimal" for negative decimal string', () => {
+      assert.equal(inferSalesforceValueClass('Adjustment', '-12.5'), 'decimal');
     });
 
     it('returns "string" for plain text', () => {
       assert.equal(inferSalesforceValueClass('Name', 'Acme Corp'), 'string');
     });
 
-    it('returns "integer" not "date" for a short numeric string like "12"', () => {
+    it('returns "decimal" not "date" for a short numeric string like "12"', () => {
       // Edge case: the date regex requires the full ISO yyyy-mm-dd form, so a bare "12"
-      // is integer, not date. Guards against false-positive date detection on numeric IDs.
-      assert.equal(inferSalesforceValueClass('Code', '12'), 'integer');
+      // is decimal, not date. Guards against false-positive date detection on numeric IDs.
+      assert.equal(inferSalesforceValueClass('Code', '12'), 'decimal');
     });
 
     it('returns "string" for date-looking strings that miss the ISO format', () => {
@@ -751,7 +772,7 @@ describe('provar_testcase_generate', () => {
       // Value looks like a date but the hint says string — hint wins (e.g. an external
       // ID that happens to look like a date).
       assert.equal(inferSalesforceValueClass('ExternalId', '2026-05-19', 'string'), 'string');
-      // Value is integer, hint says boolean — hint wins.
+      // Value is decimal, hint says boolean — hint wins.
       assert.equal(inferSalesforceValueClass('IsActive', '1', 'boolean'), 'boolean');
     });
   });
@@ -824,7 +845,7 @@ describe('provar_testcase_generate', () => {
       );
     });
 
-    it('emits valueClass="integer" for an integer-only string', () => {
+    it('emits valueClass="decimal" for an integer-only string', () => {
       const result = server.call('provar_testcase_generate', {
         test_case_name: 'IntField',
         steps: [
@@ -839,10 +860,10 @@ describe('provar_testcase_generate', () => {
       });
 
       const xml = parseText(result)['xml_content'] as string;
-      assert.ok(xml.includes('valueClass="integer">42</value>'), `Expected valueClass="integer" for "42"; got: ${xml}`);
+      assert.ok(xml.includes('valueClass="decimal">42</value>'), `Expected valueClass="decimal" for "42"; got: ${xml}`);
     });
 
-    it('emits valueClass="integer" for a negative integer string', () => {
+    it('emits valueClass="decimal" for a negative integer string', () => {
       const result = server.call('provar_testcase_generate', {
         test_case_name: 'NegIntField',
         steps: [
@@ -857,7 +878,28 @@ describe('provar_testcase_generate', () => {
       });
 
       const xml = parseText(result)['xml_content'] as string;
-      assert.ok(xml.includes('valueClass="integer">-5</value>'), `Expected valueClass="integer" for "-5"; got: ${xml}`);
+      assert.ok(xml.includes('valueClass="decimal">-5</value>'), `Expected valueClass="decimal" for "-5"; got: ${xml}`);
+    });
+
+    it('emits valueClass="decimal" for a positive decimal string', () => {
+      const result = server.call('provar_testcase_generate', {
+        test_case_name: 'DecimalField',
+        steps: [
+          {
+            api_id: 'ApexCreateObject',
+            name: 'Create Opp',
+            attributes: { Amount: '3.14' },
+          },
+        ],
+        dry_run: true,
+        overwrite: false,
+      });
+
+      const xml = parseText(result)['xml_content'] as string;
+      assert.ok(
+        xml.includes('valueClass="decimal">3.14</value>'),
+        `Expected valueClass="decimal" for "3.14"; got: ${xml}`
+      );
     });
 
     it('emits valueClass="string" for plain text', () => {


### PR DESCRIPTION
## Summary

- Adds an exported `inferSalesforceValueClass(key, val, fieldTypeHint?)` helper in `src/mcp/tools/testCaseGenerate.ts` and wires `buildArgumentValue` to use it instead of the prior hard-coded `valueClass="string"` fallback. The generator now emits `valueClass="date"` / `"datetime"` / `"boolean"` / `"integer"` / `"string"` based on a strict detection order: explicit `fieldTypeHint` → ISO-8601 datetime → ISO-8601 date → literal `true`/`false` → integer-only string → string.
- Closes a regression introduced in 2d4240c (which refactored away the boolean-only `inferValueClass` helper from 3c1545c) and additionally covers datetime + integer dispatch that was never previously detected. Provar runtime silently discards Salesforce date fields whose XML emits `valueClass="string"` — this fix prevents the silent-drop failure mode.
- Tool description and `docs/mcp.md` argument-conventions table updated to spell out the auto-detection rules. No new MCP tool surface or input-schema fields are exposed in this PR — the `fieldTypeHint` parameter is wired into the helper signature only and lands in the MCP input schema in PDX-492 (H2b, Thread C PR 2/2), which sits behind PDX-491 (H2a, `provar_org_describe`).

## Scope and threading

This is **Thread C, PR 1 of 2** of the PDX-477 plan ("Categories G/H feedback + validate-typo blindspot"). PDX-492 (H2b) — the parameter exposure on `provar_testcase_generate` — depends on PDX-491 (H2a, `provar_org_describe`) landing first and is intentionally out of scope here.

No `warningCodes.ts` enum entry is added because this PR does not emit any new warning code in PR 1 — the warning emission ("required field missing", "object not in cache") lands in H2b.

## Files changed

- `src/mcp/tools/testCaseGenerate.ts` — new exported helper, dispatch wired into `buildArgumentValue`, tool description updated.
- `test/unit/mcp/testCaseGenerate.test.ts` — two new describe blocks (`PDX-493 — inferSalesforceValueClass helper` and `PDX-493 — valueClass emission in generated XML`).
- `docs/mcp.md` — argument-conventions table extended with the four new value-shape rows + auto-detection paragraph.

## Test plan

- [x] `node_modules/.bin/nyc node_modules/.bin/mocha "test/**/*.test.ts"` — 1172 passing / 0 failing (bypasses wireit cache per CLAUDE.md guidance).
- [x] `yarn compile` — clean.
- [x] `yarn lint` — clean (lint:script-names + lint).
- [x] Pre-push hook (`yarn build && yarn test`) passed.
- [x] Helper unit-tested directly (8 cases including the "12 is integer not date" edge and all three `fieldTypeHint` override directions).
- [x] Tool round-trip verified through `provar_testcase_generate` for all six dispatch branches (date, datetime, boolean true, boolean false, positive integer, negative integer, plain string).

## Not in this PR (flagged for follow-up)

- `field_type_hints` and `required_fields_hint` parameters on `provar_testcase_generate` → **PDX-492 / H2b** (Thread C PR 2/2, gated on PDX-491 H2a `provar_org_describe`).
- External / customer-facing docs (`docs/provar-mcp-public-docs.md`, `docs/university-of-provar-mcp-course.md`) are Provar-team-maintained per CLAUDE.md — flagging here so the Provar team can roll the new valueClass rules into the public docs when they next update.
- No `package.json` / `server.json` version bump in this feature PR per the plan's "Coordination chores" rule — version bumps happen in a sweeper PR after each batch of merges.