### PR TITLE
PDX-508: Port render/load-blocking check types to local validator

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1074,6 +1074,15 @@ Validates an XML test case for schema correctness (validity score) and best prac
   - **BDD** — `BDD-GIVEN-001` / `BDD-WHEN-001` / `BDD-THEN-001` (`Given`/`When`/`Then` → `description`).
   - **Apex / database** — `SOQL-QUERY-001` (`ApexSoqlQuery` → `soqlQuery`), `DB-CONNECT-001`/`-002` (`DbConnect` → `connectionName` / `resultName`), `SQL-QUERY-001`/`-002` (`SqlQuery` → `query` / `dbConnectionName`).
   - **Web service** — `REST-CONN-001`/`-002` (`WebConnect` → `connectionName` / `resultName`), `REST-REQUEST-001` (`RestRequest` → `connectionName`).
+- **Render / load-blocking rules** — Structural checks that catch XML which prevents a test case from rendering or loading in the Provar IDE. They run offline / in `local_fallback` and emit one violation per rule (the message names the first offender; `count` is set only when more than one element offends), matching the Quality Hub back-end so the weighted-deduction score stays in parity with the Lambda. Currently enforced:
+  - **`RENDER-CASE-001`** (`valueClassCasing`, critical) — a `valueClass` spelled with the wrong case (e.g. `Boolean` instead of `boolean`). Only a known class with bad casing fires; an unknown class does not.
+  - **`RENDER-BOOL-001`** (`booleanCasing`, critical) — a `<value valueClass="boolean">` whose text is `True`/`False`/`TRUE`/`FALSE`; it must be lowercase `true`/`false`.
+  - **`VALUE-CLASS-001`** (`invalidValueClass`, critical) — a `<value class="…">` whose `class` is not a recognised Provar value class (e.g. the hallucinated `class="null"`), or a `class="value"` whose `valueClass` is not one of `string`/`boolean`/`decimal`/`id`/`date`/`dateTime`. Empty/optional arguments must omit the `<value>` entirely.
+  - **`RENDER-DATE-VALUECLASS-001`** (`dateValueClassFormat`, critical) — a `valueClass="date"`/`"dateTime"` value whose text is an ISO date string (e.g. `2025-01-15`) instead of an epoch-milliseconds integer; store dates as `valueClass="string"` or convert to epoch millis.
+  - **`SETVALUES-INVALID-ELEMENT-001`** (`setValuesInvalidElements`, critical) — a `SetValues` step containing hallucinated `<namedValueSet>` or `<name>` elements, or a `<namedValues>` child other than `<namedValue>`. The correct shape is `<namedValues mutable="Mutable">` with `<namedValue name="valuePath|value|valueScope">` children.
+  - **`APEX-CONNECT-ARGS-001`** (`apexConnectValidArguments`, critical) — an `ApexConnect` step using an argument id outside the 20-id whitelist (overridable per rule via `check.validArgumentIds`).
+  - **`APEX-CONNECT-CONNID-001`** (`apexConnectConnectionIdValueClass`, critical) — an `ApexConnect` `connectionId` value that uses `valueClass="string"` (or any non-`id` class) instead of `valueClass="id"`; leave it empty if there is no GUID.
+  - **`APEX-REUSE-CONN-001`** (`apexConnectReuseConnection`, major) — an `ApexConnect` `reuseConnectionName` argument that carries a value; it must be left blank.
 
 **Error codes**
 

--- a/src/mcp/tools/bestPracticesEngine.ts
+++ b/src/mcp/tools/bestPracticesEngine.ts
@@ -1210,6 +1210,402 @@ function validateMustContainArgument(tc: XmlNode, rule: BPRule): BPViolation | n
   return makeViolation(rule, msg);
 }
 
+// ── Render / load-blocking validators (Tier 2) ───────────────────────────────
+// Faithful ports of the Quality Hub XMLRendering / InvalidValueClass /
+// DateValueClassFormat / ApexConnect* / SetValuesInvalidElements validators.
+// These check types map 1:1 to load-blocking rules (mostly `critical`) that
+// stop a test case rendering or loading in the Provar IDE. Each returns a
+// single BPViolation per rule (the back-end reports the first offender and sets
+// `count = len(offenders)` only when > 1), so the weighted-deduction score stays
+// in parity with the Lambda.
+
+const APEX_CONNECT_API_ID = 'com.provar.plugins.forcedotcom.core.testapis.ApexConnect';
+const SETVALUES_API_ID = 'com.provar.plugins.bundled.apis.control.SetValues';
+
+/**
+ * Recursively collect every element that appears under `tag` anywhere in the
+ * subtree (the fast-xml-parser equivalent of ElementTree's `.//tag`). Returns
+ * the raw values (object, string, or — for repeated tags — each array member);
+ * callers filter to objects when they need attributes. Mirrors the back-end's
+ * descendant search so nested-step double-counting matches exactly.
+ */
+function collectElementsByTag(node: unknown, tag: string): unknown[] {
+  const out: unknown[] = [];
+  function walk(n: unknown): void {
+    if (!n || typeof n !== 'object') return;
+    if (Array.isArray(n)) {
+      for (const item of n) walk(item);
+      return;
+    }
+    for (const [k, v] of Object.entries(n as XmlNode)) {
+      if (k.startsWith('@_') || k === '#text') continue;
+      if (k === tag) for (const item of toArr(v)) out.push(item);
+      walk(v);
+    }
+  }
+  walk(node);
+  return out;
+}
+
+/** Object-form `<value>` descendants of a node (string-only text values are skipped). */
+function collectValueElements(node: unknown): XmlNode[] {
+  return collectElementsByTag(node, 'value').filter((v): v is XmlNode => v != null && typeof v === 'object');
+}
+
+/**
+ * Trimmed text of an element's `#text`, coercing to string first. fast-xml-parser
+ * parses numeric tag text to a `number` (e.g. an epoch-millis date), so a raw
+ * `.trim()` on `#text` would throw — always read element text through here.
+ */
+function nodeText(node: XmlNode): string {
+  const t = node['#text'];
+  return t == null ? '' : String(t).trim();
+}
+
+/** Step context used in load-blocking violation messages, mirroring the back-end defaults. */
+function stepContext(call: XmlNode): { apiName: string; title: string; tid: string } {
+  const apiId = (call['@_apiId'] as string | undefined) ?? '';
+  const apiName = apiId ? apiId.split('.').pop() ?? apiId : 'Unknown';
+  const title = (call['@_title'] as string | undefined) ?? apiName;
+  const tid = (call['@_testItemId'] as string | undefined) ?? 'N/A';
+  return { apiName, title, tid };
+}
+
+/** A `<value>` element paired with the id of the `<argument>` that encloses it (`unknown` if none). */
+interface StepValueElem {
+  value: XmlNode;
+  argId: string;
+}
+
+/**
+ * Every `<value>` element within an apiCall, tagged with its parent `<argument id>`.
+ * Replicates the back-end's "find the first enclosing argument" lookup so violation
+ * messages name the right argument. Values not inside any argument get `unknown`.
+ */
+function getStepValueElements(call: XmlNode): StepValueElem[] {
+  const argOf = new Map<XmlNode, string>();
+  for (const arg of collectElementsByTag(call, 'argument')) {
+    if (!arg || typeof arg !== 'object') continue;
+    const id = ((arg as XmlNode)['@_id'] as string | undefined) ?? 'unknown';
+    for (const v of collectValueElements(arg)) if (!argOf.has(v)) argOf.set(v, id);
+  }
+  return collectValueElements(call).map((value) => ({ value, argId: argOf.get(value) ?? 'unknown' }));
+}
+
+/** Trimmed text of an argument's direct `<value>` child (handles string and object forms). */
+function directValueText(arg: XmlNode): string {
+  const v = Array.isArray(arg['value']) ? (arg['value'] as unknown[])[0] : arg['value'];
+  if (v == null) return '';
+  if (typeof v === 'string') return v.trim();
+  if (typeof v !== 'object') return String(v).trim();
+  return nodeText(v as XmlNode);
+}
+
+// RENDER-CASE-001 — valid valueClass set, EXACTLY as the back-end declares it: the
+// mixed-case `funcCall`/`valueList` members never match a lowercased input, so
+// casing on those two is deliberately never flagged (parity-preserving quirk).
+const VALUE_CLASS_CASING_VALID: ReadonlySet<string> = new Set([
+  'string',
+  'boolean',
+  'decimal',
+  'integer',
+  'date',
+  'datetime',
+  'variable',
+  'compound',
+  'funcCall',
+  'value',
+  'valueList',
+  'gt',
+  'lt',
+  'eq',
+  'ne',
+  'ge',
+  'le',
+  'and',
+  'or',
+  'not',
+]);
+
+/** RENDER-CASE-001 — a known valueClass spelled with wrong case (e.g. `Boolean` → `boolean`). */
+function validateValueClassCasing(tc: XmlNode, rule: BPRule): BPViolation | null {
+  const offenders: Array<{ valueClass: string; expected: string }> = [];
+  for (const v of collectValueElements(tc)) {
+    const vc = v['@_valueClass'] as string | undefined;
+    if (!vc) continue;
+    const lower = vc.toLowerCase();
+    if (VALUE_CLASS_CASING_VALID.has(lower) && vc !== lower) offenders.push({ valueClass: vc, expected: lower });
+  }
+  if (!offenders.length) return null;
+  const MAX = 5;
+  const reported = Math.min(offenders.length, MAX);
+  let msg = offenders
+    .slice(0, 3)
+    .map((o) => `valueClass='${o.valueClass}' should be '${o.expected}'`)
+    .join('; ');
+  if (reported > 3) msg += ` (+${reported - 3} more)`;
+  if (offenders.length > MAX) msg += ` (total: ${offenders.length})`;
+  return makeViolation(rule, msg, reported);
+}
+
+const BOOLEAN_CASING_BAD: ReadonlySet<string> = new Set(['True', 'False', 'TRUE', 'FALSE']);
+
+/** RENDER-BOOL-001 — `<value valueClass="boolean">` text must be lowercase `true`/`false`. */
+function validateBooleanCasing(tc: XmlNode, rule: BPRule): BPViolation | null {
+  const offenders: string[] = [];
+  for (const v of collectValueElements(tc)) {
+    if (v['@_valueClass'] !== 'boolean') continue;
+    const text = nodeText(v);
+    if (BOOLEAN_CASING_BAD.has(text)) offenders.push(text);
+  }
+  if (!offenders.length) return null;
+  const MAX = 5;
+  const reported = Math.min(offenders.length, MAX);
+  let msg = `Boolean values must be lowercase: ${offenders
+    .slice(0, 3)
+    .map((t) => `'${t}' should be '${t.toLowerCase()}'`)
+    .join('; ')}`;
+  if (reported > 3) msg += ` (+${reported - 3} more)`;
+  if (offenders.length > MAX) msg += ` (total: ${offenders.length})`;
+  return makeViolation(rule, msg, reported);
+}
+
+// VALUE-CLASS-001 — the back-end HARDCODES these sets and ignores the rule JSON's
+// validClasses list, so we mirror the hardcoded sets (note `invalid` and
+// `namedValues` are accepted, and `dateTime` is camelCase) to stay score-exact.
+const VALID_VALUE_ELEMENT_CLASSES: ReadonlySet<string> = new Set([
+  'value',
+  'variable',
+  'compound',
+  'funcCall',
+  'valueList',
+  'namedValues',
+  'uiWait',
+  'uiLocator',
+  'uiTarget',
+  'uiInteraction',
+  'restTarget',
+  'excelTarget',
+  'csvTarget',
+  'url',
+  'template',
+  'add',
+  'sub',
+  'mult',
+  'div',
+  'eq',
+  'ne',
+  'gt',
+  'lt',
+  'ge',
+  'le',
+  'and',
+  'or',
+  'match',
+  'invalid',
+]);
+const VALID_VALUE_CLASS_TYPES: ReadonlySet<string> = new Set([
+  'string',
+  'boolean',
+  'decimal',
+  'id',
+  'date',
+  'dateTime',
+]);
+
+/** Classify one `<value>` for VALUE-CLASS-001, or `null` when it is valid / unattributed. */
+function classifyInvalidValueClass(v: XmlNode): { kind: 'class' | 'valueClass'; bad: string } | null {
+  const cls = (v['@_class'] as string | undefined) ?? '';
+  if (!cls) return null;
+  if (!VALID_VALUE_ELEMENT_CLASSES.has(cls)) return { kind: 'class', bad: cls };
+  const vc = (v['@_valueClass'] as string | undefined) ?? '';
+  if (cls === 'value' && vc && !VALID_VALUE_CLASS_TYPES.has(vc)) return { kind: 'valueClass', bad: vc };
+  return null;
+}
+
+/** VALUE-CLASS-001 — `<value class="…">` must use a valid class (and valueClass when class="value"). */
+function validateInvalidValueClass(tc: XmlNode, rule: BPRule): BPViolation | null {
+  const offenders: Array<{
+    argId: string;
+    ctx: ReturnType<typeof stepContext>;
+    kind: 'class' | 'valueClass';
+    bad: string;
+  }> = [];
+  for (const call of getAllApiCalls(tc)) {
+    const ctx = stepContext(call);
+    for (const { value, argId } of getStepValueElements(call)) {
+      const c = classifyInvalidValueClass(value);
+      if (c) offenders.push({ argId, ctx, kind: c.kind, bad: c.bad });
+    }
+  }
+  if (!offenders.length) return null;
+  const f = offenders[0];
+  const message =
+    f.kind === 'class'
+      ? `Step '${f.ctx.title}' has invalid class="${f.bad}" in argument '${f.argId}'. Valid class values: value, ` +
+        'variable, compound, funcCall, valueList, uiWait, uiLocator, uiTarget, etc. For empty arguments, omit ' +
+        `<value> entirely: <argument id="${f.argId}"/> (testItemId=${f.ctx.tid})`
+      : `Step '${f.ctx.title}' has invalid valueClass="${f.bad}" in argument '${f.argId}'. Valid valueClass values: ` +
+        `string, boolean, decimal, id, date, dateTime. (testItemId=${f.ctx.tid})`;
+  return makeViolation(rule, message, offenders.length);
+}
+
+/** RENDER-DATE-VALUECLASS-001 — `valueClass="date"|"dateTime"` text must be an epoch-millis integer. */
+function validateDateValueClassFormat(tc: XmlNode, rule: BPRule): BPViolation | null {
+  const offenders: Array<{ argId: string; ctx: ReturnType<typeof stepContext>; vc: string; text: string }> = [];
+  for (const call of getAllApiCalls(tc)) {
+    const ctx = stepContext(call);
+    for (const { value, argId } of getStepValueElements(call)) {
+      if (value['@_class'] !== 'value') continue;
+      const vc = (value['@_valueClass'] as string | undefined) ?? '';
+      if (vc !== 'date' && vc !== 'dateTime') continue;
+      const text = nodeText(value);
+      if (!text || /^\d+$/.test(text)) continue;
+      offenders.push({ argId, ctx, vc, text: text.slice(0, 50) });
+    }
+  }
+  if (!offenders.length) return null;
+  const f = offenders[0];
+  const message =
+    `Step '${f.ctx.title}' uses valueClass='${f.vc}' with invalid string value '${f.text}' in argument ` +
+    `'${f.argId}'. valueClass='${f.vc}' requires an epoch timestamp (milliseconds), not a date string. This ` +
+    `causes test case loading failures in Provar. (testItemId=${f.ctx.tid})`;
+  return makeViolation(rule, message, offenders.length);
+}
+
+/** Return the ApexConnect calls in a test case (exact apiId match, nested-aware). */
+function getApexConnectCalls(tc: XmlNode): XmlNode[] {
+  return getAllApiCalls(tc).filter((c) => c['@_apiId'] === APEX_CONNECT_API_ID);
+}
+
+/** APEX-REUSE-CONN-001 — ApexConnect `reuseConnectionName` must be blank. */
+function validateApexConnectReuseConnection(tc: XmlNode, rule: BPRule): BPViolation | null {
+  const offenders: Array<{ ctx: ReturnType<typeof stepContext>; value: string }> = [];
+  for (const call of getApexConnectCalls(tc)) {
+    const arg = getCallArguments(call).find((a) => a['@_id'] === 'reuseConnectionName');
+    if (!arg) continue;
+    const text = directValueText(arg);
+    if (text) offenders.push({ ctx: stepContext(call), value: text });
+  }
+  if (!offenders.length) return null;
+  const f = offenders[0];
+  const message =
+    `ApexConnect step '${f.ctx.title}' has non-empty reuseConnectionName value '${f.value}'. The ` +
+    `reuseConnectionName argument should be left blank: <argument id="reuseConnectionName"/> (testItemId=${f.ctx.tid})`;
+  return makeViolation(rule, message, offenders.length);
+}
+
+const APEX_CONNECT_VALID_ARGS_DEFAULT: readonly string[] = [
+  'connectionName',
+  'resultName',
+  'resultScope',
+  'uiApplicationName',
+  'quickUiLogin',
+  'closeAllPrimaryTabs',
+  'reuseConnectionName',
+  'alreadyOpenBehaviour',
+  'autoCleanup',
+  'cleanupConnectionName',
+  'logFileLocation',
+  'connectionId',
+  'enableObjectIdLogging',
+  'privateBrowsingMode',
+  'lightningMode',
+  'username',
+  'password',
+  'securityToken',
+  'environment',
+  'webBrowser',
+];
+
+/** APEX-CONNECT-ARGS-001 — every ApexConnect `<argument id>` must be in the valid whitelist. */
+function validateApexConnectValidArguments(tc: XmlNode, rule: BPRule): BPViolation | null {
+  const validIds = new Set<string>(
+    (rule.check['validArgumentIds'] as string[] | undefined) ?? APEX_CONNECT_VALID_ARGS_DEFAULT
+  );
+  const offenders: Array<{ ctx: ReturnType<typeof stepContext>; id: string }> = [];
+  for (const call of getApexConnectCalls(tc)) {
+    if (!call['arguments'] || typeof call['arguments'] !== 'object') continue;
+    for (const arg of getCallArguments(call)) {
+      const id = arg['@_id'] as string | undefined;
+      if (id && !validIds.has(id)) offenders.push({ ctx: stepContext(call), id });
+    }
+  }
+  if (!offenders.length) return null;
+  const f = offenders[0];
+  const message =
+    `ApexConnect step '${f.ctx.title}' uses invalid argument ID(s): ${offenders.map((o) => o.id).join(', ')}. ` +
+    'Only the documented ApexConnect argument IDs are valid (connectionName, resultName, resultScope, …, ' +
+    'webBrowser). Leave unused arguments empty (e.g. <argument id="username"/>) rather than inventing IDs. ' +
+    `(testItemId=${f.ctx.tid})`;
+  return makeViolation(rule, message, offenders.length);
+}
+
+/** APEX-CONNECT-CONNID-001 — `connectionId` value must use `valueClass="id"`, not string/other. */
+function validateApexConnectConnectionIdValueClass(tc: XmlNode, rule: BPRule): BPViolation | null {
+  const offenders: Array<{ ctx: ReturnType<typeof stepContext>; wrong: string; value: string }> = [];
+  for (const call of getApexConnectCalls(tc)) {
+    const arg = getCallArguments(call).find((a) => a['@_id'] === 'connectionId');
+    if (!arg) continue;
+    const ve = Array.isArray(arg['value']) ? (arg['value'] as unknown[])[0] : arg['value'];
+    if (!ve || typeof ve !== 'object') continue;
+    const v = ve as XmlNode;
+    const vc = (v['@_valueClass'] as string | undefined) ?? '';
+    if (v['@_class'] !== 'value' || !vc || vc === 'id') continue;
+    offenders.push({ ctx: stepContext(call), wrong: vc, value: nodeText(v) });
+  }
+  if (!offenders.length) return null;
+  const f = offenders[0];
+  const message =
+    `ApexConnect step '${f.ctx.title}' uses incorrect valueClass='${f.wrong}' for connectionId argument. The ` +
+    "connectionId must use valueClass='id' with a GUID value, NOT valueClass='string'. Current value: " +
+    `'${f.value}'. If you have no specific connection GUID, leave it empty: <argument id="connectionId"/> ` +
+    `(testItemId=${f.ctx.tid})`;
+  return makeViolation(rule, message, offenders.length);
+}
+
+/** Tags found directly under a `<namedValues>` container that are not the allowed `namedValue`. */
+function namedValuesInvalidChildren(nv: XmlNode): string[] {
+  const bad: string[] = [];
+  for (const [k, v] of Object.entries(nv)) {
+    if (k.startsWith('@_') || k === '#text' || k === 'namedValue') continue;
+    const instances = toArr(v).length; // one entry per element instance (mirrors the back-end count)
+    for (let i = 0; i < instances; i++) bad.push(k);
+  }
+  return bad;
+}
+
+/** SETVALUES-INVALID-ELEMENT-001 — reject hallucinated `<namedValueSet>`/`<name>` and bad namedValues children. */
+function validateSetValuesInvalidElements(tc: XmlNode, rule: BPRule): BPViolation | null {
+  const invalidElements = (rule.check['invalidElements'] as string[] | undefined) ?? ['namedValueSet', 'name'];
+  let count = 0;
+  let first: { ctx: ReturnType<typeof stepContext>; elem: string; context?: string } | null = null;
+  for (const call of getAllApiCalls(tc)) {
+    if (call['@_apiId'] !== SETVALUES_API_ID) continue;
+    const ctx = stepContext(call);
+    for (const elem of invalidElements) {
+      if (collectElementsByTag(call, elem).length) {
+        count++;
+        first ??= { ctx, elem };
+      }
+    }
+    for (const nv of collectElementsByTag(call, 'namedValues')) {
+      if (!nv || typeof nv !== 'object') continue;
+      for (const childTag of namedValuesInvalidChildren(nv as XmlNode)) {
+        count++;
+        first ??= { ctx, elem: childTag, context: 'inside <namedValues>' };
+      }
+    }
+  }
+  if (!first) return null;
+  const ctxStr = first.context ? ` ${first.context}` : '';
+  const message =
+    `SetValues step '${first.ctx.title}' contains invalid element <${first.elem}>${ctxStr}. SetValues must use ` +
+    '<namedValues mutable="Mutable"> with <namedValue name="valuePath|value|valueScope"> children. Do not use ' +
+    `<namedValueSet> or <name> elements. (testItemId=${first.ctx.tid})`;
+  return makeViolation(rule, message, count);
+}
+
 // ── Validator dispatch map ────────────────────────────────────────────────────
 
 type ValidatorFn = (tc: XmlNode, rule: BPRule) => BPViolation | null;
@@ -1227,6 +1623,15 @@ const VALIDATOR_REGISTRY: Record<string, ValidatorFn> = {
   uniqueResultNames: validateUniqueResultNames,
   uiWithScreenTarget: validateUiWithScreenTarget,
   mustContainArgument: validateMustContainArgument,
+  // Tier 2 — render / load-blocking check types (ports of the QH load-blocking validators)
+  valueClassCasing: validateValueClassCasing,
+  booleanCasing: validateBooleanCasing,
+  invalidValueClass: validateInvalidValueClass,
+  dateValueClassFormat: validateDateValueClassFormat,
+  apexConnectReuseConnection: validateApexConnectReuseConnection,
+  apexConnectValidArguments: validateApexConnectValidArguments,
+  apexConnectConnectionIdValueClass: validateApexConnectConnectionIdValueClass,
+  setValuesInvalidElements: validateSetValuesInvalidElements,
   // 'regex' is dispatched separately (needs metadata)
   // 'uiActionNestingStructure' is dispatched separately (emits one violation per offending step)
 };

--- a/test/unit/mcp/bestPracticesEngine.test.ts
+++ b/test/unit/mcp/bestPracticesEngine.test.ts
@@ -733,3 +733,276 @@ ${stepsXml}
     assert.ok(v?.message.includes('testItemId=3'), `Message should locate the nested step: ${v?.message}`);
   });
 });
+
+describe('render / load-blocking validators (Tier 2)', () => {
+  const GUID_T2_TC = '550e8400-e29b-41d4-a716-4466554408b0';
+  const GUID_T2_S1 = '550e8400-e29b-41d4-a716-4466554408b1';
+  const APEX_CONNECT = 'com.provar.plugins.forcedotcom.core.testapis.ApexConnect';
+  const SET_VALUES = 'com.provar.plugins.bundled.apis.control.SetValues';
+
+  // Wrap raw <apiCall> XML in a minimal, schema-valid test case.
+  function buildTc(stepsXml: string): string {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<testCase id="tc-t2" guid="${GUID_T2_TC}" registryId="tc-t2" name="Tier2 Test">
+  <steps>
+${stepsXml}
+  </steps>
+</testCase>`;
+  }
+
+  // Wrap a single <value> in an AssertValues argument (whole-tree validators don't need apiCall context).
+  function buildValueStep(valueXml: string): string {
+    return buildTc(`    <apiCall guid="${GUID_T2_S1}" apiId="com.provar.plugins.bundled.apis.AssertValues" name="Assert" testItemId="1">
+      <arguments>
+        <argument id="actualValue">${valueXml}</argument>
+      </arguments>
+    </apiCall>`);
+  }
+
+  function find(violations: BPViolation[], ruleId: string): BPViolation | undefined {
+    return violations.find((v) => v.rule_id === ruleId);
+  }
+
+  // ── valueClassCasing (RENDER-CASE-001) ──────────────────────────────────────
+  describe('valueClassCasing — RENDER-CASE-001', () => {
+    it('fires when a known valueClass is spelled with wrong case', () => {
+      const v = find(
+        runBestPractices(buildValueStep('<value class="value" valueClass="Boolean">true</value>')).violations,
+        'RENDER-CASE-001'
+      );
+      assert.ok(v, 'Expected RENDER-CASE-001 to fire for valueClass="Boolean"');
+      assert.equal(v?.severity, 'critical');
+      assert.ok(v?.message.includes("'boolean'"), `Message should suggest lowercase: ${v?.message}`);
+    });
+
+    it('passes when the valueClass is already lowercase', () => {
+      const v = find(
+        runBestPractices(buildValueStep('<value class="value" valueClass="boolean">true</value>')).violations,
+        'RENDER-CASE-001'
+      );
+      assert.ok(!v, `Lowercase valueClass should pass, got: ${v?.message}`);
+    });
+
+    it('does not fire for funcCall/valueList casing (back-end parity quirk: lowercased form is not in the valid set)', () => {
+      const v = find(
+        runBestPractices(buildValueStep('<value class="value" valueClass="FuncCall">x</value>')).violations,
+        'RENDER-CASE-001'
+      );
+      assert.ok(!v, 'valueClass="FuncCall" must NOT fire — mirrors the back-end (funcCall.lower() is not in the set)');
+    });
+  });
+
+  // ── booleanCasing (RENDER-BOOL-001) ─────────────────────────────────────────
+  describe('booleanCasing — RENDER-BOOL-001', () => {
+    it('fires for an uppercase boolean value', () => {
+      const v = find(
+        runBestPractices(buildValueStep('<value class="value" valueClass="boolean">True</value>')).violations,
+        'RENDER-BOOL-001'
+      );
+      assert.ok(v, 'Expected RENDER-BOOL-001 to fire for "True"');
+      assert.equal(v?.severity, 'critical');
+    });
+
+    it('passes for a lowercase boolean value', () => {
+      const v = find(
+        runBestPractices(buildValueStep('<value class="value" valueClass="boolean">false</value>')).violations,
+        'RENDER-BOOL-001'
+      );
+      assert.ok(!v, `Lowercase boolean should pass, got: ${v?.message}`);
+    });
+
+    it('does not fire when the value is not a boolean valueClass', () => {
+      const v = find(
+        runBestPractices(buildValueStep('<value class="value" valueClass="string">True</value>')).violations,
+        'RENDER-BOOL-001'
+      );
+      assert.ok(!v, 'Only valueClass="boolean" values are checked for boolean casing');
+    });
+  });
+
+  // ── invalidValueClass (VALUE-CLASS-001) ─────────────────────────────────────
+  describe('invalidValueClass — VALUE-CLASS-001', () => {
+    it('fires for a hallucinated class like "null"', () => {
+      const v = find(runBestPractices(buildValueStep('<value class="null"/>')).violations, 'VALUE-CLASS-001');
+      assert.ok(v, 'Expected VALUE-CLASS-001 to fire for class="null"');
+      assert.equal(v?.severity, 'critical');
+      assert.ok(v?.message.includes('actualValue'), `Message should name the argument: ${v?.message}`);
+    });
+
+    it('fires for an invalid valueClass on a class="value" element', () => {
+      const v = find(
+        runBestPractices(buildValueStep('<value class="value" valueClass="money">1</value>')).violations,
+        'VALUE-CLASS-001'
+      );
+      assert.ok(v, 'Expected VALUE-CLASS-001 to fire for valueClass="money"');
+      assert.ok(v?.message.includes('valueClass'), `Message should call out the valueClass: ${v?.message}`);
+    });
+
+    it('passes for a valid class="value" valueClass="string"', () => {
+      const v = find(
+        runBestPractices(buildValueStep('<value class="value" valueClass="string">x</value>')).violations,
+        'VALUE-CLASS-001'
+      );
+      assert.ok(!v, `A valid value class should pass, got: ${v?.message}`);
+    });
+
+    it('accepts class="invalid" (back-end hardcodes it in the valid set — parity)', () => {
+      const v = find(runBestPractices(buildValueStep('<value class="invalid"/>')).violations, 'VALUE-CLASS-001');
+      assert.ok(!v, 'class="invalid" is accepted by the back-end and must not fire here');
+    });
+  });
+
+  // ── dateValueClassFormat (RENDER-DATE-VALUECLASS-001) ───────────────────────
+  describe('dateValueClassFormat — RENDER-DATE-VALUECLASS-001', () => {
+    it('fires for an ISO date string with valueClass="date"', () => {
+      const v = find(
+        runBestPractices(buildValueStep('<value class="value" valueClass="date">2025-01-15</value>')).violations,
+        'RENDER-DATE-VALUECLASS-001'
+      );
+      assert.ok(v, 'Expected the date-format rule to fire for an ISO string');
+      assert.equal(v?.severity, 'critical');
+    });
+
+    it('passes for an epoch-millis integer with valueClass="date"', () => {
+      const v = find(
+        runBestPractices(buildValueStep('<value class="value" valueClass="date">1736899200000</value>')).violations,
+        'RENDER-DATE-VALUECLASS-001'
+      );
+      assert.ok(!v, `Epoch millis should pass, got: ${v?.message}`);
+    });
+
+    it('does not fire when the same string is stored as valueClass="string"', () => {
+      const v = find(
+        runBestPractices(buildValueStep('<value class="value" valueClass="string">2025-01-15</value>')).violations,
+        'RENDER-DATE-VALUECLASS-001'
+      );
+      assert.ok(!v, 'Only date/dateTime valueClasses are checked for epoch format');
+    });
+  });
+
+  // ── apexConnectReuseConnection (APEX-REUSE-CONN-001) ────────────────────────
+  describe('apexConnectReuseConnection — APEX-REUSE-CONN-001', () => {
+    it('fires when reuseConnectionName carries a non-empty value', () => {
+      const xml = buildTc(`    <apiCall guid="${GUID_T2_S1}" apiId="${APEX_CONNECT}" name="Connect" testItemId="1">
+      <arguments>
+        <argument id="reuseConnectionName"><value class="value" valueClass="string">Reuse</value></argument>
+      </arguments>
+    </apiCall>`);
+      const v = find(runBestPractices(xml).violations, 'APEX-REUSE-CONN-001');
+      assert.ok(v, 'Expected APEX-REUSE-CONN-001 to fire for a non-empty reuseConnectionName');
+      assert.equal(v?.severity, 'major');
+    });
+
+    it('passes when reuseConnectionName is left blank', () => {
+      const xml = buildTc(`    <apiCall guid="${GUID_T2_S1}" apiId="${APEX_CONNECT}" name="Connect" testItemId="1">
+      <arguments>
+        <argument id="reuseConnectionName"/>
+      </arguments>
+    </apiCall>`);
+      const v = find(runBestPractices(xml).violations, 'APEX-REUSE-CONN-001');
+      assert.ok(!v, `A blank reuseConnectionName should pass, got: ${v?.message}`);
+    });
+  });
+
+  // ── apexConnectValidArguments (APEX-CONNECT-ARGS-001) ───────────────────────
+  describe('apexConnectValidArguments — APEX-CONNECT-ARGS-001', () => {
+    it('fires for a hallucinated argument id', () => {
+      const xml = buildTc(`    <apiCall guid="${GUID_T2_S1}" apiId="${APEX_CONNECT}" name="Connect" testItemId="1">
+      <arguments>
+        <argument id="connectionName"><value class="value" valueClass="string">SF</value></argument>
+        <argument id="commandTimeout"><value class="value" valueClass="decimal">30</value></argument>
+      </arguments>
+    </apiCall>`);
+      const v = find(runBestPractices(xml).violations, 'APEX-CONNECT-ARGS-001');
+      assert.ok(v, 'Expected APEX-CONNECT-ARGS-001 to fire for commandTimeout');
+      assert.equal(v?.severity, 'critical');
+      assert.ok(v?.message.includes('commandTimeout'), `Message should name the bad arg: ${v?.message}`);
+    });
+
+    it('passes when all argument ids are in the whitelist', () => {
+      const xml = buildTc(`    <apiCall guid="${GUID_T2_S1}" apiId="${APEX_CONNECT}" name="Connect" testItemId="1">
+      <arguments>
+        <argument id="connectionName"><value class="value" valueClass="string">SF</value></argument>
+        <argument id="resultName"><value class="value" valueClass="string">conn</value></argument>
+      </arguments>
+    </apiCall>`);
+      const v = find(runBestPractices(xml).violations, 'APEX-CONNECT-ARGS-001');
+      assert.ok(!v, `All-valid arguments should pass, got: ${v?.message}`);
+    });
+  });
+
+  // ── apexConnectConnectionIdValueClass (APEX-CONNECT-CONNID-001) ─────────────
+  describe('apexConnectConnectionIdValueClass — APEX-CONNECT-CONNID-001', () => {
+    it('fires when connectionId uses valueClass="string"', () => {
+      const xml = buildTc(`    <apiCall guid="${GUID_T2_S1}" apiId="${APEX_CONNECT}" name="Connect" testItemId="1">
+      <arguments>
+        <argument id="connectionId"><value class="value" valueClass="string">default</value></argument>
+      </arguments>
+    </apiCall>`);
+      const v = find(runBestPractices(xml).violations, 'APEX-CONNECT-CONNID-001');
+      assert.ok(v, 'Expected APEX-CONNECT-CONNID-001 to fire for valueClass="string"');
+      assert.equal(v?.severity, 'critical');
+    });
+
+    it('passes when connectionId uses valueClass="id"', () => {
+      const xml = buildTc(`    <apiCall guid="${GUID_T2_S1}" apiId="${APEX_CONNECT}" name="Connect" testItemId="1">
+      <arguments>
+        <argument id="connectionId"><value class="value" valueClass="id">bce7fd3f-0f81-4c5c-ab68-c3edd44b5d1e</value></argument>
+      </arguments>
+    </apiCall>`);
+      const v = find(runBestPractices(xml).violations, 'APEX-CONNECT-CONNID-001');
+      assert.ok(!v, `valueClass="id" should pass, got: ${v?.message}`);
+    });
+
+    it('passes when connectionId is left empty', () => {
+      const xml = buildTc(`    <apiCall guid="${GUID_T2_S1}" apiId="${APEX_CONNECT}" name="Connect" testItemId="1">
+      <arguments>
+        <argument id="connectionId"/>
+      </arguments>
+    </apiCall>`);
+      const v = find(runBestPractices(xml).violations, 'APEX-CONNECT-CONNID-001');
+      assert.ok(!v, `An empty connectionId should pass, got: ${v?.message}`);
+    });
+  });
+
+  // ── setValuesInvalidElements (SETVALUES-INVALID-ELEMENT-001) ────────────────
+  describe('setValuesInvalidElements — SETVALUES-INVALID-ELEMENT-001', () => {
+    it('fires for hallucinated <namedValueSet>/<name> elements', () => {
+      const xml = buildTc(`    <apiCall guid="${GUID_T2_S1}" apiId="${SET_VALUES}" name="Set" testItemId="1">
+      <arguments>
+        <argument id="values">
+          <value class="valueList" mutable="Mutable">
+            <namedValues mutable="Mutable">
+              <namedValueSet>
+                <name>LeadId</name>
+                <value class="variable"><path element="x"/></value>
+              </namedValueSet>
+            </namedValues>
+          </value>
+        </argument>
+      </arguments>
+    </apiCall>`);
+      const v = find(runBestPractices(xml).violations, 'SETVALUES-INVALID-ELEMENT-001');
+      assert.ok(v, 'Expected SETVALUES-INVALID-ELEMENT-001 to fire for <namedValueSet>/<name>');
+      assert.equal(v?.severity, 'critical');
+    });
+
+    it('passes for a correctly-structured SetValues step', () => {
+      const xml = buildTc(`    <apiCall guid="${GUID_T2_S1}" apiId="${SET_VALUES}" name="Set" testItemId="1">
+      <arguments>
+        <argument id="values">
+          <value class="valueList" mutable="Mutable">
+            <namedValues mutable="Mutable">
+              <namedValue name="valuePath"><value class="value" valueClass="string">MyVar</value></namedValue>
+              <namedValue name="value"><value class="value" valueClass="string">1</value></namedValue>
+              <namedValue name="valueScope"><value class="value" valueClass="string">Test</value></namedValue>
+            </namedValues>
+          </value>
+        </argument>
+      </arguments>
+    </apiCall>`);
+      const v = find(runBestPractices(xml).violations, 'SETVALUES-INVALID-ELEMENT-001');
+      assert.ok(!v, `A correctly-structured SetValues step should pass, got: ${v?.message}`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements the eight render / load-blocking check types that were referenced by rules but **unregistered**, so the local validator silently skipped them and diverged from the Quality Hub score.
- Faithful ports of the Quality Hub validators, preserving score parity with the Lambda (one violation per rule; `count` only when >1; the casing checks cap at 5).

| Check type | Rule (severity) | Fires when |
|---|---|---|
| `valueClassCasing` | RENDER-CASE-001 (critical) | known `valueClass` spelled wrong-case (`Boolean`→`boolean`); unknown class doesn't fire |
| `booleanCasing` | RENDER-BOOL-001 (critical) | `<value valueClass="boolean">` text is `True/False/TRUE/FALSE` |
| `invalidValueClass` | VALUE-CLASS-001 (critical) | `class` not a valid Provar value class, or `class="value"` w/ bad `valueClass` |
| `dateValueClassFormat` | RENDER-DATE-VALUECLASS-001 (critical) | `valueClass="date"/"dateTime"` text is an ISO string, not epoch millis |
| `setValuesInvalidElements` | SETVALUES-INVALID-ELEMENT-001 (critical) | `SetValues` has `<namedValueSet>`/`<name>` or bad `<namedValues>` child |
| `apexConnectValidArguments` | APEX-CONNECT-ARGS-001 (critical) | `ApexConnect` argument id outside the 20-id whitelist |
| `apexConnectConnectionIdValueClass` | APEX-CONNECT-CONNID-001 (critical) | `connectionId` value uses `valueClass="string"`/non-`id` |
| `apexConnectReuseConnection` | APEX-REUSE-CONN-001 (major) | `reuseConnectionName` carries a value (must be blank) |

This is **scope item 2** of the PDX-508 umbrella (load-blocking check types). Item 1 (`mustContainArgument`, PR #207) shipped earlier; tiers 3–6 follow in separate PRs.

## Backend parity notes (validated against `quality-hub-agents` `best_practices_engine.py`)
- `valueClassCasing` preserves the back-end quirk where `funcCall`/`valueList` casing never fires (their lowercased form isn't in the valid set).
- `invalidValueClass` mirrors the back-end's **hardcoded** `VALID_CLASSES` (which accepts `invalid`/`namedValues` and the camelCase `dateTime`) — it intentionally ignores the rule JSON's `validClasses` list, to stay score-exact.
- Per-apiCall `.//value` scans replicate the back-end's nested-step double-counting.
- Found and fixed a latent crash: fast-xml-parser parses numeric tag text (e.g. epoch-millis dates) to `number`, so reading `#text` now coerces to string before `.trim()`.

## Jira
https://provartesting.atlassian.net/browse/PDX-508

## Test plan
- [x] yarn compile passes
- [x] full unit suite passes (1383 passing, +22 new Tier 2 tests)
- [x] mcp-smoke.cjs passes (60/60)
- [x] yarn lint passes
- [x] prettier clean

## Changes
- `src/mcp/tools/bestPracticesEngine.ts`: eight new validators + shared helpers (`collectElementsByTag`, `getStepValueElements`, `nodeText`, …), registered in `VALIDATOR_REGISTRY`.
- `test/unit/mcp/bestPracticesEngine.test.ts`: 22 parity tests (fire + pass + key edge cases per check type).
- `docs/mcp.md`: "Render / load-blocking rules" subsection documenting all eight.

> No customer-facing public-doc behaviour change beyond the documented rules; no new MCP tool/error code, so smoke `TOTAL_EXPECTED` is unchanged.