### PR TITLE
PDX-501: scope comparisonType enum sets by step type

### DIFF
--- a/docs/PROVAR_TEST_STEP_REFERENCE.md
+++ b/docs/PROVAR_TEST_STEP_REFERENCE.md
@@ -573,7 +573,9 @@ Verifies field values or element state on the current screen. Must always includ
 </apiCall>
 ```
 
-**Valid `comparisonType` values:** `EqualTo` | `NotEqualTo` | `Contains` | `NotContains` | `StartsWith` | `EndsWith` | `None`
+**Valid `comparisonType` values (UI Assert):** `EqualTo` | `Contains` | `StartsWith` | `EndsWith` | `Matches` | `None`
+
+`comparisonType` is a single Provar enum (`com.provar.core.model.base.java.ComparisonType`), but **each step type accepts only a subset of it**. A value used outside its step's subset is _load-blocking_: the whole test case fails to load with `IllegalArgumentException: No enum constant …ComparisonType.<value>`. The set above is the **UI Assert** subset (`uiAttributeAssertion`); it is strictly smaller than the AssertValues subset. In particular `NotEqualTo`, `NotContains`, `NotStartsWith`, `NotEndsWith`, and the relational/presence operators are **valid in AssertValues but not in a UI Assert** — to negate a UI comparison, invert the assertion logic instead. The UI dropdown labels map as: Equals → `EqualTo`, Contains → `Contains`, Starts With → `StartsWith`, Ends With → `EndsWith`, Matches → `Matches`; the no-assert/read-only choices (Ignore / Read) map to the single enum value `None`. For the full AssertValues subset see [AssertValues](#assertvalues).
 
 ### UiRead
 
@@ -1255,6 +1257,16 @@ Variable-to-variable or variable-to-literal comparison. For UI field assertions 
   </arguments>
 </apiCall>
 ```
+
+**Valid `comparisonType` values (AssertValues):** `EqualTo` | `NotEqualTo` | `GreaterThan` | `GreaterThanOrEqualTo` | `LessThan` | `LessThanOrEqualTo` | `IsPresent` | `IsEmpty` | `Matches` | `NotMatches` | `Contains` | `NotContains` | `StartsWith` | `NotStartsWith` | `EndsWith` | `NotEndsWith`
+
+This is the **AssertValues** subset of `com.provar.core.model.base.java.ComparisonType` (`assertValuesComparison`) — wider than the [UI Assert](#uiassert) subset. The negation and relational operators (`NotEqualTo`, `NotContains`, `NotStartsWith`, `NotEndsWith`, `NotMatches`, `GreaterThan`, `GreaterThanOrEqualTo`, `LessThan`, `LessThanOrEqualTo`, `IsPresent`, `IsEmpty`) are valid here but **not** on a UI Assert step. Using a value outside this subset is load-blocking (`IllegalArgumentException: No enum constant …ComparisonType.<value>`).
+
+**Comparison semantics and field-type notes:**
+
+- **Direction of `Contains`:** the comparison reads as `expectedValue` _contains_ `actualValue` — i.e. `actualValue` is the substring searched for inside `expectedValue`. Order the arguments accordingly.
+- **Encrypted fields:** a SOQL read of an encrypted field returns `null`, not the cleartext. Assert with `IsEmpty` (or compare against `null`) rather than the expected plaintext; an `EqualTo` against the real value will always fail.
+- **Rich-text / long-textarea fields:** values come back wrapped in HTML block markup (e.g. `<p>…</p>`), so an exact `EqualTo` against the raw text fails. Use `Contains` (with the inner text as `actualValue`) to match the meaningful content.
 
 ---
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -926,6 +926,15 @@ The tool's chip-level `title` — `Generate Test Case (full steps in one call)` 
 
 AssertValues uses **flat** argument structure (`expectedValue`, `actualValue`, `comparisonType`) — not the `valueList`/namedValues format.
 
+**`comparisonType` is step-scoped.** `comparisonType` is a single Provar enum (`com.provar.core.model.base.java.ComparisonType`), but each step type accepts only a subset. A value used outside its step's subset is _load-blocking_ — the whole test case fails to load (`IllegalArgumentException: No enum constant …ComparisonType.<value>`).
+
+| Step type                                 | Valid `comparisonType` subset                                                                                                                                                                                                              |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `AssertValues` (`assertValuesComparison`) | `EqualTo`, `NotEqualTo`, `GreaterThan`, `GreaterThanOrEqualTo`, `LessThan`, `LessThanOrEqualTo`, `IsPresent`, `IsEmpty`, `Matches`, `NotMatches`, `Contains`, `NotContains`, `StartsWith`, `NotStartsWith`, `EndsWith`, `NotEndsWith` (16) |
+| UI Assert (`uiAttributeAssertion`)        | `EqualTo`, `Contains`, `StartsWith`, `EndsWith`, `Matches`, `None` (6)                                                                                                                                                                     |
+
+`NotEqualTo` (and the other negation/relational operators) is valid in an `AssertValues` step but **not** in a UI Assert — that mismatch is a common load-blocking error. The full enum and the field-type semantics (encrypted fields read as `null`; rich-text/textarea values arrive wrapped in `<p>…</p>`, so use `Contains`; `Contains` direction is `expectedValue` contains `actualValue`) are documented in the `provar://docs/step-reference` resource.
+
 **Input**
 
 | Parameter             | Type                                     | Required | Description                                                                                                                                                                             |

--- a/src/mcp/rules/provar_best_practices_rules.json
+++ b/src/mcp/rules/provar_best_practices_rules.json
@@ -892,7 +892,7 @@
       "appliesTo": ["Step"],
       "severity": "critical",
       "weight": 8,
-      "recommendation": "Add 'comparisonType' argument with valid value: EqualTo, NotEqualTo, Contains, NotContains, StartsWith, EndsWith, GreaterThan, LessThan, Matches, IsNull, NotNull.",
+      "recommendation": "Add 'comparisonType' argument with a value from the AssertValues subset of ComparisonType: EqualTo, NotEqualTo, GreaterThan, GreaterThanOrEqualTo, LessThan, LessThanOrEqualTo, IsPresent, IsEmpty, Matches, NotMatches, Contains, NotContains, StartsWith, NotStartsWith, EndsWith, NotEndsWith. Note: UI Assert (uiAttributeAssertion) steps accept only the narrower subset EqualTo, Contains, StartsWith, EndsWith, Matches, None; a value used outside its step's subset is load-blocking.",
       "check": {
         "type": "mustContainArgument",
         "apiId": "com.provar.plugins.bundled.apis.AssertValues",
@@ -1506,7 +1506,7 @@
       "id": "ASSERT-VALUES-COMPARISON-001",
       "category": "TestCaseDesign",
       "name": "AssertValues should have meaningful expected values",
-      "description": "AssertValues steps using comparison operators (EqualTo, Contains, GreaterThan, etc.) should specify meaningful expectedValue arguments. Empty or missing expected values defeat the purpose of assertions and provide no validation. Without expected values, assertions cannot verify correct behavior. Comparison types requiring values: EqualTo, NotEqualTo, Contains, NotContains, StartsWith, NotStartsWith, EndsWith, NotEndsWith, Matches, NotMatches, GreaterThan, LessThan, GreaterThanOrEqualTo, LessThanOrEqualTo.",
+      "description": "AssertValues steps using comparison operators (EqualTo, Contains, GreaterThan, etc.) should specify meaningful expectedValue arguments. Empty or missing expected values defeat the purpose of assertions and provide no validation. Without expected values, assertions cannot verify correct behavior. The AssertValues subset of ComparisonType is: EqualTo, NotEqualTo, GreaterThan, GreaterThanOrEqualTo, LessThan, LessThanOrEqualTo, IsPresent, IsEmpty, Matches, NotMatches, Contains, NotContains, StartsWith, NotStartsWith, EndsWith, NotEndsWith. Of these, the value-requiring comparators are EqualTo, NotEqualTo, Contains, NotContains, StartsWith, NotStartsWith, EndsWith, NotEndsWith, Matches, NotMatches, GreaterThan, LessThan, GreaterThanOrEqualTo, LessThanOrEqualTo (the presence checks IsPresent and IsEmpty do not need an expectedValue). UI Assert (uiAttributeAssertion) steps use a narrower subset: EqualTo, Contains, StartsWith, EndsWith, Matches, None.",
       "appliesTo": ["Step"],
       "severity": "major",
       "weight": 5,


### PR DESCRIPTION
## Summary
- Corrects the `comparisonType` guidance to present **two step-scoped subsets** of the single `com.provar.core.model.base.java.ComparisonType` enum, instead of one flat/incorrect list. A value used outside its step's subset is load-blocking (`IllegalArgumentException: No enum constant …ComparisonType.<value>`).
  - **AssertValues** (`assertValuesComparison`): 16 values — `EqualTo, NotEqualTo, GreaterThan, GreaterThanOrEqualTo, LessThan, LessThanOrEqualTo, IsPresent, IsEmpty, Matches, NotMatches, Contains, NotContains, StartsWith, NotStartsWith, EndsWith, NotEndsWith`.
  - **UI Assert** (`uiAttributeAssertion`): 6 values — `EqualTo, Contains, StartsWith, EndsWith, Matches, None`.
- Root cause of the dogfooding failure: `NotEqualTo` is valid in AssertValues but **not** in a UI Assert; the old docs/rules conflated the two contexts.
- Adds schema-aware field-type notes to the step reference (encrypted fields read as `null`; rich-text/textarea values arrive wrapped in `<p>…</p>` so use `Contains`; `Contains` direction is `expectedValue` contains `actualValue`).

## Jira
https://provartesting.atlassian.net/browse/PDX-501

## Test plan
- [x] yarn compile passes
- [x] yarn test:only passes (1315 passing)
- [x] mcp-smoke.cjs passes (57/57)
- [x] yarn lint passes

## Changes
- `docs/PROVAR_TEST_STEP_REFERENCE.md`: UI Assert section now lists the 6-value subset with a cross-context explainer; AssertValues section gains the 16-value subset and the comparison/field-type semantics notes.
- `src/mcp/rules/provar_best_practices_rules.json`: ASSERT-COMPARISON-001 and ASSERT-VALUES-COMPARISON-001 rule strings scoped to the AssertValues subset, with a note about the narrower UI Assert subset.
- `docs/mcp.md`: AssertValues section gains a step-scoped `comparisonType` table.

## Note for Provar team
External/customer-facing docs (`docs/provar-mcp-public-docs.md`, `docs/university-of-provar-mcp-course.md`) are maintained separately — if they document `comparisonType`, they should adopt the same two step-scoped sets.