### PR TITLE
fix(mcp): TC_010 — accept any integer testCase id, make id optional

### DIFF
--- a/src/mcp/tools/testCaseValidate.ts
+++ b/src/mcp/tools/testCaseValidate.ts
@@ -384,21 +384,18 @@ export function validateTestCaseXml(filePath: string, config: ServerConfig): Tes
 
 /** TC_010/TC_011: validate testCase id and guid attributes. */
 function checkTestCaseIdAndGuid(tcId: string | null, tcGuid: string | undefined, issues: ValidationIssue[]): void {
-  if (!tcId) {
+  // The testCase `id` is OPTIONAL — the guid is the unique identifier (real Provar
+  // projects routinely omit id). When an id IS present it must be a non-negative
+  // integer: test case ids are project-unique sequential numbers (corpus shows 0…N),
+  // NOT the literal "1". Only a present-but-non-numeric id (e.g. a UUID) is rejected.
+  if (tcId !== null && !/^\d+$/.test(tcId)) {
     issues.push({
       rule_id: 'TC_010',
       severity: 'ERROR',
-      message: 'testCase missing required id attribute.',
+      message: `testCase id="${tcId}" is invalid — when present, the id must be a non-negative integer (test case ids are unique within a project, numbered sequentially). The guid is the cross-project unique identifier.`,
       applies_to: 'testCase',
-      suggestion: 'Add id="1" to testCase element (Provar requires the integer literal "1").',
-    });
-  } else if (tcId !== '1') {
-    issues.push({
-      rule_id: 'TC_010',
-      severity: 'ERROR',
-      message: `testCase id="${tcId}" is invalid — Provar requires id="1" (integer literal).`,
-      applies_to: 'testCase',
-      suggestion: 'Set id="1" on the testCase element. The unique identifier is the guid attribute, not id.',
+      suggestion:
+        'Set id to a project-unique non-negative integer (typically the highest in use + 1), or omit the id attribute entirely and rely on the guid.',
     });
   }
   if (!tcGuid) {

--- a/test/unit/mcp/testCaseValidate.test.ts
+++ b/test/unit/mcp/testCaseValidate.test.ts
@@ -77,29 +77,46 @@ describe('validateTestCase', () => {
   });
 
   describe('testCase attribute rules', () => {
-    it('TC_010: flags missing id', () => {
+    it('TC_010: does NOT fire for a missing id — id is optional, guid is the identifier', () => {
       const r = validateTestCase(
         `<?xml version="1.0" encoding="UTF-8"?><testCase guid="${GUID_TC}" registryId="r"><steps/></testCase>`
       );
       assert.ok(
-        r.issues.some((i) => i.rule_id === 'TC_010'),
-        'Expected TC_010'
+        !r.issues.some((i) => i.rule_id === 'TC_010'),
+        'A missing id must not be flagged (real Provar test cases routinely omit it)'
       );
     });
 
-    it('TC_010: flags non-"1" id (e.g. UUID used as id)', () => {
+    it('TC_010: flags a non-numeric id (e.g. UUID used as id)', () => {
       const r = validateTestCase(
         `<?xml version="1.0" encoding="UTF-8"?><testCase id="${GUID_TC}" guid="${GUID_TC}" registryId="r"><steps/></testCase>`
       );
       assert.ok(
         r.issues.some((i) => i.rule_id === 'TC_010'),
-        'Expected TC_010 for UUID used as id'
+        'Expected TC_010 for a non-numeric id'
       );
     });
 
-    it('TC_010: does not fire when id="1" (the correct literal)', () => {
+    it('TC_010: does not fire for id="0" — non-negative integers are valid (corpus uses 0)', () => {
+      const r = validateTestCase(
+        `<?xml version="1.0" encoding="UTF-8"?><testCase id="0" guid="${GUID_TC}" registryId="r"><steps/></testCase>`
+      );
+      assert.ok(!r.issues.some((i) => i.rule_id === 'TC_010'), 'id="0" must be accepted');
+    });
+
+    it('TC_010: does not fire for a valid integer id (id="1")', () => {
       const r = validateTestCase(VALID_TC);
       assert.ok(!r.issues.some((i) => i.rule_id === 'TC_010'), 'TC_010 must not fire when id="1"');
+    });
+
+    it('TC_010: does not fire for a sequential project id (e.g. id="42") — ids are not literally "1"', () => {
+      const r = validateTestCase(
+        `<?xml version="1.0" encoding="UTF-8"?><testCase id="42" guid="${GUID_TC}" registryId="r"><steps/></testCase>`
+      );
+      assert.ok(
+        !r.issues.some((i) => i.rule_id === 'TC_010'),
+        'TC_010 must accept any non-negative-integer id (test case ids are project-unique sequential numbers)'
+      );
     });
 
     it('TC_011: flags missing guid', () => {


### PR DESCRIPTION
## Fix: `TC_010` wrongly required `id="1"` on every test case

`TC_010` treated the testCase `id` attribute as a required literal `"1"` ("Provar requires id=1"). That belief is wrong:
- Test case **ids are project-unique integers numbered sequentially** (a full `AllPOCProjects` scan shows real, loadable test cases with ids `0…51`).
- **`id` is optional** — many real test cases have none, and the **`guid`** is the cross-project unique identifier.

So the strict rule fired `TC_010` — an `is_valid`-gating `ERROR` — on **~28 of 29 real files**, wrongly marking valid test cases invalid.

### Fix
- `id` is now optional: a missing `id` is no longer flagged.
- When present, `id` must be a **non-negative integer** (`0,1,2,…`); a present-but-non-numeric `id` (e.g. a UUID) is still rejected.

Boundaries confirmed against the corpus: real files use `id="0"` (accepted) and routinely omit `id` (accepted).

### Verification
- Full unit suite green (1430); tests cover missing `id`, `id="0"`, `id="42"`, and a UUID-as-id.
- Corpus sweep: `TC_010` now fires on **0 of 123 files** (previously ~28/29).

### Follow-up (separate)
`provar_testcase_generate` still hard-codes `id="1"`. That's valid under the corrected rule, but when generating into an existing project it should allocate the next free id (highest-in-use + 1) to avoid an id collision. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
