### PR TITLE
PDX-0: chore: bump version to 1.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provartesting/provardx-cli",
   "description": "A plugin for the Salesforce CLI to orchestrate testing activities and report quality metrics to Provar Quality Hub",
-  "version": "1.5.2-beta.4",
+  "version": "1.5.4",
   "mcpName": "io.github.ProvarTesting/provar",
   "license": "BSD-3-Clause",
   "plugins": [

--- a/server.json
+++ b/server.json
@@ -14,12 +14,12 @@
     "url": "https://github.com/ProvarTesting/provardx-cli",
     "source": "github"
   },
-  "version": "1.5.2-beta.4",
+  "version": "1.5.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@provartesting/provardx-cli",
-      "version": "1.5.2-beta.4",
+      "version": "1.5.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Bumps the package version from `1.5.2-beta.4` to **`1.5.4`** on `develop`.
- Keeps the version in sync across all three fields per the repo convention: `package.json` `version`, `server.json` top-level `version`, and `server.json` `packages[0].version`.

## Context
`1.5.3` was released from a release branch to `main` and never back-merged to `develop`, so `develop` was still at `1.5.2-beta.4`. This advances it to the next version (`1.5.4`), reflecting the merged PDX-501…PDX-505 MCP fixes.

> ⚠️ **Note for maintainers (not addressed in this PR):** `develop` is currently behind `main` for the `1.5.3` release — the release branch landed on `main` only. A separate `main → develop` back-merge may be warranted so develop carries the 1.5.3 release history. Flagging rather than fixing here, since that reconciliation is out of scope for a version-bump chore.

## Test plan
- [x] yarn compile passes
- [x] yarn lint passes
- [x] pre-push (yarn build && yarn test) passed
- [x] package.json and server.json versions are identical (`1.5.4`)

## Changes
- `package.json`: `version` → `1.5.4`
- `server.json`: top-level `version` and `packages[0].version` → `1.5.4`