### PR TITLE
PDX-510: keep testCase id allocation inside the allowed roots (review follow-up)

### DIFF
--- a/src/mcp/utils/testCaseId.ts
+++ b/src/mcp/utils/testCaseId.ts
@@ -71,7 +71,10 @@ function readRootTestCaseId(file: string): number | undefined {
   try {
     const match = readPrefix(file).match(/<testCase\b[^>]*?\bid=["'](\d+)["']/);
     if (!match) return undefined;
-    return Number.parseInt(match[1], 10);
+    const id = Number.parseInt(match[1], 10);
+    // Ignore ids too large to round-trip as an exact integer: otherwise `max + 1`
+    // would render in scientific notation (e.g. id="1e+22"), an invalid id.
+    return Number.isSafeInteger(id) ? id : undefined;
   } catch {
     return undefined;
   }
@@ -116,7 +119,16 @@ function maxProjectTestCaseId(projectRoot: string, excludeFile: string): number 
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         walk(full);
-      } else if (entry.name.endsWith('.testcase') && path.resolve(full) !== excludeFile) {
+      } else if (
+        // Only read real files inside the project. A symlinked `.testcase` could
+        // point outside the allowed roots; skip it so the scan honours the
+        // path-policy containment promised by findProjectRoot. (Dir symlinks are
+        // already skipped — isDirectory() is false for them.)
+        entry.isFile() &&
+        !entry.isSymbolicLink() &&
+        entry.name.endsWith('.testcase') &&
+        path.resolve(full) !== excludeFile
+      ) {
         const id = readRootTestCaseId(full);
         if (id !== undefined && (max === undefined || id > max)) max = id;
       }

--- a/test/unit/mcp/testCaseId.test.ts
+++ b/test/unit/mcp/testCaseId.test.ts
@@ -43,6 +43,19 @@ afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
+/** Some Windows hosts / CI restrict symlink creation to privileged users. */
+const symlinkSupported = ((): boolean => {
+  try {
+    const probe = fs.mkdtempSync(path.join(os.tmpdir(), 'tcid-symcap-'));
+    fs.writeFileSync(path.join(probe, 'target'), 'x', 'utf-8');
+    fs.symlinkSync(path.join(probe, 'target'), path.join(probe, 'link'));
+    fs.rmSync(probe, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('allocateTestCaseId', () => {
@@ -133,5 +146,47 @@ describe('allocateTestCaseId', () => {
 
     assert.equal(alloc.id, DEFAULT_TESTCASE_ID);
     assert.equal(alloc.basis, 'default');
+  });
+
+  it('ignores a numeric id too large to be a safe integer', () => {
+    markProject();
+    writeCase('tests/Normal.testcase', '4');
+    writeCase('tests/Huge.testcase', '99999999999999999999999');
+
+    const out = path.join(tmpDir, 'tests', 'New.testcase');
+    const alloc = allocateTestCaseId(out, [tmpDir]);
+
+    // The 23-digit id overflows JS integer precision; it must be ignored so the
+    // generator never emits id="1e+22". Only the safe id 4 counts → next is 5.
+    assert.equal(alloc.id, 5);
+    assert.equal(alloc.basis, 'project-max-plus-1');
+    assert.equal(alloc.highestExistingId, 4);
+  });
+
+  (symlinkSupported ? it : it.skip)('does not read a symlinked .testcase that points outside the allowed roots', () => {
+    markProject();
+    writeCase('tests/Real.testcase', '4');
+
+    // A "secret" project OUTSIDE the allowed root, carrying a deliberately huge id.
+    const secretDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'tcid-secret-')));
+    try {
+      const secretCase = path.join(secretDir, 'Secret.testcase');
+      fs.writeFileSync(
+        secretCase,
+        '<?xml version="1.0"?>\n<testCase guid="11111111-1111-4111-8111-111111111111" id="88888"><steps/></testCase>\n',
+        'utf-8'
+      );
+      fs.symlinkSync(secretCase, path.join(tmpDir, 'tests', 'Link.testcase'));
+
+      const out = path.join(tmpDir, 'tests', 'New.testcase');
+      const alloc = allocateTestCaseId(out, [tmpDir]);
+
+      // The symlink must be skipped: only the in-root id 4 counts → next is 5,
+      // NOT 88889 (which would mean the out-of-root file was read).
+      assert.equal(alloc.id, 5);
+      assert.equal(alloc.highestExistingId, 4);
+    } finally {
+      fs.rmSync(secretDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Follow-up hardening from the adversarial review of **PDX-510** (the `provar_testcase_generate` id allocator, merged in #217). Two findings, both in `src/mcp/utils/testCaseId.ts`.

## Fixes

1. **Path-policy containment (the substantive one).** `maxProjectTestCaseId` walked the project subtree and read **every** `*.testcase` entry, with no allowed-path check on the files it read. A **symlinked** `.testcase` inside the project could therefore pull a root `id` out of a file **outside** the configured `--allowed-paths` — violating the containment `allocateTestCaseId` documents ("the project scan never leaves [the allowed roots]") and the CLAUDE.md path-safety rule. The reviewer demonstrated a working escape. Fix: only read **real files** (`entry.isFile() && !entry.isSymbolicLink()`), so an out-of-root symlinked `.testcase` is skipped. (Directory symlinks were already skipped — `isDirectory()` is false for them.)

2. **Unsafe-integer ids.** A `.testcase` with a numeric id beyond `Number.MAX_SAFE_INTEGER` (≥ ~16 digits) made `max + 1` render in scientific notation, so the generator could emit a malformed `id="1e+22"`. Fix: `readRootTestCaseId` ignores ids that aren't `Number.isSafeInteger`, falling back to the normal precedence.

## Tests

Added to `test/unit/mcp/testCaseId.test.ts`:
- a symlinked `.testcase` pointing outside the allowed roots is ignored (id stays in-root) — **skipped automatically** on hosts/CI without symlink privileges;
- a 23-digit id is ignored when computing the project max.

## Verification

```
yarn compile ... clean
yarn lint ...... clean
mcp-smoke ...... 60/60 PASS
unit suite ..... 1474 passing, 1 pending, 0 failing
```

Behavior on real projects is unchanged — normal files satisfy `isFile()`, and real corpus ids are small. No public-doc impact; `docs/mcp.md` untouched (no tool surface change).

Reviewed adversarially (no Copilot review per current session policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
