### PR TITLE
PDX-511: Single-source the Layer-1 validation-rule catalog (registry drift hardening)

### DIFF
--- a/scripts/build-validation-rule-registry.cjs
+++ b/scripts/build-validation-rule-registry.cjs
@@ -9,8 +9,9 @@
 /*
  * Generates the canonical Validation Rule Registry (docs/VALIDATION_RULE_REGISTRY.md)
  * from the two rule sources:
- *   - Layer 1 (structural validity): hand-coded checks in src/mcp/tools/testCaseValidate.ts.
- *     These are listed here explicitly because they are code, not data.
+ *   - Layer 1 (structural validity): metadata catalog in
+ *     src/mcp/rules/provar_layer1_rules.json — the single source of truth shared
+ *     with testCaseValidate.ts (detection stays in code; only metadata is data).
  *   - Layer 2 (best practices): src/mcp/rules/provar_best_practices_rules.json.
  *
  * "Gates is_valid?" reflects the PDX-509 model:
@@ -29,70 +30,18 @@ const path = require('node:path');
 const ROOT = path.resolve(__dirname, '..');
 const OUT = path.join(ROOT, 'docs', 'VALIDATION_RULE_REGISTRY.md');
 const BP_JSON = path.join(ROOT, 'src', 'mcp', 'rules', 'provar_best_practices_rules.json');
+const LAYER1_JSON = path.join(ROOT, 'src', 'mcp', 'rules', 'provar_layer1_rules.json');
 
-// Layer-2 critical rules whose concept a Layer-1 hand-coded check already owns. Mirrors
-// LAYER1_OWNED_BP_RULES in testCaseValidate.ts — these criticals are NOT bridged.
-const LAYER1_OWNED = new Set([
-  'SCHEMA-ROOT-001',
-  'SCHEMA-STEPS-001',
-  'VALID-STEPS-001',
-  'SCHEMA-ID-001',
-  'VALID-GUID-001',
-  'STEP-ITEMID-001',
-  'COMPARISON-TYPE-ENUM-001',
-]);
+// Layer-1 structural-validity catalog (id, severity, applies_to, description,
+// owns_bp_rules), read from the shared single source of truth. The same JSON is
+// consumed by testCaseValidate.ts (owned-set) and validationRuleRegistry.test.ts
+// (drift guard). Detection stays in code; only this metadata is centralized.
+const LAYER1 = JSON.parse(fs.readFileSync(LAYER1_JSON, 'utf8')).rules;
 
-// Layer-1 structural validity rules (hand-coded in testCaseValidate.ts).
-const LAYER1 = [
-  ['TC_001', 'ERROR', 'document', 'XML declaration present (<?xml …?> first line).'],
-  ['TC_002', 'ERROR', 'document', 'XML is well-formed (parses without error).'],
-  ['TC_003', 'ERROR', 'document', 'Root element is <testCase>.'],
-  [
-    'TC_010',
-    'ERROR',
-    'testCase',
-    'testCase id, when present, is a non-negative integer (id is optional; guid is the identifier).',
-  ],
-  ['TC_011', 'ERROR', 'testCase', 'testCase has a guid attribute.'],
-  ['TC_012', 'ERROR', 'testCase', 'testCase guid is a valid UUID v4.'],
-  ['TC_020', 'ERROR', 'testCase', 'testCase has a <steps> element.'],
-  ['TC_030', 'ERROR', 'apiCall', 'Each apiCall has a guid attribute.'],
-  ['TC_031', 'ERROR', 'apiCall', 'Each apiCall guid is a valid UUID v4.'],
-  ['TC_032', 'ERROR', 'apiCall', 'Each apiCall has an apiId attribute.'],
-  ['TC_033', 'WARNING', 'apiCall', 'Each apiCall has a descriptive name attribute.'],
-  ['TC_034', 'ERROR', 'apiCall', 'Each apiCall has a testItemId attribute.'],
-  ['TC_035', 'ERROR', 'apiCall', 'apiCall testItemId is a whole number.'],
-  [
-    'DATA-001',
-    'WARNING',
-    'testCase',
-    '<dataTable> only iterates under a test plan; flags direct testCase-mode execution.',
-  ],
-  ['VAR-REF-001', 'WARNING', 'argument', 'A whole-token {Var} stored as valueClass="string" (use class="variable").'],
-  ['VAR-REF-002', 'WARNING', 'argument', '{Var} tokens embedded in a plain string (use class="compound").'],
-  ['UI-TARGET-001', 'ERROR', 'apiCall', 'UiWithScreen/UiWithRow target uses class="uiTarget".'],
-  ['UI-LOCATOR-001', 'ERROR', 'apiCall', 'UI action locator uses class="uiLocator".'],
-  ['UI-INTERACTION-001', 'ERROR', 'apiCall', 'UiDoAction interaction uses class="uiInteraction".'],
-  [
-    'UI-ASSERT-STRUCTURE-001',
-    'ERROR',
-    'apiCall',
-    'UiAssert uses nested field/column/page assertion containers, not a flat argument.',
-  ],
-  [
-    'SETVALUES-STRUCTURE-001',
-    'ERROR',
-    'apiCall',
-    'SetValues values argument uses class="valueList" with <namedValues>.',
-  ],
-  ['ASSERT-001', 'WARNING', 'apiCall', 'AssertValues namedValues format flagged for variable/Apex comparisons.'],
-  [
-    'COMPARISON-TYPE-001',
-    'ERROR',
-    'apiCall',
-    'comparisonType is within the step-scoped enum subset (load-blocking otherwise).',
-  ],
-];
+// Layer-2 critical rules whose concept a Layer-1 check already owns — derived
+// from the catalog's `owns_bp_rules` (mirrors LAYER1_OWNED_BP_RULES in
+// testCaseValidate.ts, same source). These criticals are NOT bridged.
+const LAYER1_OWNED = new Set(LAYER1.flatMap((r) => r.owns_bp_rules || []));
 
 function gatesLayer1(sev) {
   return sev === 'ERROR' ? 'Yes' : 'No';
@@ -142,19 +91,19 @@ lines.push(
 );
 lines.push('');
 lines.push(
-  `**Counts:** Layer 1 — ${LAYER1.length} rules (${LAYER1.filter((r) => r[1] === 'ERROR').length} gating). Layer 2 — ${
-    rules.length
-  } rules (critical ${sev.critical} / major ${sev.major} / minor ${sev.minor} / info ${
-    sev.info
-  }; ${bpGating} bridged to \`is_valid\`).`
+  `**Counts:** Layer 1 — ${LAYER1.length} rules (${
+    LAYER1.filter((r) => r.severity === 'ERROR').length
+  } gating). Layer 2 — ${rules.length} rules (critical ${sev.critical} / major ${sev.major} / minor ${
+    sev.minor
+  } / info ${sev.info}; ${bpGating} bridged to \`is_valid\`).`
 );
 lines.push('');
 lines.push('## Layer 1 — Structural validity rules');
 lines.push('');
 lines.push('| Rule ID | Severity | Gates is_valid? | Applies to | Checks |');
 lines.push('| ------- | -------- | --------------- | ---------- | ------ |');
-for (const [id, s, applies, desc] of LAYER1) {
-  lines.push(`| \`${id}\` | ${s} | ${gatesLayer1(s)} | ${applies} | ${esc(desc)} |`);
+for (const r of LAYER1) {
+  lines.push(`| \`${r.id}\` | ${r.severity} | ${gatesLayer1(r.severity)} | ${r.applies_to} | ${esc(r.description)} |`);
 }
 lines.push('');
 lines.push('## Layer 2 — Best-practice rules');

--- a/src/mcp/rules/provar_layer1_rules.json
+++ b/src/mcp/rules/provar_layer1_rules.json
@@ -1,0 +1,151 @@
+{
+  "schemaVersion": "1.0",
+  "name": "Provar Test Case Layer-1 Structural Validity Rules",
+  "description": "Single source of truth for the Layer-1 (structural validity) rule catalog. The DETECTION logic stays imperative in src/mcp/tools/testCaseValidate.ts; only the rule metadata (id, severity, applies_to, description) and the best-practice ownership/suppression mapping are centralized here. Consumers: testCaseValidate.ts (derives the bridge-suppression owned-set), scripts/build-validation-rule-registry.cjs (renders the Layer-1 registry rows), and test/unit/mcp/validationRuleRegistry.test.ts (drift guard). The `owns_bp_rules` field lists the Layer-2 `critical` best-practice rule ids whose concept this Layer-1 check already owns — those criticals are NOT bridged into is_valid (avoids double-reporting). Order is display order for the registry; keep it stable. severity is ERROR or WARNING (INFO reserved).",
+  "rules": [
+    {
+      "id": "TC_001",
+      "severity": "ERROR",
+      "applies_to": "document",
+      "description": "XML declaration present (<?xml …?> first line)."
+    },
+    {
+      "id": "TC_002",
+      "severity": "ERROR",
+      "applies_to": "document",
+      "description": "XML is well-formed (parses without error)."
+    },
+    {
+      "id": "TC_003",
+      "severity": "ERROR",
+      "applies_to": "document",
+      "description": "Root element is <testCase>.",
+      "owns_bp_rules": ["SCHEMA-ROOT-001"]
+    },
+    {
+      "id": "TC_010",
+      "severity": "ERROR",
+      "applies_to": "testCase",
+      "description": "testCase id, when present, is a non-negative integer (id is optional; guid is the identifier).",
+      "owns_bp_rules": ["SCHEMA-ID-001"]
+    },
+    {
+      "id": "TC_011",
+      "severity": "ERROR",
+      "applies_to": "testCase",
+      "description": "testCase has a guid attribute.",
+      "owns_bp_rules": ["VALID-GUID-001"]
+    },
+    {
+      "id": "TC_012",
+      "severity": "ERROR",
+      "applies_to": "testCase",
+      "description": "testCase guid is a valid UUID v4."
+    },
+    {
+      "id": "TC_020",
+      "severity": "ERROR",
+      "applies_to": "testCase",
+      "description": "testCase has a <steps> element.",
+      "owns_bp_rules": ["SCHEMA-STEPS-001", "VALID-STEPS-001"]
+    },
+    {
+      "id": "TC_030",
+      "severity": "ERROR",
+      "applies_to": "apiCall",
+      "description": "Each apiCall has a guid attribute."
+    },
+    {
+      "id": "TC_031",
+      "severity": "ERROR",
+      "applies_to": "apiCall",
+      "description": "Each apiCall guid is a valid UUID v4."
+    },
+    {
+      "id": "TC_032",
+      "severity": "ERROR",
+      "applies_to": "apiCall",
+      "description": "Each apiCall has an apiId attribute."
+    },
+    {
+      "id": "TC_033",
+      "severity": "WARNING",
+      "applies_to": "apiCall",
+      "description": "Each apiCall has a descriptive name attribute."
+    },
+    {
+      "id": "TC_034",
+      "severity": "ERROR",
+      "applies_to": "apiCall",
+      "description": "Each apiCall has a testItemId attribute.",
+      "owns_bp_rules": ["STEP-ITEMID-001"]
+    },
+    {
+      "id": "TC_035",
+      "severity": "ERROR",
+      "applies_to": "apiCall",
+      "description": "apiCall testItemId is a whole number."
+    },
+    {
+      "id": "DATA-001",
+      "severity": "WARNING",
+      "applies_to": "testCase",
+      "description": "<dataTable> only iterates under a test plan; flags direct testCase-mode execution."
+    },
+    {
+      "id": "VAR-REF-001",
+      "severity": "WARNING",
+      "applies_to": "argument",
+      "description": "A whole-token {Var} stored as valueClass=\"string\" (use class=\"variable\")."
+    },
+    {
+      "id": "VAR-REF-002",
+      "severity": "WARNING",
+      "applies_to": "argument",
+      "description": "{Var} tokens embedded in a plain string (use class=\"compound\")."
+    },
+    {
+      "id": "UI-TARGET-001",
+      "severity": "ERROR",
+      "applies_to": "apiCall",
+      "description": "UiWithScreen/UiWithRow target uses class=\"uiTarget\"."
+    },
+    {
+      "id": "UI-LOCATOR-001",
+      "severity": "ERROR",
+      "applies_to": "apiCall",
+      "description": "UI action locator uses class=\"uiLocator\"."
+    },
+    {
+      "id": "UI-INTERACTION-001",
+      "severity": "ERROR",
+      "applies_to": "apiCall",
+      "description": "UiDoAction interaction uses class=\"uiInteraction\"."
+    },
+    {
+      "id": "UI-ASSERT-STRUCTURE-001",
+      "severity": "ERROR",
+      "applies_to": "apiCall",
+      "description": "UiAssert uses nested field/column/page assertion containers, not a flat argument."
+    },
+    {
+      "id": "SETVALUES-STRUCTURE-001",
+      "severity": "ERROR",
+      "applies_to": "apiCall",
+      "description": "SetValues values argument uses class=\"valueList\" with <namedValues>."
+    },
+    {
+      "id": "ASSERT-001",
+      "severity": "WARNING",
+      "applies_to": "apiCall",
+      "description": "AssertValues namedValues format flagged for variable/Apex comparisons."
+    },
+    {
+      "id": "COMPARISON-TYPE-001",
+      "severity": "ERROR",
+      "applies_to": "apiCall",
+      "description": "comparisonType is within the step-scoped enum subset (load-blocking otherwise).",
+      "owns_bp_rules": ["COMPARISON-TYPE-ENUM-001"]
+    }
+  ]
+}

--- a/src/mcp/tools/testCaseValidate.ts
+++ b/src/mcp/tools/testCaseValidate.ts
@@ -9,6 +9,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import { XMLParser } from 'fast-xml-parser';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -961,6 +962,36 @@ function validateComparisonTypes(tc: Record<string, unknown>, issues: Validation
 }
 
 /**
+ * The Layer-1 structural-validity rule catalog — the single source of truth for
+ * Layer-1 rule metadata (id / severity / applies_to / description) and the
+ * best-practice ownership mapping. Loaded from `provar_layer1_rules.json`
+ * (copied into `lib/mcp/rules/` at compile, same as the best-practices ruleset).
+ * The imperative DETECTION below is unchanged; centralizing only the metadata
+ * keeps the published Validation Rule Registry from drifting from the validator.
+ * The same JSON is read by `scripts/build-validation-rule-registry.cjs` (renders
+ * the registry rows) and guarded by `validationRuleRegistry.test.ts`.
+ */
+export interface Layer1RuleCatalogEntry {
+  id: string;
+  severity: 'ERROR' | 'WARNING';
+  applies_to: string;
+  description: string;
+  /** Layer-2 `critical` BP rule ids whose concept this Layer-1 check owns (suppressed from the bridge). */
+  owns_bp_rules?: string[];
+}
+
+export const LAYER1_RULE_CATALOG: readonly Layer1RuleCatalogEntry[] = ((): Layer1RuleCatalogEntry[] => {
+  const catalogPath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'rules',
+    'provar_layer1_rules.json'
+  );
+  const parsed = JSON.parse(fs.readFileSync(catalogPath, 'utf-8')) as { rules: Layer1RuleCatalogEntry[] };
+  return parsed.rules;
+})();
+
+/**
  * PDX-509 — validity bridge.
  *
  * Best-practice violations carry a `critical|major|minor|info` severity, but
@@ -986,15 +1017,15 @@ function validateComparisonTypes(tc: Record<string, unknown>, issues: Validation
  * NOT check (unknown apiId, missing required control/connection args, invalid
  * render value-class casing, NitroX connect args…).
  */
-const LAYER1_OWNED_BP_RULES: ReadonlySet<string> = new Set([
-  'SCHEMA-ROOT-001', // TC_003 owns root element
-  'SCHEMA-STEPS-001', // TC_020 owns steps presence
-  'VALID-STEPS-001',
-  'SCHEMA-ID-001', // TC_010/TC_011/TC_012 own identifier
-  'VALID-GUID-001',
-  'STEP-ITEMID-001', // TC_034/TC_035 own testItemId
-  'COMPARISON-TYPE-ENUM-001', // COMPARISON-TYPE-001 owns comparisonType enums (deferred BP rule)
-]);
+// Derived from the catalog's `owns_bp_rules` — the single source shared with the
+// registry generator. A Layer-2 `critical` listed here is NOT bridged into
+// `is_valid` (the named Layer-1 check is authoritative; bridging would
+// double-report). Ownership today: TC_003→SCHEMA-ROOT-001, TC_010→SCHEMA-ID-001,
+// TC_011→VALID-GUID-001, TC_020→SCHEMA-STEPS-001/VALID-STEPS-001,
+// TC_034→STEP-ITEMID-001, COMPARISON-TYPE-001→COMPARISON-TYPE-ENUM-001.
+export const LAYER1_OWNED_BP_RULES: ReadonlySet<string> = new Set(
+  LAYER1_RULE_CATALOG.flatMap((rule) => rule.owns_bp_rules ?? [])
+);
 
 /** Map a Best-Practices `appliesTo` token to the issue `applies_to` vocabulary. */
 const BP_APPLIES_TO_ISSUE: Record<string, string> = {

--- a/test/unit/mcp/validationRuleRegistry.test.ts
+++ b/test/unit/mcp/validationRuleRegistry.test.ts
@@ -10,30 +10,43 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { describe, it } from 'mocha';
+import { LAYER1_OWNED_BP_RULES } from '../../../src/mcp/tools/testCaseValidate.js';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const registryPath = join(repoRoot, 'docs', 'VALIDATION_RULE_REGISTRY.md');
 const bpRulesPath = join(repoRoot, 'src', 'mcp', 'rules', 'provar_best_practices_rules.json');
+const layer1RulesPath = join(repoRoot, 'src', 'mcp', 'rules', 'provar_layer1_rules.json');
+const validatorSrcPath = join(repoRoot, 'src', 'mcp', 'tools', 'testCaseValidate.ts');
 
 interface BPRule {
   id: string;
   severity: string;
 }
 
-describe('Validation Rule Registry (PDX-508 Tier 6)', () => {
+interface Layer1Rule {
+  id: string;
+  severity: 'ERROR' | 'WARNING';
+  applies_to: string;
+  description: string;
+  owns_bp_rules?: string[];
+}
+
+describe('Validation Rule Registry (PDX-508 Tier 6 / PDX-511)', () => {
   const registry = readFileSync(registryPath, 'utf-8');
   const bp = JSON.parse(readFileSync(bpRulesPath, 'utf-8')) as { rules: BPRule[] };
+  // Layer-1 catalog — the single source of truth (PDX-511). Both the registry
+  // generator and testCaseValidate.ts read this JSON; nothing is hand-copied.
+  const layer1 = (JSON.parse(readFileSync(layer1RulesPath, 'utf-8')) as { rules: Layer1Rule[] }).rules;
+  // Layer-2 criticals a Layer-1 check owns — derived from the catalog, NOT hand-listed.
+  const ownedFromCatalog = new Set(layer1.flatMap((r) => r.owns_bp_rules ?? []));
 
-  // Layer-2 criticals whose concept a Layer-1 check owns — NOT bridged to is_valid.
-  const LAYER1_OWNED = new Set([
-    'SCHEMA-ROOT-001',
-    'SCHEMA-STEPS-001',
-    'VALID-STEPS-001',
-    'SCHEMA-ID-001',
-    'VALID-GUID-001',
-    'STEP-ITEMID-001',
-    'COMPARISON-TYPE-ENUM-001',
-  ]);
+  /** Pull the "Gates is_valid?" cell for a given rule id from its table row. */
+  function gatingCell(ruleId: string): string | undefined {
+    const line = registry.split('\n').find((l) => l.includes(`\`${ruleId}\``));
+    if (!line) return undefined;
+    const cells = line.split('|').map((c) => c.trim());
+    return cells.find((c) => c === 'Yes' || c === 'No');
+  }
 
   it('lists every best-practice rule (guards against doc drift)', () => {
     const missing = bp.rules.filter((r) => !registry.includes(`\`${r.id}\``)).map((r) => r.id);
@@ -50,14 +63,6 @@ describe('Validation Rule Registry (PDX-508 Tier 6)', () => {
     }
   });
 
-  /** Pull the "Gates is_valid?" cell for a given rule id from its table row. */
-  function gatingCell(ruleId: string): string | undefined {
-    const line = registry.split('\n').find((l) => l.includes(`\`${ruleId}\``));
-    if (!line) return undefined;
-    const cells = line.split('|').map((c) => c.trim());
-    return cells.find((c) => c === 'Yes' || c === 'No');
-  }
-
   it('marks a bridged critical as gating is_valid', () => {
     // API-UNKNOWN-001 is critical and not Layer-1-owned → bridged → gates is_valid.
     assert.equal(gatingCell('API-UNKNOWN-001'), 'Yes');
@@ -72,11 +77,79 @@ describe('Validation Rule Registry (PDX-508 Tier 6)', () => {
     assert.equal(gatingCell('VAR-STRING-LITERAL-001'), 'No');
   });
 
-  it('the LAYER1_OWNED criticals never gate in the registry', () => {
-    for (const id of LAYER1_OWNED) {
+  it('the Layer-1-owned criticals never gate in the registry', () => {
+    for (const id of ownedFromCatalog) {
       if (registry.includes(`\`${id}\``)) {
         assert.equal(gatingCell(id), 'No', `${id} is Layer-1-owned and must not be bridged`);
       }
+    }
+  });
+
+  // ── PDX-511: provar_layer1_rules.json is the single source of truth ──────────
+  // Each guard below fails CI if the Layer-1 catalog drifts from either consumer
+  // (the registry generator, or the validator's detection + bridge-suppression).
+
+  it('renders every Layer-1 catalog rule with the gating its severity implies', () => {
+    for (const r of layer1) {
+      assert.ok(
+        registry.includes(`\`${r.id}\``),
+        `Layer-1 rule ${r.id} missing from the registry — re-run scripts/build-validation-rule-registry.cjs`
+      );
+      // Layer-1 ERROR gates is_valid; WARNING is advisory (quality only).
+      assert.equal(gatingCell(r.id), r.severity === 'ERROR' ? 'Yes' : 'No', `${r.id} gating column mismatch`);
+    }
+  });
+
+  it('renders the Layer-1 counts line from the catalog', () => {
+    const gating = layer1.filter((r) => r.severity === 'ERROR').length;
+    assert.ok(
+      registry.includes(`Layer 1 — ${layer1.length} rules (${gating} gating)`),
+      `Layer-1 counts line is stale — expected "Layer 1 — ${layer1.length} rules (${gating} gating)"`
+    );
+  });
+
+  it('derives the validator bridge-suppression set from the catalog (no hand-duplication)', () => {
+    assert.deepEqual(
+      [...LAYER1_OWNED_BP_RULES].sort(),
+      [...ownedFromCatalog].sort(),
+      'testCaseValidate.ts LAYER1_OWNED_BP_RULES drifted from provar_layer1_rules.json owns_bp_rules'
+    );
+  });
+
+  it('catalog owns_bp_rules reference critical best-practice rules', () => {
+    const bpById = new Map(bp.rules.map((r) => [r.id, r]));
+    for (const owned of ownedFromCatalog) {
+      const rule = bpById.get(owned);
+      // COMPARISON-TYPE-ENUM-001 is a deferred BP rule id (owned pre-emptively); tolerate absence.
+      if (rule) {
+        assert.equal(rule.severity, 'critical', `${owned} is owned by a Layer-1 check but is not a critical BP rule`);
+      }
+    }
+  });
+
+  it('catalogs every Layer-1 rule the validator emits, with matching severity (drift guard)', () => {
+    const src = readFileSync(validatorSrcPath, 'utf-8');
+    // Detection sites read `rule_id: 'ID',` immediately followed by `severity: 'SEV',`.
+    // The validity bridge uses `rule_id: v.rule_id` (no string literal) and is skipped.
+    const re = /rule_id:\s*'([A-Za-z0-9_-]+)',\s*\n\s*severity:\s*'(ERROR|WARNING)'/g;
+    const emitted = new Map<string, string>();
+    for (let m = re.exec(src); m !== null; m = re.exec(src)) {
+      const [, id, severity] = m;
+      const prior = emitted.get(id);
+      assert.ok(
+        prior === undefined || prior === severity,
+        `${id} is emitted with conflicting severities in testCaseValidate.ts`
+      );
+      emitted.set(id, severity);
+    }
+    const catalogSeverity = new Map(layer1.map((r) => [r.id, r.severity as string]));
+    assert.deepEqual(
+      [...emitted.keys()].sort(),
+      [...catalogSeverity.keys()].sort(),
+      'Layer-1 rule ids emitted by testCaseValidate.ts differ from provar_layer1_rules.json — update the catalog'
+    );
+    for (const [id, severity] of emitted) {
+      assert.equal(severity, catalogSeverity.get(id), `${id} severity in the validator differs from the catalog`);
     }
   });
 });

--- a/test/unit/mcp/validationRuleRegistry.test.ts
+++ b/test/unit/mcp/validationRuleRegistry.test.ts
@@ -127,29 +127,36 @@ describe('Validation Rule Registry (PDX-508 Tier 6 / PDX-511)', () => {
     }
   });
 
-  it('catalogs every Layer-1 rule the validator emits, with matching severity (drift guard)', () => {
+  it('catalogs every Layer-1 rule the validator emits, with matching severity + applies_to (drift guard)', () => {
     const src = readFileSync(validatorSrcPath, 'utf-8');
-    // Detection sites read `rule_id: 'ID',` immediately followed by `severity: 'SEV',`.
-    // The validity bridge uses `rule_id: v.rule_id` (no string literal) and is skipped.
-    const re = /rule_id:\s*'([A-Za-z0-9_-]+)',\s*\n\s*severity:\s*'(ERROR|WARNING)'/g;
-    const emitted = new Map<string, string>();
+    // Detection sites read `rule_id: 'ID',` then `severity: 'SEV',` then (after the
+    // message/suggestion) `applies_to: 'SCOPE'`. The validity bridge uses
+    // `rule_id: v.rule_id` (no string literal) and is skipped. This guard relies on
+    // that field order: a push that emits severity before rule_id drops out of the
+    // set below and trips the deepEqual — a loud, if indirect, failure (see message).
+    const re =
+      /rule_id:\s*'([A-Za-z0-9_-]+)',\s*\n\s*severity:\s*'(ERROR|WARNING)',[\s\S]*?applies_to:\s*'([A-Za-z]+)'/g;
+    const emitted = new Map<string, { severity: string; appliesTo: string }>();
     for (let m = re.exec(src); m !== null; m = re.exec(src)) {
-      const [, id, severity] = m;
+      const [, id, severity, appliesTo] = m;
       const prior = emitted.get(id);
       assert.ok(
-        prior === undefined || prior === severity,
-        `${id} is emitted with conflicting severities in testCaseValidate.ts`
+        prior === undefined || (prior.severity === severity && prior.appliesTo === appliesTo),
+        `${id} is emitted with conflicting metadata across detection sites in testCaseValidate.ts`
       );
-      emitted.set(id, severity);
+      emitted.set(id, { severity, appliesTo });
     }
-    const catalogSeverity = new Map(layer1.map((r) => [r.id, r.severity as string]));
+    const catalogById = new Map(layer1.map((r) => [r.id, r]));
     assert.deepEqual(
       [...emitted.keys()].sort(),
-      [...catalogSeverity.keys()].sort(),
-      'Layer-1 rule ids emitted by testCaseValidate.ts differ from provar_layer1_rules.json — update the catalog'
+      [...catalogById.keys()].sort(),
+      'Layer-1 rule ids emitted by testCaseValidate.ts differ from provar_layer1_rules.json ' +
+        '(or a detection push reordered its rule_id/severity fields, which this guard scans for) — update the catalog'
     );
-    for (const [id, severity] of emitted) {
-      assert.equal(severity, catalogSeverity.get(id), `${id} severity in the validator differs from the catalog`);
+    for (const [id, meta] of emitted) {
+      const rule = catalogById.get(id);
+      assert.equal(meta.severity, rule?.severity, `${id} severity in the validator differs from the catalog`);
+      assert.equal(meta.appliesTo, rule?.applies_to, `${id} applies_to in the validator differs from the catalog`);
     }
   });
 });


### PR DESCRIPTION
## Summary

Registry-drift hardening flagged in PDX-508 Tier 6. The **Layer-1** (structural validity) rule catalog was hand-duplicated across two files and could silently drift; the published Validation Rule Registry would then misrepresent what the validator does. This extracts the Layer-1 catalog into one declarative source of truth — mirroring the existing Layer-2 (best-practices JSON) model.

**Behavior-preserving refactor** — no rule, severity, or detection logic changes.

## What changed

- **New `src/mcp/rules/provar_layer1_rules.json`** — the single source for all 23 Layer-1 rules (`id`, `severity`, `applies_to`, `description`) plus the best-practice ownership map (`owns_bp_rules`, which replaces the standalone owned-set).
- **`scripts/build-validation-rule-registry.cjs`** — reads the catalog; the hard-coded `LAYER1` array and `LAYER1_OWNED` set are deleted. Regenerated registry is **byte-identical**.
- **`src/mcp/tools/testCaseValidate.ts`** — loads the catalog and derives `LAYER1_OWNED_BP_RULES` from `owns_bp_rules` (the hand-maintained `Set` is gone). Detection stays imperative — only metadata is centralized.
- **`test/unit/mcp/validationRuleRegistry.test.ts`** — drift guard extended to Layer-1: catalog↔registry gating + counts, catalog↔validator owned-set, and a source-scan asserting every `rule_id`/`severity` the validator emits is catalogued. The test's own hand-listed owned-set is now catalog-derived too.

## Acceptance criteria

- [x] Single declarative source of truth for the Layer-1 catalog + ownership; no Layer-1 metadata hand-duplicated between `testCaseValidate.ts` and the generator.
- [x] Generator derives all Layer-1 rows from the shared source; **regenerated `VALIDATION_RULE_REGISTRY.md` is byte-identical** (verified via regen diff).
- [x] `LAYER1_OWNED_BP_RULES` (validator) and the generator's owned-set resolve from the same source.
- [x] Drift guard fails if a Layer-1 rule is added/changed in the validator without updating the catalog (mutation-tested: a severity flip trips the gating, counts, and source-scan guards).
- [x] **No validator behavior change** — full sweep over the 651-file corpus (`AllPOCProjects`) yields **0 diffs** in `is_valid` and issue sets before vs after.
- [x] `provar://docs/validation-rules` still serves the regenerated registry; `compile` copies the new JSON into `lib/` (existing `src/mcp/rules/*.json` glob — no `package.json` change needed).
- [x] `compile`, `lint`, `mcp-smoke` (60/60), and the full unit suite (**1477 passing**) green; `docs/mcp.md` unchanged.

## Implementation note (vs. ticket)

The ticket's primary plan also suggested routing the validator's per-issue `severity` through the catalog at each push site. I kept the detection code's inline severities **untouched** and instead **guard** them with the source-scan test (the ticket's named AC4 mechanism). Rationale: this makes the refactor provably behavior-preserving (zero edits to detection → the 0-corpus-diff result is structural, not just tested) while still single-sourcing everything the **registry** consumes and catching any future drift at CI. The `.cjs`↔JSON duplication — the actual Tier-6 drift surface — is fully removed.

## Verification

```
registry regen .......... byte-identical to develop baseline
corpus sweep (651 files)  0 diffs (is_valid + issue sets)
yarn compile ............ clean
yarn lint ............... clean
mcp-smoke ............... 60/60 PASS
unit suite .............. 1477 passing, 1 pending, 0 failing
drift guards ............ mutation-tested (severity flip → 3 guards fail as expected)
```

No customer-facing/public-doc impact (internal refactor; `docs/mcp.md` and the university course untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
