### PR TITLE
PDX-0: chore(release) — bump version to 1.5.2-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provartesting/provardx-cli",
   "description": "A plugin for the Salesforce CLI to orchestrate testing activities and report quality metrics to Provar Quality Hub",
-  "version": "1.5.1",
+  "version": "1.5.2-beta.1",
   "mcpName": "io.github.ProvarTesting/provar",
   "license": "BSD-3-Clause",
   "plugins": [

--- a/server.json
+++ b/server.json
@@ -14,12 +14,12 @@
     "url": "https://github.com/ProvarTesting/provardx-cli",
     "source": "github"
   },
-  "version": "1.5.1",
+  "version": "1.5.2-beta.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@provartesting/provardx-cli",
-      "version": "1.5.1",
+      "version": "1.5.2-beta.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Context

Develop is ahead of 1.5.1 (the last tagged release) by **13 commits** spanning 7 PRs from the Sessions 6/7 backlog:

- **PDX-485** — shared `warningCodes.ts` enum
- **PDX-486** — VALIDATE-TYPO (A: strict validator unknown-key detection / B: testrun zero-tests guard)
- **PDX-489** — G3 DATA-001 dataTable direct-mode warning + path-safety hardening
- **PDX-490** — G5 `error_category` + `retryable` on test-run failures
- **PDX-492** — H2a `provar_org_describe` tool reading Provar workspace `.metadata` cache
- **PDX-493** — H3 date/datetime/boolean/decimal `valueClass` dispatch (canonical-reference alignment)

Per `CLAUDE.md`, the develop branch tracks `<major>.<minor>.<patch>-beta.<n>`. Bumping to **`1.5.2-beta.1`** so the next publish from develop doesn't clash with the released `1.5.1`.

## Files changed

- `package.json` — `version: "1.5.1"` → `"1.5.2-beta.1"`
- `server.json` — top-level `version` AND `packages[0].version` updated in lock-step per the version-sync rule

## Verification

- [x] `yarn compile` — clean
- [x] `yarn lint` — clean (incl. `lint:script-names`)
- [x] `node_modules/.bin/mocha "test/**/*.test.ts"` — **1245 passing / 1 pending / 0 failing**
- [x] All three version fields synced (verified via `git diff`)

## Next step

After this merges to develop, open the release PR **develop → main** and tag `v1.5.2` on the release merge commit.