### PR TITLE
PDX-510: feat(mcp): allocate testCase id from project context

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -895,13 +895,13 @@ The tool's chip-level `title` — `Generate Test Case (full steps in one call)` 
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<testCase guid="<uuid>" id="1" registryId="<uuid>">
+<testCase guid="<uuid>" id="<n>" registryId="<uuid>">
   <summary/>
   <steps>...</steps>
 </testCase>
 ```
 
-- `id` is always the integer literal `"1"` — Provar ignores any other value
+- `id` is a numeric integer **label**, not a uniqueness key — Provar identifies the test case by its `guid`. When the output path sits inside an existing Provar project (a directory tree containing a `.testproject` marker, within the allowed roots), the generator auto-allocates the next integer after the highest `id` already in use, so a new case does not land on a duplicate `id="1"`. With no surrounding project — preview/`dry_run` runs, or output outside the allowed roots — it defaults to `1`. Regenerating over an existing file preserves that file's id. The chosen value is echoed back as `test_case_id`.
 - No `name` attribute on `<testCase>` — Provar derives the name from the file name
 - `<summary/>` must appear before `<steps>`
 - `standalone="no"` is required in the XML declaration
@@ -982,9 +982,9 @@ If `target_uri` is `ui:pageobject:target?pageId=…` the single-screen wrap take
 
 Validation rules: `UI-NITROX-CONNECT-ARGS-001` (critical, bans ApexConnect-only and cross-variant args), `UI-NITROX-VARIANT-ARG-001` (minor, requires variant-specific arg unless declared in `<generatedParameters>`).
 
-**Output** — `{ xml_content: string, file_path?: string, written: boolean, validation?: ValidationResult }`
+**Output** — `{ xml_content: string, file_path?: string, written: boolean, test_case_id: number, validation?: ValidationResult }`
 
-`validation` is present when `validate_after_edit=true` (default). If the generated XML fails validation the tool returns `TESTCASE_INVALID` with the `validation` field in `details`.
+`test_case_id` is the `id` written into the `<testCase>` element (auto-allocated as highest-in-project + 1 on the write path; `1` for preview runs). `validation` is present when `validate_after_edit=true` (default). If the generated XML fails validation the tool returns `TESTCASE_INVALID` with the `validation` field in `details`.
 
 **Error codes**
 

--- a/src/mcp/tools/testCaseGenerate.ts
+++ b/src/mcp/tools/testCaseGenerate.ts
@@ -15,6 +15,7 @@ import type { ServerConfig } from '../server.js';
 import { assertPathAllowed, PathPolicyError } from '../security/pathPolicy.js';
 import { makeError, makeRequestId } from '../schemas/common.js';
 import { log } from '../logging/logger.js';
+import { allocateTestCaseId, DEFAULT_TESTCASE_ID } from '../utils/testCaseId.js';
 import { validateTestCase } from './testCaseValidate.js';
 import { desc } from './descHelper.js';
 import { UI_ACTION_API_IDS, UI_SCREEN_CONTAINER_API_IDS, UI_LOCATOR_BEARING_API_IDS } from './uiActionApiIds.js';
@@ -201,7 +202,7 @@ const TOOL_DESCRIPTION = [
   // ── Existing description (unchanged below) ───────────────────────────────────
   'Generate a Provar XML test case skeleton with proper UUID v4 guids, sequential testItemId values, and <steps> structure.',
   'Returns XML content. Writes to disk only when dry_run=false.',
-  'Generated structure: <?xml version="1.0" encoding="UTF-8" standalone="no"?> with <testCase guid="..." id="1" registryId="..."> (id is always the integer literal "1" as required by the Provar runtime), a <summary/> child, then <steps>.',
+  'Generated structure: <?xml version="1.0" encoding="UTF-8" standalone="no"?> with <testCase guid="..." id="N" registryId="..."> (a numeric integer id), a <summary/> child, then <steps>. The unique identifier is the guid; id is a human-facing label. When writing into an existing project the id is auto-allocated as the highest in-use id + 1; otherwise it defaults to 1.',
   'URI-aware generation: use target_uri to control the XML nesting structure.',
   '  - sf:ui:target (or omit target_uri) → flat Salesforce XML structure (existing behaviour).',
   '  - ui:pageobject:target?pageId=pageobjects.PageClass → wraps all steps in a UiWithScreen element targeting that non-SF page object.',
@@ -389,13 +390,23 @@ export function registerTestCaseGenerate(server: McpServer, config: ServerConfig
       }
 
       try {
-        const xmlContent = buildTestCaseXml(input);
         const filePath: string | undefined = input.output_path ? path.resolve(input.output_path) : undefined;
+
+        // Allocate the root testCase id from surrounding project context, but only
+        // when actually persisting (a write path that has cleared the path policy).
+        // Preview/dry-run runs have no project anchor, so they keep the default id.
+        let idAllocation = { id: DEFAULT_TESTCASE_ID, basis: 'default' as const } as ReturnType<
+          typeof allocateTestCaseId
+        >;
+        if (filePath && !input.dry_run) {
+          assertPathAllowed(filePath, config.allowedPaths);
+          idAllocation = allocateTestCaseId(filePath, config.allowedPaths);
+        }
+
+        const xmlContent = buildTestCaseXml(input, idAllocation.id);
         let written = false;
 
         if (filePath && !input.dry_run) {
-          assertPathAllowed(filePath, config.allowedPaths);
-
           if (fs.existsSync(filePath) && !input.overwrite) {
             const err = makeError(
               'FILE_EXISTS',
@@ -408,7 +419,12 @@ export function registerTestCaseGenerate(server: McpServer, config: ServerConfig
           fs.mkdirSync(path.dirname(filePath), { recursive: true });
           fs.writeFileSync(filePath, xmlContent, 'utf-8');
           written = true;
-          log('info', 'provar_testcase_generate: wrote file', { requestId, filePath });
+          log('info', 'provar_testcase_generate: wrote file', {
+            requestId,
+            filePath,
+            testCaseId: idAllocation.id,
+            idBasis: idAllocation.basis,
+          });
         }
 
         const warnings = buildStepWarnings(input.steps);
@@ -420,6 +436,7 @@ export function registerTestCaseGenerate(server: McpServer, config: ServerConfig
           written,
           dry_run: input.dry_run,
           step_count: input.steps.length,
+          test_case_id: idAllocation.id,
           idempotency_key: input.idempotency_key,
           ...(warnings.length > 0 ? { warnings } : {}),
         };
@@ -905,12 +922,15 @@ function emitGroupedSteps(nodes: StepNode[], indent: string, startId: number): {
   return { xml: lines.join('\n'), nextId: id };
 }
 
-function buildTestCaseXml(input: {
-  test_case_name: string;
-  steps: Step[];
-  target_uri?: string;
-  grouping_mode?: 'auto' | 'flat' | 'single-screen';
-}): string {
+function buildTestCaseXml(
+  input: {
+    test_case_name: string;
+    steps: Step[];
+    target_uri?: string;
+    grouping_mode?: 'auto' | 'flat' | 'single-screen';
+  },
+  testCaseId: number = DEFAULT_TESTCASE_ID
+): string {
   const testCaseGuid = randomUUID();
   const registryId = randomUUID();
   const groupingMode = input.grouping_mode ?? 'auto';
@@ -956,10 +976,12 @@ function buildTestCaseXml(input: {
     stepLines = lines || '    <!-- TODO: Add test steps here -->';
   }
 
-  // Provar requires: standalone="no", id="1" (integer literal), no name attr, <summary/> before <steps>.
+  // Provar requires: standalone="no", a numeric integer id, no name attr, <summary/> before <steps>.
+  // The id is a human-facing label, not a uniqueness key (guid is) — see allocateTestCaseId:
+  // when writing into an existing project we pass highest-in-use + 1; otherwise it defaults to 1.
   return (
     '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n' +
-    `<testCase guid="${testCaseGuid}" id="1" registryId="${registryId}">\n` +
+    `<testCase guid="${testCaseGuid}" id="${testCaseId}" registryId="${registryId}">\n` +
     '  <summary/>\n' +
     '  <steps>\n' +
     stepLines +

--- a/src/mcp/utils/testCaseId.ts
+++ b/src/mcp/utils/testCaseId.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2024 Provar Limited.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.md file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { assertPathAllowed } from '../security/pathPolicy.js';
+
+/*
+ * Root-`<testCase>` id allocation for the generator.
+ *
+ * Important: the `id` attribute is NOT a uniqueness key. A corpus sweep of 651
+ * real `.testcase` files shows id values duplicate freely within a single
+ * project (id="0" appears 9× in one project), there is no project-level "next
+ * id" counter file, and the Quality Hub backend requires only ONE of
+ * id/guid/registryId — never checking id uniqueness or integer-ness. The
+ * generator already emits a unique `guid`, which is the real identifier.
+ *
+ * So duplicate ids cause no runtime or validation failure. This allocator is a
+ * convention-alignment nicety: when we can see the surrounding project, pick the
+ * next integer after the highest in use so a freshly generated case does not
+ * carry a confusing duplicate id="1". Where there is no project context (preview
+ * runs, or output outside the allowed roots) we keep the historical default.
+ */
+
+export const DEFAULT_TESTCASE_ID = 1;
+
+/** How an id was chosen — surfaced for logging and the tool response. */
+export type TestCaseIdBasis = 'preserved-existing' | 'project-max-plus-1' | 'default';
+
+export interface TestCaseIdAllocation {
+  id: number;
+  basis: TestCaseIdBasis;
+  /** Project root that was scanned, when basis is project-max-plus-1. */
+  projectRoot?: string;
+  /** Highest numeric id found in the project, when basis is project-max-plus-1. */
+  highestExistingId?: number;
+}
+
+/** Non-throwing wrapper around assertPathAllowed. */
+function isAllowed(p: string, allowedPaths: string[]): boolean {
+  try {
+    assertPathAllowed(p, allowedPaths);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Read the first `bytes` of a file as UTF-8 (the root element lives at the top). */
+function readPrefix(file: string, bytes = 8192): string {
+  const fd = fs.openSync(file, 'r');
+  try {
+    const buf = Buffer.alloc(bytes);
+    const read = fs.readSync(fd, buf, 0, bytes, 0);
+    return buf.toString('utf-8', 0, read);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/**
+ * The numeric `id` of the root `<testCase>` element, or undefined when the file
+ * is unreadable, has no id, or the id is non-numeric (e.g. a UUID). `[^>]*?`
+ * keeps the match inside the opening tag, so only the root id is considered.
+ */
+function readRootTestCaseId(file: string): number | undefined {
+  try {
+    const match = readPrefix(file).match(/<testCase\b[^>]*?\bid=["'](\d+)["']/);
+    if (!match) return undefined;
+    return Number.parseInt(match[1], 10);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Walk up from `startDir` to the nearest ancestor containing a `.testproject`
+ * marker, staying within the allowed roots. Returns undefined when no project
+ * marker is reachable.
+ */
+function findProjectRoot(startDir: string, allowedPaths: string[]): string | undefined {
+  let dir = path.resolve(startDir);
+  // Bound the walk: a `.testproject` we cannot read (outside allowed roots) is
+  // not ours to scan, and the loop terminates at the filesystem root.
+  for (;;) {
+    if (!isAllowed(dir, allowedPaths)) return undefined;
+    if (fs.existsSync(path.join(dir, '.testproject'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+/**
+ * Highest numeric root-`<testCase>` id under `projectRoot` (scanning `tests/`
+ * when present, else the root), ignoring `excludeFile`. Undefined when no
+ * numeric id is found.
+ */
+function maxProjectTestCaseId(projectRoot: string, excludeFile: string): number | undefined {
+  const scanRoot = fs.existsSync(path.join(projectRoot, 'tests')) ? path.join(projectRoot, 'tests') : projectRoot;
+  let max: number | undefined;
+
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.name.endsWith('.testcase') && path.resolve(full) !== excludeFile) {
+        const id = readRootTestCaseId(full);
+        if (id !== undefined && (max === undefined || id > max)) max = id;
+      }
+    }
+  };
+
+  walk(scanRoot);
+  return max;
+}
+
+/**
+ * Choose the `id` for a test case the generator is about to write to disk.
+ *
+ * Precedence:
+ * 1. Overwriting an existing file with a numeric id → preserve it (stable regeneration).
+ * 2. Output sits inside a reachable Provar project → highest project id + 1.
+ * 3. Otherwise → DEFAULT_TESTCASE_ID.
+ *
+ * @param outputPath   The `.testcase` file that will be written (need not exist yet).
+ * @param allowedPaths The MCP path-policy roots; the project scan never leaves them.
+ */
+export function allocateTestCaseId(outputPath: string, allowedPaths: string[]): TestCaseIdAllocation {
+  const resolved = path.resolve(outputPath);
+
+  if (fs.existsSync(resolved)) {
+    const selfId = readRootTestCaseId(resolved);
+    if (selfId !== undefined) return { id: selfId, basis: 'preserved-existing' };
+  }
+
+  const projectRoot = findProjectRoot(path.dirname(resolved), allowedPaths);
+  if (projectRoot) {
+    const max = maxProjectTestCaseId(projectRoot, resolved);
+    if (max !== undefined) {
+      return { id: max + 1, basis: 'project-max-plus-1', projectRoot, highestExistingId: max };
+    }
+  }
+
+  return { id: DEFAULT_TESTCASE_ID, basis: 'default' };
+}

--- a/test/unit/mcp/testCaseGenerate.test.ts
+++ b/test/unit/mcp/testCaseGenerate.test.ts
@@ -504,6 +504,76 @@ describe('provar_testcase_generate', () => {
     });
   });
 
+  // ── testCase id allocation (highest-in-use + 1 within an existing project) ──────
+  describe('testCase id allocation', () => {
+    const SMOKE_STEPS = [{ api_id: 'UiConnect', name: 'Connect', attributes: {} }];
+
+    /** Pull the root testCase id from emitted xml_content. */
+    function emittedId(result: unknown): string | undefined {
+      const xml = parseText(result)['xml_content'] as string;
+      return xml.match(/<testCase\b[^>]*?\bid="([^"]+)"/)?.[1];
+    }
+
+    function seedProject(): void {
+      fs.writeFileSync(path.join(tmpDir, '.testproject'), '<project/>', 'utf-8');
+      const testsDir = path.join(tmpDir, 'tests');
+      fs.mkdirSync(testsDir, { recursive: true });
+      const guid = '22222222-2222-4222-8222-222222222222';
+      fs.writeFileSync(
+        path.join(testsDir, 'Existing.testcase'),
+        `<testCase guid="${guid}" id="5" registryId="${guid}"><summary/><steps/></testCase>`,
+        'utf-8'
+      );
+    }
+
+    it('defaults to id="1" when output is not inside a project', () => {
+      const outPath = path.join(tmpDir, 'Loose.testcase');
+      const result = server.call('provar_testcase_generate', {
+        test_case_name: 'Loose',
+        steps: SMOKE_STEPS,
+        output_path: outPath,
+        dry_run: false,
+        overwrite: false,
+      });
+
+      assert.equal(isError(result), false);
+      assert.equal(emittedId(result), '1');
+      assert.equal(parseText(result)['test_case_id'], 1);
+    });
+
+    it('allocates highest-in-use + 1 when writing into an existing project', () => {
+      seedProject();
+      const outPath = path.join(tmpDir, 'tests', 'New.testcase');
+      const result = server.call('provar_testcase_generate', {
+        test_case_name: 'New',
+        steps: SMOKE_STEPS,
+        output_path: outPath,
+        dry_run: false,
+        overwrite: false,
+      });
+
+      assert.equal(isError(result), false);
+      assert.equal(emittedId(result), '6', 'project max id is 5 → next is 6');
+      assert.equal(parseText(result)['test_case_id'], 6);
+    });
+
+    it('does not scan the project for a dry_run preview (keeps default id)', () => {
+      seedProject();
+      const outPath = path.join(tmpDir, 'tests', 'Preview.testcase');
+      const result = server.call('provar_testcase_generate', {
+        test_case_name: 'Preview',
+        steps: SMOKE_STEPS,
+        output_path: outPath,
+        dry_run: true,
+        overwrite: false,
+      });
+
+      assert.equal(isError(result), false);
+      assert.equal(emittedId(result), '1');
+      assert.equal(parseText(result)['test_case_id'], 1);
+    });
+  });
+
   // ── PDX-483 runtime guard: reject empty steps[] on non-dry-run with output_path ──
   // The PDX-479 regression class arose from agents calling generate with steps:[]
   // intending to append later via step_edit. The passive contract (PDX-482) lives in

--- a/test/unit/mcp/testCaseId.test.ts
+++ b/test/unit/mcp/testCaseId.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2024 Provar Limited.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.md file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { allocateTestCaseId, DEFAULT_TESTCASE_ID } from '../../../src/mcp/utils/testCaseId.js';
+
+// ── Fixture helpers ────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+/** Write a minimal .testcase file carrying the given root id (string so we can test UUIDs). */
+function writeCase(relPath: string, id: string): string {
+  const full = path.join(tmpDir, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  const guid = '11111111-1111-4111-8111-111111111111';
+  fs.writeFileSync(
+    full,
+    `<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n<testCase guid="${guid}" id="${id}" registryId="${guid}">\n  <summary/>\n  <steps/>\n</testCase>\n`,
+    'utf-8'
+  );
+  return full;
+}
+
+function markProject(relDir = '.'): void {
+  const dir = path.join(tmpDir, relDir);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, '.testproject'), '<project/>', 'utf-8');
+}
+
+beforeEach(() => {
+  tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'tcid-test-')));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('allocateTestCaseId', () => {
+  it('defaults to DEFAULT_TESTCASE_ID when there is no surrounding project', () => {
+    const out = path.join(tmpDir, 'Loose.testcase');
+    const alloc = allocateTestCaseId(out, [tmpDir]);
+    assert.equal(alloc.id, DEFAULT_TESTCASE_ID);
+    assert.equal(alloc.basis, 'default');
+  });
+
+  it('allocates highest project id + 1 when writing into an existing project', () => {
+    markProject();
+    writeCase('tests/A.testcase', '3');
+    writeCase('tests/sub/B.testcase', '7');
+    writeCase('tests/sub/C.testcase', '5');
+
+    const out = path.join(tmpDir, 'tests', 'New.testcase');
+    const alloc = allocateTestCaseId(out, [tmpDir]);
+
+    assert.equal(alloc.id, 8, 'max id is 7 → next is 8');
+    assert.equal(alloc.basis, 'project-max-plus-1');
+    assert.equal(alloc.highestExistingId, 7);
+    assert.equal(alloc.projectRoot, tmpDir);
+  });
+
+  it('finds the project root by walking up from a nested output directory', () => {
+    markProject();
+    writeCase('tests/area/Existing.testcase', '12');
+
+    const out = path.join(tmpDir, 'tests', 'area', 'deep', 'New.testcase');
+    const alloc = allocateTestCaseId(out, [tmpDir]);
+
+    assert.equal(alloc.id, 13);
+    assert.equal(alloc.basis, 'project-max-plus-1');
+  });
+
+  it('preserves an existing numeric id on overwrite (stable regeneration)', () => {
+    markProject();
+    writeCase('tests/Other.testcase', '50');
+    const out = writeCase('tests/Target.testcase', '42');
+
+    const alloc = allocateTestCaseId(out, [tmpDir]);
+
+    assert.equal(alloc.id, 42, 'should keep the file’s own id, not jump to 51');
+    assert.equal(alloc.basis, 'preserved-existing');
+  });
+
+  it('ignores non-numeric (UUID) ids when computing the max', () => {
+    markProject();
+    writeCase('tests/Uuid.testcase', 'ced6c489-5a6d-4a40-a92f-71986c895b73');
+    writeCase('tests/Num.testcase', '2');
+
+    const out = path.join(tmpDir, 'tests', 'New.testcase');
+    const alloc = allocateTestCaseId(out, [tmpDir]);
+
+    assert.equal(alloc.id, 3, 'only the numeric id 2 counts → next is 3');
+  });
+
+  it('defaults when the project has a marker but no numeric ids yet', () => {
+    markProject();
+    const out = path.join(tmpDir, 'tests', 'First.testcase');
+    const alloc = allocateTestCaseId(out, [tmpDir]);
+
+    assert.equal(alloc.id, DEFAULT_TESTCASE_ID);
+    assert.equal(alloc.basis, 'default');
+  });
+
+  it('scans the project root itself when there is no tests/ folder', () => {
+    markProject();
+    writeCase('Flat.testcase', '9');
+
+    const out = path.join(tmpDir, 'Another.testcase');
+    const alloc = allocateTestCaseId(out, [tmpDir]);
+
+    assert.equal(alloc.id, 10);
+    assert.equal(alloc.basis, 'project-max-plus-1');
+  });
+
+  it('does not cross above the allowed roots to find a project marker', () => {
+    // .testproject sits at tmpDir, but the allowed root is tmpDir/tests — the walk
+    // must stop at the boundary and fall back to the default rather than scanning above it.
+    markProject();
+    writeCase('tests/A.testcase', '4');
+    const testsDir = path.join(tmpDir, 'tests');
+
+    const out = path.join(testsDir, 'New.testcase');
+    const alloc = allocateTestCaseId(out, [testsDir]);
+
+    assert.equal(alloc.id, DEFAULT_TESTCASE_ID);
+    assert.equal(alloc.basis, 'default');
+  });
+});


### PR DESCRIPTION
## Summary

`provar_testcase_generate` hard-coded `id="1"` on every generated `<testCase>`. This change allocates the id from the surrounding project context: **highest in-use numeric id + 1** when writing into an existing Provar project, falling back to `1` when there is no project context.

Resolves **PDX-510** (follow-up flagged in #213, the `TC_010` corpus fix).

## Why (corpus + backend research)

A read-only sweep of `AllPOCProjects` (651 real `.testcase` files) and the Quality Hub backend established:

- **`id` is not a uniqueness key** — it duplicates freely *within* a single project (e.g. `id="0"` 9× in one project). The unique identifier is the `guid`, which the generator already emits.
- **No "next id" counter file** exists anywhere in a project.
- The **QH backend** requires only *one of* `id`/`guid`/`registryId` and never checks id uniqueness or integer-ness.

So this is **convention alignment / hygiene** — avoid a misleading duplicate `id="1"` label — not a correctness fix. No customer-facing contract breaks; `id` was never a guaranteed value.

## Changes

- **New** `src/mcp/utils/testCaseId.ts` — `allocateTestCaseId(outputPath, allowedPaths)`:
  | Situation | Result |
  | --- | --- |
  | Overwriting a file that already has a numeric id | **preserve** it (stable regeneration, no drift) |
  | Output inside a reachable `.testproject` (within allowed roots) | **highest project id + 1** |
  | Preview/`dry_run`, or output outside the allowed roots | default **`1`** |
- `testCaseGenerate.ts` — allocate **only on the write path** (after the path policy passes), thread the id into the XML, return it as `test_case_id`, log `idBasis`. Misleading "always 1 / required by runtime" comment + tool description corrected.
- Scan reads only an 8 KB prefix per file; non-numeric (UUID) ids are ignored; the walk never leaves `--allowed-paths`.
- `docs/mcp.md` — generator section: id semantics + new `test_case_id` output field.

## Testing

- `node_modules/.bin/nyc mocha "test/**/*.test.ts"` → **1472 passing**, 0 failing (incl. new `allocateTestCaseId` suite of 8 + 3 handler-level tests).
- `yarn compile` clean · `yarn lint` clean · `node scripts/mcp-smoke.cjs` → **60/60 PASS** (no new tool, `TOTAL_EXPECTED` unchanged).
- Adversarial check on the root-id regex confirms it ignores `guid` (ends in "id"), `registryId`, and non-numeric ids.

## Docs / rollout

- Internal `docs/mcp.md` updated. **No public-doc change required** — `id` was never a documented guaranteed value — but flagging for awareness since the generated XML's `id` attribute now varies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
