### PR TITLE
PDX-504: quote sf executable and args for spaces on Windows

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -2586,6 +2586,8 @@ provar_nitrox_patch      → apply targeted edits to an existing .po.json (RFC 7
 ```
 
 > **Note:** `provar_automation_*` and `provar_qualityhub_*` tools invoke `sf` CLI subprocesses. The Salesforce CLI must be installed and in `PATH`, or pass `sf_path` pointing to the executable directly (e.g. `~/.nvm/versions/node/v22.0.0/bin/sf`). A missing `sf` binary returns the error code `SF_NOT_FOUND` with an installation hint.
+>
+> **Windows paths with spaces are handled automatically.** On Windows the `sf` launcher is a `.cmd` script and must run through `cmd.exe`. The executable path (including auto-discovered `C:\Program Files\sf\...` installs), an explicit `sf_path`, and any argument value (e.g. a `--properties-file` under a `Provar Manager` directory) are quoted before invocation, so spaces no longer split the command. The 8.3 short-name workaround (`C:\PROGRA~1\...`) is no longer needed. A user-supplied `sf_path` containing shell metacharacters (`&`, `|`, `;`, `<`, `>`, backtick, quotes, or line-breaks) is still rejected with `INVALID_SF_PATH`.
 
 ---
 

--- a/src/mcp/tools/sfSpawn.ts
+++ b/src/mcp/tools/sfSpawn.ts
@@ -180,6 +180,22 @@ function assertShellSafePath(sfPath: string): void {
 }
 
 /**
+ * Quote a single command-line token for cmd.exe when the whole command is run
+ * through `shell: true`. Tokens containing whitespace or cmd-significant
+ * characters are wrapped in double quotes (embedded `"` doubled per cmd rules);
+ * simple tokens are left as-is. This is what keeps spaced paths — e.g.
+ * `C:\Program Files\sf\client\bin\sf.cmd` or a `--properties-file` value under a
+ * "Provar Manager" directory — from being split by cmd.exe.
+ */
+function quoteWindowsToken(token: string): string {
+  if (token === '') return '""';
+  if (/[\s"&|<>^()]/.test(token)) {
+    return `"${token.replace(/"/g, '""')}"`;
+  }
+  return token;
+}
+
+/**
  * Run `sf <args>` synchronously and return stdout, stderr, and exit code.
  * Throws SfNotFoundError if the `sf` binary cannot be found.
  * Pass `sfPath` to override auto-discovery with an explicit executable path.
@@ -201,7 +217,19 @@ export function runSfCommand(args: string[], sfPath?: string): SpawnResult {
     assertShellSafePath(resolvedSfPath);
   }
 
-  const result = sfSpawnHelper.spawnSync(executable, args, {
+  // On Windows, `.cmd`/`.bat`/bare-name executables must run through cmd.exe
+  // (shell:true). Under shell:true Node concatenates executable + args into one
+  // unquoted string, so spaces in the auto-resolved Program Files path, an
+  // explicit sf_path, or any argument value would split the command
+  // (`'C:\Program' is not recognized ...`). Pre-quote the executable and each
+  // argument: Node joins them and wraps the whole line in cmd's outer quotes,
+  // and cmd's `/s` rule strips only that outermost pair, preserving our
+  // per-token quoting. This applies to auto-resolved paths too — not just
+  // user-supplied ones. On non-Windows the args pass through verbatim.
+  const spawnExecutable = useShell ? quoteWindowsToken(executable) : executable;
+  const spawnArgs = useShell ? args.map(quoteWindowsToken) : args;
+
+  const result = sfSpawnHelper.spawnSync(spawnExecutable, spawnArgs, {
     encoding: 'utf-8',
     shell: useShell,
     maxBuffer: MAX_BUFFER,

--- a/test/unit/mcp/sfSpawn.test.ts
+++ b/test/unit/mcp/sfSpawn.test.ts
@@ -354,4 +354,53 @@ describe('runSfCommand', () => {
       assert.equal(opts.shell, true);
     });
   });
+
+  describe('Windows shell quoting (spaced executable & args not split)', () => {
+    beforeEach(() => {
+      setSfPlatformForTesting('win32');
+      spawnStub.returns(makeSpawnOk('ok'));
+    });
+
+    it('(a) does not split an auto-resolved Program Files path', () => {
+      const sfCmd = 'C:\\Program Files\\sf\\client\\bin\\sf.cmd';
+      setSfPathCacheForTesting(sfCmd);
+      runSfCommand(['provar', 'automation', 'config-load']);
+      const [exe, , opts] = spawnStub.firstCall.args as [string, string[], { shell: boolean }];
+      // The auto-resolved path is quoted as a single token even though no sf_path was passed.
+      assert.equal(exe, `"${sfCmd}"`, `executable must be quoted as a single token, got: ${exe}`);
+      assert.equal(opts.shell, true);
+    });
+
+    it('(b) does not split an explicit spaced sf_path', () => {
+      const sfCmd = 'C:\\Program Files\\sf\\bin\\sf.cmd';
+      runSfCommand(['--version'], sfCmd);
+      const [exe] = spawnStub.firstCall.args as [string, string[]];
+      assert.equal(exe, `"${sfCmd}"`, `explicit sf_path must be quoted, got: ${exe}`);
+    });
+
+    it('(c) does not split an argument value containing a space', () => {
+      setSfPathCacheForTesting('sf');
+      const propsPath = 'C:\\Users\\mrdai\\git\\Provar Manager\\test-manager\\provardx-properties.json';
+      runSfCommand(['provar', 'automation', 'config-load', '--properties-file', propsPath]);
+      const [exe, args] = spawnStub.firstCall.args as [string, string[]];
+      assert.equal(exe, 'sf'); // space-free executable stays unquoted
+      assert.deepEqual(args, ['provar', 'automation', 'config-load', '--properties-file', `"${propsPath}"`]);
+    });
+
+    it('leaves simple (space-free) tokens unquoted on win32', () => {
+      setSfPathCacheForTesting('sf');
+      runSfCommand(['provar', 'automation', 'config-load']);
+      const [exe, args] = spawnStub.firstCall.args as [string, string[]];
+      assert.equal(exe, 'sf');
+      assert.deepEqual(args, ['provar', 'automation', 'config-load']);
+    });
+
+    it('still rejects a user sf_path with shell metacharacters (spaces are now allowed)', () => {
+      assert.throws(() => runSfCommand(['--version'], 'C:\\sf & evil\\sf.cmd'), /unsafe for shell execution/);
+      // A spaced-but-clean user path is accepted and quoted.
+      spawnStub.returns(makeSpawnOk('ok'));
+      const result = runSfCommand(['--version'], 'C:\\Program Files\\sf\\bin\\sf.cmd');
+      assert.equal(result.exitCode, 0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes the **High-severity** Windows bug where `sf` invocation split on spaces. On Windows the `sf` launcher is a `.cmd` and must run through `cmd.exe` (`shell: true`); Node then concatenates executable + args into one **unquoted** string, so any space broke the command (`'C:\Program' is not recognized ...`).
- This affected the **default install case** — `getSfCommonPaths()` auto-discovers `C:\Program Files\sf\...`, and arg values under a `Provar Manager` directory also split.
- **Fix:** on the win32 shell branch, pre-quote the executable and every argument (`quoteWindowsToken`). Node joins them and wraps the line in cmd's outer quotes; cmd's `/s` rule strips only that outermost pair, preserving our per-token quoting. Applied to **auto-resolved paths too** — not gated on a user-supplied `sf_path`. The 3-arg `spawnSync(executable, args, opts)` shape is kept, so space-free tokens are byte-identical (no behavioural change off the spaced-path case).
- Metacharacter rejection (`assertShellSafePath` → `INVALID_SF_PATH`) still applies to user-supplied `sf_path`; spaces are now allowed (and quoted) where previously the 8.3 short-name workaround was needed.

## Jira
https://provartesting.atlassian.net/browse/PDX-504

## Test plan
- [x] yarn compile passes
- [x] yarn test:only passes (1325 passing; 5 new sfSpawn tests)
- [x] mcp-smoke.cjs passes (58/58)
- [x] yarn lint passes

## Tests (per acceptance criteria, win32 via `setSfPlatformForTesting`)
- (a) auto-resolved `C:\Program Files\sf\client\bin\sf.cmd` is quoted as a single token (not gated on `sf_path`)
- (b) explicit spaced `sf_path` is quoted
- (c) an argument value containing a space (`--properties-file` under `Provar Manager`) is quoted, not split
- space-free tokens stay unquoted (no regression)
- a user `sf_path` with shell metacharacters is still rejected; a spaced-but-clean one is accepted

## Changes
- `src/mcp/tools/sfSpawn.ts`: `quoteWindowsToken` helper; quote executable + args on the win32 shell branch.
- `test/unit/mcp/sfSpawn.test.ts`: 5 new win32 quoting tests.
- `docs/mcp.md`: note that Windows spaced paths are handled automatically (8.3 workaround no longer needed).