### PR TITLE
PDX-0: chore: portable, non-personal paths (PR #201 Copilot review)

### DIFF
--- a/docs/loops/pdx-501-505.md
+++ b/docs/loops/pdx-501-505.md
@@ -82,12 +82,12 @@ TICKET-SPECIFIC RULES:
   authored testcases:
     • AssertValues / assertValuesComparison (apiId
       com.provar.plugins.bundled.apis.AssertValues) — valid set from
-      C:\Users\mrdai\git\provar-manager-regression\tests\ComparisonTypes.testcase:
+      ~/git/provar-manager-regression/tests/ComparisonTypes.testcase:
         EqualTo, NotEqualTo, GreaterThan, GreaterThanOrEqualTo, LessThan,
         LessThanOrEqualTo, IsPresent, IsEmpty, Matches, NotMatches, Contains,
         NotContains, StartsWith, NotStartsWith, EndsWith, NotEndsWith  (16)
     • UiAssert / uiAttributeAssertion — valid set from the comparisonType
-      attributes in C:\Users\mrdai\git\provar-manager-regression\tests\SauceDemo Purchase Flow (Demo).testcase:
+      attributes in ~/git/provar-manager-regression/tests/SauceDemo Purchase Flow (Demo).testcase:
         EqualTo, Contains, StartsWith, EndsWith, Matches, None  (6)
         (dropdown labels: Equals→EqualTo, Contains, Starts With→StartsWith,
         Ends With→EndsWith, Matches; Ignore/Read→None. Verify the Ignore-vs-Read

--- a/test/unit/mcp/sfSpawn.test.ts
+++ b/test/unit/mcp/sfSpawn.test.ts
@@ -384,7 +384,7 @@ describe('runSfCommand', () => {
 
     it('(c) does not split an argument value containing a space', () => {
       setSfPathCacheForTesting('sf');
-      const propsPath = 'C:\\Users\\mrdai\\git\\Provar Manager\\test-manager\\provardx-properties.json';
+      const propsPath = 'C:\\Users\\username\\git\\Provar Manager\\test-manager\\provardx-properties.json';
       runSfCommand(['provar', 'automation', 'config-load', '--properties-file', propsPath]);
       const [exe, args] = spawnStub.firstCall.args as [string, string[]];
       assert.equal(exe, 'sf'); // space-free executable stays unquoted


### PR DESCRIPTION
## Summary
Addresses the three Copilot review comments on the develop → main PR #201, all flagging a hard-coded personal username (`mrdai`) in example paths.

- `test/unit/mcp/sfSpawn.test.ts` — the win32 spaced-arg test now uses `C:\Users\username\git\Provar Manager\...` (generic username; still a Windows path with a space, so the space-handling assertion is unchanged).
- `docs/loops/pdx-501-505.md` — the two example testcase paths are now OS- and user-agnostic: `~/git/provar-manager-regression/tests/...` (instead of `C:\Users\mrdai\git\...`).

Once merged to `develop`, PR #201 (`develop → main`) picks these up and the Copilot comments are resolved.

## Test plan
- [x] yarn compile passes
- [x] sfSpawn tests pass (47 passing; test (c) green with the generic path)
- [x] yarn lint passes

## Changes
- `test/unit/mcp/sfSpawn.test.ts`: `mrdai` → `username` in the spaced `--properties-file` path.
- `docs/loops/pdx-501-505.md`: two `C:\Users\mrdai\git\...` example paths → `~/git/...`.