### PR TITLE
PDX-505: detect missing provar plugin with PROVAR_PLUGIN_NOT_FOUND

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1602,7 +1602,7 @@ Checks in this order:
 
 After a successful setup, update `provarHome` in your `provardx-properties.json` using `provar_properties_set`.
 
-**Error codes:** `AUTOMATION_SETUP_FAILED`, `SF_NOT_FOUND`
+**Error codes:** `AUTOMATION_SETUP_FAILED`, `SF_NOT_FOUND`, `PROVAR_PLUGIN_NOT_FOUND`
 
 ---
 
@@ -1648,7 +1648,7 @@ warning is additive and never flips exitCode or sets isError; the failure surfac
 ▎ what ran". In those cases the response carries details.warning (explaining why structured step data is missing) and RUN-001 is suppressed to
 ▎ avoid misdirecting the agent toward a typo when the real issue is a missing/unreadable results dir.
 
-Error codes: AUTOMATION_TESTRUN_FAILED, SF_NOT_FOUND
+Error codes: AUTOMATION_TESTRUN_FAILED, SF_NOT_FOUND, PROVAR_PLUGIN_NOT_FOUND
 Warning codes: RUN-001 (zero tests executed despite success)
 ```
 
@@ -1664,7 +1664,7 @@ Compiles PageObject and PageControl Java source files. Invokes `sf provar automa
 
 **Output** — `{ requestId, exitCode, stdout, stderr }`
 
-**Error codes:** `AUTOMATION_COMPILE_FAILED`, `SF_NOT_FOUND`
+**Error codes:** `AUTOMATION_COMPILE_FAILED`, `SF_NOT_FOUND`, `PROVAR_PLUGIN_NOT_FOUND`
 
 ---
 
@@ -1680,7 +1680,7 @@ Downloads Salesforce metadata into the Provar project cache. Invokes `sf provar 
 
 **Output** — `{ requestId, exitCode, stdout, stderr }`
 
-**Error codes:** `AUTOMATION_METADATA_FAILED`, `SF_NOT_FOUND`
+**Error codes:** `AUTOMATION_METADATA_FAILED`, `SF_NOT_FOUND`, `PROVAR_PLUGIN_NOT_FOUND`
 
 ---
 
@@ -1724,7 +1724,7 @@ Invokes `sf provar automation config load --properties-file <path>`, writing the
 | `exitCode`        | Exit code from the sf CLI       |
 | `properties_path` | Echoes back the registered path |
 
-**Error codes:** `AUTOMATION_CONFIG_LOAD_FAILED`, `SF_NOT_FOUND`
+**Error codes:** `AUTOMATION_CONFIG_LOAD_FAILED`, `SF_NOT_FOUND`, `PROVAR_PLUGIN_NOT_FOUND`
 
 ---
 
@@ -2586,6 +2586,8 @@ provar_nitrox_patch      → apply targeted edits to an existing .po.json (RFC 7
 ```
 
 > **Note:** `provar_automation_*` and `provar_qualityhub_*` tools invoke `sf` CLI subprocesses. The Salesforce CLI must be installed and in `PATH`, or pass `sf_path` pointing to the executable directly (e.g. `~/.nvm/versions/node/v22.0.0/bin/sf`). A missing `sf` binary returns the error code `SF_NOT_FOUND` with an installation hint.
+>
+> **`PROVAR_PLUGIN_NOT_FOUND`** — the `sf` binary is present but the `@provartesting/provardx-cli` plugin is not installed (the `sf` CLI has no `provar` topic). The `provar_automation_*` tools detect this case (sf reports e.g. `Command provar not found`) and return `PROVAR_PLUGIN_NOT_FOUND` with `details.suggestion` instead of the opaque `AUTOMATION_*_FAILED`. Remediation: `sf plugins install @provartesting/provardx-cli`.
 >
 > **Windows paths with spaces are handled automatically.** On Windows the `sf` launcher is a `.cmd` script and must run through `cmd.exe`. The executable path (including auto-discovered `C:\Program Files\sf\...` installs), an explicit `sf_path`, and any argument value (e.g. a `--properties-file` under a `Provar Manager` directory) are quoted before invocation, so spaces no longer split the command. The 8.3 short-name workaround (`C:\PROGRA~1\...`) is no longer needed. A user-supplied `sf_path` containing shell metacharacters (`&`, `|`, `;`, `<`, `>`, backtick, quotes, or line-breaks) is still rejected with `INVALID_SF_PATH`.
 

--- a/src/mcp/tools/automationTools.ts
+++ b/src/mcp/tools/automationTools.ts
@@ -17,11 +17,44 @@ import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { WARNING_CODES, formatWarning } from '../utils/warningCodes.js';
 import { parseJUnitResults } from './antTools.js';
-import { runSfCommand } from './sfSpawn.js';
+import { runSfCommand, isProvarPluginMissing, PROVAR_PLUGIN_INSTALL_HINT } from './sfSpawn.js';
 import { desc } from './descHelper.js';
 
 // Re-export sf resolution helpers so existing test imports from automationTools continue to work
 export { getSfCommonPaths, needsWindowsShell, setSfPathCacheForTesting, setSfPlatformForTesting } from './sfSpawn.js';
+
+/**
+ * When an automation sf command exits non-zero because the `provar` topic is
+ * missing (the @provartesting/provardx-cli plugin isn't installed), return a
+ * dedicated PROVAR_PLUGIN_NOT_FOUND error with remediation instead of the
+ * opaque AUTOMATION_*_FAILED carrying "Command provar not found". Returns null
+ * when the failure is not a missing-plugin case, so the caller falls through to
+ * its normal error.
+ */
+function provarPluginErrorResponse(
+  result: { stdout: string; stderr: string },
+  requestId: string
+): { isError: true; content: Array<{ type: 'text'; text: string }> } | null {
+  if (!isProvarPluginMissing(result.stdout, result.stderr)) return null;
+  return {
+    isError: true as const,
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          makeError(
+            'PROVAR_PLUGIN_NOT_FOUND',
+            'The Provar sf plugin is not installed — the sf CLI has no "provar" topic. ' +
+              `Install it with: ${PROVAR_PLUGIN_INSTALL_HINT}`,
+            requestId,
+            false,
+            { suggestion: PROVAR_PLUGIN_INSTALL_HINT }
+          )
+        ),
+      },
+    ],
+  };
+}
 
 function handleSpawnError(
   err: unknown,
@@ -96,6 +129,8 @@ export function registerAutomationConfigLoad(server: McpServer, config: ServerCo
         };
 
         if (result.exitCode !== 0) {
+          const pluginErr = provarPluginErrorResponse(result, requestId);
+          if (pluginErr) return pluginErr;
           return {
             isError: true as const,
             content: [
@@ -316,6 +351,8 @@ export function registerAutomationTestRun(server: McpServer, config: ServerConfi
         const junit = introspectJUnit(config);
 
         if (result.exitCode !== 0) {
+          const pluginErr = provarPluginErrorResponse(result, requestId);
+          if (pluginErr) return pluginErr;
           const { filtered: filteredErr, suppressed: suppressedErr } = filterTestRunOutput(
             result.stderr || result.stdout
           );
@@ -416,6 +453,8 @@ export function registerAutomationCompile(server: McpServer): void {
         const response = { requestId, exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr };
 
         if (result.exitCode !== 0) {
+          const pluginErr = provarPluginErrorResponse(result, requestId);
+          if (pluginErr) return pluginErr;
           return {
             isError: true as const,
             content: [
@@ -492,6 +531,8 @@ export function registerAutomationMetadataDownload(server: McpServer): void {
         const message = result.stderr || result.stdout;
 
         if (result.exitCode !== 0) {
+          const pluginErr = provarPluginErrorResponse(result, requestId);
+          if (pluginErr) return pluginErr;
           const isDownloadError = message.includes('[DOWNLOAD_ERROR]');
           const details: Record<string, unknown> | undefined = isDownloadError
             ? { suggestion: DOWNLOAD_ERROR_SUGGESTION }
@@ -685,6 +726,8 @@ export function registerAutomationSetup(server: McpServer): void {
         const result = runSfCommand(['provar', 'automation', 'setup', ...flags], sf_path);
 
         if (result.exitCode !== 0) {
+          const pluginErr = provarPluginErrorResponse(result, requestId);
+          if (pluginErr) return pluginErr;
           return {
             isError: true as const,
             content: [

--- a/src/mcp/tools/sfSpawn.ts
+++ b/src/mcp/tools/sfSpawn.ts
@@ -34,6 +34,56 @@ export class SfNotFoundError extends Error {
   }
 }
 
+/** Remediation command for a missing Provar sf plugin. */
+export const PROVAR_PLUGIN_INSTALL_HINT = 'sf plugins install @provartesting/provardx-cli';
+
+/**
+ * Raised when the `sf` binary is present but the `@provartesting/provardx-cli`
+ * plugin is not installed (the `sf` CLI has no `provar` topic). Mirrors
+ * SfNotFoundError so callers get a dedicated code + actionable remediation
+ * instead of an opaque `AUTOMATION_*_FAILED` carrying "Command provar not found".
+ */
+export class ProvarPluginNotFoundError extends Error {
+  public readonly code = 'PROVAR_PLUGIN_NOT_FOUND';
+  public constructor() {
+    super(
+      'The Provar sf plugin is not installed — the sf CLI has no "provar" topic. ' +
+        `Install it with: ${PROVAR_PLUGIN_INSTALL_HINT}`
+    );
+    this.name = 'ProvarPluginNotFoundError';
+  }
+}
+
+// Patterns sf emits when the `provar` topic/command is unknown (plugin missing).
+const PROVAR_PLUGIN_MISSING_PATTERNS: RegExp[] = [
+  /command\s+provar\S*\s+not\s+found/i, // "command provar not found" / "command provar:automation:... not found"
+  /\bprovar\S*\s+is not a[n]?\s+(?:sf|@salesforce\/cli)\s+command/i, // oclif "provar is not a sf command"
+  /no such (?:command|topic)[^\n]*\bprovar\b/i,
+];
+
+/**
+ * Heuristic: does sf stdout/stderr indicate the `provar` topic/plugin is missing?
+ * Used to translate a generic non-zero sf exit into PROVAR_PLUGIN_NOT_FOUND.
+ */
+export function isProvarPluginMissing(stdout: string, stderr: string): boolean {
+  const haystack = `${stderr ?? ''}\n${stdout ?? ''}`;
+  return PROVAR_PLUGIN_MISSING_PATTERNS.some((re) => re.test(haystack));
+}
+
+/**
+ * Lightweight probe for the `provar` topic. Returns true when `sf provar --help`
+ * succeeds (plugin installed), false when sf is missing or the topic is absent.
+ * Non-throwing so it can be used as a best-effort startup health check.
+ */
+export function probeProvarTopic(sfPath?: string): boolean {
+  try {
+    const result = runSfCommand(['provar', '--help'], sfPath);
+    return result.exitCode === 0 && !isProvarPluginMissing(result.stdout, result.stderr);
+  } catch {
+    return false;
+  }
+}
+
 // ── Shared result type ────────────────────────────────────────────────────────
 
 export interface SpawnResult {

--- a/test/unit/mcp/automationTools.test.ts
+++ b/test/unit/mcp/automationTools.test.ts
@@ -1044,6 +1044,72 @@ describe('filterTestRunOutput', () => {
     assert.ok(filtered.includes('INFO Starting'), 'Real output should remain');
     assert.ok(filtered.includes('INFO Done'), 'Real output should remain');
   });
+
+  // ── PROVAR_PLUGIN_NOT_FOUND (missing provar topic / plugin) ────────────────
+  describe('PROVAR_PLUGIN_NOT_FOUND', () => {
+    const REMEDIATION = 'sf plugins install @provartesting/provardx-cli';
+    let server: MockMcpServer;
+    let spawnStub: sinon.SinonStub;
+
+    beforeEach(async () => {
+      server = new MockMcpServer();
+      spawnStub = sinon.stub(sfSpawnHelper, 'spawnSync');
+      const { registerAllAutomationTools, setSfPathCacheForTesting } = await import(
+        '../../../src/mcp/tools/automationTools.js'
+      );
+      setSfPathCacheForTesting('sf');
+      registerAllAutomationTools(server as unknown as McpServer, { allowedPaths: [] });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('config_load surfaces PROVAR_PLUGIN_NOT_FOUND with remediation when the provar topic is missing', () => {
+      spawnStub.returns(makeSpawnResult('', 'Warning: provar is not a sf command.\nDid you mean a typo?', 1));
+      const result = server.call('provar_automation_config_load', {
+        properties_path: '/proj/provardx-properties.json',
+      });
+      assert.ok(isError(result));
+      const body = parseBody(result);
+      assert.equal(body.error_code, 'PROVAR_PLUGIN_NOT_FOUND');
+      assert.notEqual(body.error_code, 'AUTOMATION_CONFIG_LOAD_FAILED');
+      assert.match(String(body.message), /Provar sf plugin is not installed/);
+      assert.match(String(body.message), /sf plugins install @provartesting\/provardx-cli/);
+      assert.equal((body.details as { suggestion?: string }).suggestion, REMEDIATION);
+    });
+
+    it('detects the "command provar not found" phrasing', () => {
+      spawnStub.returns(makeSpawnResult('', 'command provar not found', 1));
+      const result = server.call('provar_automation_config_load', {
+        properties_path: '/proj/provardx-properties.json',
+      });
+      assert.equal(parseBody(result).error_code, 'PROVAR_PLUGIN_NOT_FOUND');
+    });
+
+    it('does NOT fire for a generic config-load failure (stays AUTOMATION_CONFIG_LOAD_FAILED)', () => {
+      spawnStub.returns(makeSpawnResult('', 'Error: properties file not found at /proj/x.json', 1));
+      const result = server.call('provar_automation_config_load', {
+        properties_path: '/proj/provardx-properties.json',
+      });
+      assert.equal(parseBody(result).error_code, 'AUTOMATION_CONFIG_LOAD_FAILED');
+    });
+
+    it('maps a missing provar topic on testrun too', () => {
+      spawnStub.returns(makeSpawnResult('', 'command provar:automation:test:run not found', 1));
+      const result = server.call('provar_automation_testrun', { flags: [] });
+      assert.equal(parseBody(result).error_code, 'PROVAR_PLUGIN_NOT_FOUND');
+    });
+
+    it('does not fire on a successful command (exit 0)', () => {
+      spawnStub.returns(makeSpawnResult('properties file loaded successfully', '', 0));
+      const result = server.call('provar_automation_config_load', {
+        properties_path: '/proj/provardx-properties.json',
+      });
+      assert.ok(!isError(result));
+      assert.equal(parseBody(result).exitCode, 0);
+    });
+  });
 });
 
 // ── getSfCommonPaths — B2a Windows standalone installer paths ─────────────────

--- a/test/unit/mcp/sfSpawn.test.ts
+++ b/test/unit/mcp/sfSpawn.test.ts
@@ -12,6 +12,10 @@ import sinon from 'sinon';
 import {
   sfSpawnHelper,
   SfNotFoundError,
+  ProvarPluginNotFoundError,
+  PROVAR_PLUGIN_INSTALL_HINT,
+  isProvarPluginMissing,
+  probeProvarTopic,
   getSfCommonPaths,
   needsWindowsShell,
   runSfCommand,
@@ -402,5 +406,77 @@ describe('runSfCommand', () => {
       const result = runSfCommand(['--version'], 'C:\\Program Files\\sf\\bin\\sf.cmd');
       assert.equal(result.exitCode, 0);
     });
+  });
+});
+
+// ── ProvarPluginNotFoundError ───────────────────────────────────────────────
+
+describe('ProvarPluginNotFoundError', () => {
+  it('has code PROVAR_PLUGIN_NOT_FOUND and remediation in the message', () => {
+    const err = new ProvarPluginNotFoundError();
+    assert.equal(err.code, 'PROVAR_PLUGIN_NOT_FOUND');
+    assert.equal(err.name, 'ProvarPluginNotFoundError');
+    assert.ok(err.message.includes(PROVAR_PLUGIN_INSTALL_HINT));
+    assert.ok(err.message.toLowerCase().includes('provar'));
+  });
+});
+
+// ── isProvarPluginMissing ────────────────────────────────────────────────────
+
+describe('isProvarPluginMissing', () => {
+  it('matches "command provar not found"', () => {
+    assert.equal(isProvarPluginMissing('', 'command provar not found'), true);
+  });
+
+  it('matches a nested provar command not found (stdout)', () => {
+    assert.equal(isProvarPluginMissing('command provar:automation:test:run not found', ''), true);
+  });
+
+  it('matches oclif "provar is not a sf command"', () => {
+    assert.equal(isProvarPluginMissing('', 'Warning: provar is not a sf command.'), true);
+  });
+
+  it('does not match an unrelated failure', () => {
+    assert.equal(isProvarPluginMissing('', 'Error: properties file not found at /proj/x.json'), false);
+  });
+
+  it('does not match a benign sf update warning', () => {
+    assert.equal(
+      isProvarPluginMissing('', 'Warning: @salesforce/cli update available from 2.132.14 to 2.136.8.'),
+      false
+    );
+  });
+});
+
+// ── probeProvarTopic ─────────────────────────────────────────────────────────
+
+describe('probeProvarTopic', () => {
+  let spawnStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    spawnStub = sinon.stub(sfSpawnHelper, 'spawnSync');
+    setSfPathCacheForTesting('sf');
+    setSfPlatformForTesting('linux');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    setSfPathCacheForTesting(undefined);
+    setSfPlatformForTesting(undefined);
+  });
+
+  it('returns true when `sf provar --help` succeeds', () => {
+    spawnStub.returns(makeSpawnOk('USAGE\n  $ sf provar COMMAND'));
+    assert.equal(probeProvarTopic(), true);
+  });
+
+  it('returns false when the provar topic is missing', () => {
+    spawnStub.returns(makeSpawnFail(1, '', 'command provar not found'));
+    assert.equal(probeProvarTopic(), false);
+  });
+
+  it('returns false (does not throw) when sf itself is not found', () => {
+    setSfPathCacheForTesting(null);
+    assert.equal(probeProvarTopic(), false);
   });
 });


### PR DESCRIPTION
## Summary
- When the `@provartesting/provardx-cli` sf plugin is **not installed** (the `sf` CLI has no `provar` topic), the automation tools previously failed opaquely with `AUTOMATION_*_FAILED` carrying `Command provar not found`. Users had to recognize that text to realize the root cause.
- Adds a dedicated **`PROVAR_PLUGIN_NOT_FOUND`** error code with actionable remediation (`details.suggestion: sf plugins install @provartesting/provardx-cli`), mirroring the `SfNotFoundError` / `SF_NOT_FOUND` pattern.
- New in `sfSpawn.ts`: `ProvarPluginNotFoundError`, `PROVAR_PLUGIN_INSTALL_HINT`, an `isProvarPluginMissing(stdout, stderr)` detector (matches `command provar … not found`, oclif `provar is not a sf command`, etc.), and a non-throwing `probeProvarTopic(sfPath?)` health-check.
- All five `provar_automation_*` tools (config_load, testrun, compile, metadata_download, setup) run a shared pre-flight: when an sf command exits non-zero **and** the output matches the missing-plugin pattern, they return `PROVAR_PLUGIN_NOT_FOUND` instead of the generic `_FAILED`. A genuine failure (or exit 0) is unaffected.

## Jira
https://provartesting.atlassian.net/browse/PDX-505

## Test plan
- [x] yarn compile passes
- [x] yarn test:only passes (1339 passing; 14 new tests)
- [x] mcp-smoke.cjs passes (58/58, unaffected)
- [x] yarn lint passes

## Tests
- `sfSpawn.test.ts`: `ProvarPluginNotFoundError` shape; `isProvarPluginMissing` positive (3 phrasings) + negatives (unrelated error, benign update warning); `probeProvarTopic` true/false/sf-missing.
- `automationTools.test.ts`: config_load surfaces `PROVAR_PLUGIN_NOT_FOUND` with remediation (positive); `command provar not found` phrasing; **negative** — a generic config-load failure stays `AUTOMATION_CONFIG_LOAD_FAILED`; testrun also maps; no-fire on exit 0.

## Changes
- `src/mcp/tools/sfSpawn.ts`: error class, install hint, detector, probe.
- `src/mcp/tools/automationTools.ts`: shared `provarPluginErrorResponse` pre-flight wired into all 5 automation failure paths.
- `docs/mcp.md`: `PROVAR_PLUGIN_NOT_FOUND` added to the 5 automation tools' error-code lists + a definition note.
- Tests as above.