### PR TITLE
PDX-512: fix(mcp): correct invalid TryCatchFinally apiId to control.Finally

### DIFF
--- a/docs/PROVAR_TEST_STEP_REFERENCE.md
+++ b/docs/PROVAR_TEST_STEP_REFERENCE.md
@@ -49,7 +49,7 @@
 | ForEach                                          | `com.provar.plugins.bundled.apis.control.ForEach`                        |
 | DoWhile                                          | `com.provar.plugins.bundled.apis.control.DoWhile`                        |
 | WaitFor                                          | `com.provar.plugins.bundled.apis.control.WaitFor`                        |
-| TryCatchFinally                                  | `com.provar.plugins.bundled.apis.control.TryCatchFinally`                |
+| Finally                                          | `com.provar.plugins.bundled.apis.control.Finally`                        |
 | Switch                                           | `com.provar.plugins.bundled.apis.Switch`                                 |
 | Sleep                                            | `com.provar.plugins.bundled.apis.control.Sleep`                          |
 | Fail                                             | `com.provar.plugins.bundled.apis.control.Fail`                           |
@@ -1118,13 +1118,13 @@ Iterates over a list variable. `list` must reference an existing variable. `valu
 </apiCall>
 ```
 
-### TryCatchFinally
+### Finally
 
 Wraps steps with error handling. The `finally` clause always runs, making it the right place for cleanup steps (e.g., delete records created during the test).
 
 ```xml
-<apiCall apiId="com.provar.plugins.bundled.apis.control.TryCatchFinally"
-         name="TryCatchFinally" testItemId="1"
+<apiCall apiId="com.provar.plugins.bundled.apis.control.Finally"
+         name="Finally" testItemId="1"
          title="Try/Catch/Finally">
   <clauses>
     <clause name="try" testItemId="2">
@@ -1616,5 +1616,5 @@ A callable test (used by `CallTest`) declares its interface via `<params>`, `<ou
 - [ ] **Control flow** — `If` has `condition`; `ForEach` has `list` and `valueName`; `WaitFor` has `maxIterations`
 - [ ] **SetValues structure** — `values` argument contains `<value class="valueList">` wrapping `<namedValues>` wrapping `<namedValue>` elements
 - [ ] **Data types** — booleans are string `"true"`/`"false"` inside `valueClass="boolean"`; numbers use `valueClass="decimal"`
-- [ ] **Cleanup** — either `autoCleanup="true"` on the connection, or explicit `ApexDeleteObject` / `TryCatchFinally` finally block
+- [ ] **Cleanup** — either `autoCleanup="true"` on the connection, or explicit `ApexDeleteObject` / `Finally` finally block
 - [ ] **No hallucinated arguments** — see the Common AI Hallucinations table at the top of this doc

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provartesting/provardx-cli",
   "description": "A plugin for the Salesforce CLI to orchestrate testing activities and report quality metrics to Provar Quality Hub",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "mcpName": "io.github.ProvarTesting/provar",
   "license": "BSD-3-Clause",
   "plugins": [

--- a/server.json
+++ b/server.json
@@ -14,12 +14,12 @@
     "url": "https://github.com/ProvarTesting/provardx-cli",
     "source": "github"
   },
-  "version": "1.6.0",
+  "version": "1.6.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@provartesting/provardx-cli",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/mcp/prompts/loopPrompts.ts
+++ b/src/mcp/prompts/loopPrompts.ts
@@ -80,7 +80,7 @@ Follow these steps in order:
    - The first UiWithScreen must use navigate="Always"
    - UiAssert requires columnAssertions, pageAssertions, resultScope, captureAfter, beforeWait, autoRetry
    - Use ApexConnect for the connection step (first step in the test)
-   - Wrap test body in TryCatchFinally if cleanup is needed (ApexDeleteObject in the finally clause)
+   - Wrap test body in a Finally block (try/catch/finally) if cleanup is needed (ApexDeleteObject in the finally clause)
 
 5. **Write the file** — save the XML to the tests/ directory in the Provar project.
    ${projectHint(projectPath)}
@@ -252,7 +252,7 @@ Follow these steps in order:
 
    **Cleanup**
    - [ ] Is cleanup handled? Either autoCleanup=true on the connection, or ApexDeleteObject steps, or
-         a TryCatchFinally with cleanup in the finally clause?
+         a Finally block with cleanup in the finally clause?
 
    **Structure**
    - [ ] Does the first UiWithScreen use navigate="Always" or "IfNecessary"?

--- a/src/mcp/rules/provar_test_step_schema.json
+++ b/src/mcp/rules/provar_test_step_schema.json
@@ -2523,7 +2523,7 @@
       },
 
       "ListCompare": {
-        "apiId": "com.provar.plugins.bundled.apis.list.ListCompareListCompare",
+        "apiId": "com.provar.plugins.bundled.apis.list.ListCompare",
         "description": "Compare two lists",
         "category": "Utility",
         "required_arguments": [

--- a/src/mcp/tools/bestPracticesEngine.ts
+++ b/src/mcp/tools/bestPracticesEngine.ts
@@ -113,7 +113,6 @@ const VALID_API_IDS = new Set<string>([
   'com.provar.plugins.bundled.apis.control.ActualResult',
   'com.provar.plugins.bundled.apis.control.DesignStep',
   'com.provar.plugins.bundled.apis.control.CallTest',
-  'com.provar.plugins.bundled.apis.control.TryCatchFinally',
   // Bundled — database
   'com.provar.plugins.bundled.apis.db.DbConnect',
   'com.provar.plugins.bundled.apis.db.DbDelete',
@@ -237,7 +236,7 @@ function toArr<T>(v: T | T[] | undefined | null): T[] {
 
 /**
  * Recursively collect every <apiCall> element in the parsed tree.
- * Works for flat and deeply nested structures (StepGroup, BDD, TryCatch…).
+ * Works for flat and deeply nested structures (StepGroup, BDD, Finally…).
  */
 function getAllApiCalls(node: XmlNode): XmlNode[] {
   const results: XmlNode[] = [];

--- a/test/unit/mcp/bestPracticesEngine.test.ts
+++ b/test/unit/mcp/bestPracticesEngine.test.ts
@@ -1627,3 +1627,62 @@ ${stepsXml}
     });
   });
 });
+
+// ── reference doc ⇄ validator apiId parity (PDX-512) ──────────────────────────
+// Regression guard: every api ID published in docs/PROVAR_TEST_STEP_REFERENCE.md
+// (served verbatim as an MCP resource) must be recognised by the validator's
+// VALID_API_IDS allow-list. The bogus `...control.TryCatchFinally` slipped
+// through precisely because the doc and the allow-list agreed on the same wrong
+// value, so existing tests stayed green. This ties the two sources together: any
+// future drift fails the build instead of shipping a step Provar cannot load.
+describe('reference doc ⇄ validator apiId parity (PDX-512)', () => {
+  function unknownApiIdViolations(apiId: string): BPViolation[] {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<testCase id="tc-apiid" guid="${GUID_TC}" registryId="tc-apiid" name="ApiId Coverage">
+  <steps>
+    <apiCall guid="${GUID_S1}" apiId="${apiId}" name="Step" testItemId="1"/>
+  </steps>
+</testCase>`;
+    return runBestPractices(xml).violations.filter((v) => v.rule_id === 'API-UNKNOWN-001');
+  }
+
+  it('recognises every apiId documented in PROVAR_TEST_STEP_REFERENCE.md', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const docPath = path.join(here, '..', '..', '..', 'docs', 'PROVAR_TEST_STEP_REFERENCE.md');
+    const doc = fs.readFileSync(docPath, 'utf-8');
+
+    // Reference-table rows are shaped `| Name | `com.provar...` |`; section-header
+    // rows have an empty 2nd cell and are skipped. The captured token keeps any
+    // NitroX `:ms-*` variant suffix so those resolve against the allow-list too.
+    const documented = [...new Set([...doc.matchAll(/^\|[^|]+\|\s*`(com\.provar[^`]+)`\s*\|/gm)].map((m) => m[1]))];
+
+    assert.ok(
+      documented.length >= 50,
+      `Expected to parse >=50 apiIds from the reference table, got ${documented.length} — table format may have changed`
+    );
+
+    const offenders = documented.filter((apiId) => unknownApiIdViolations(apiId).length > 0);
+    assert.deepEqual(
+      offenders,
+      [],
+      `Documented apiIds missing from VALID_API_IDS (doc/validator drift): ${offenders.join(', ')}`
+    );
+  });
+
+  it('still flags the bogus control.TryCatchFinally apiId (the bug this guards)', () => {
+    const vs = unknownApiIdViolations('com.provar.plugins.bundled.apis.control.TryCatchFinally');
+    assert.equal(vs.length, 1, 'API-UNKNOWN-001 must flag the non-existent TryCatchFinally apiId');
+    assert.ok(vs[0].message.includes('TryCatchFinally'), `Violation should name the offending apiId: ${vs[0].message}`);
+  });
+
+  it('accepts the canonical control.Finally apiId', () => {
+    assert.equal(
+      unknownApiIdViolations('com.provar.plugins.bundled.apis.control.Finally').length,
+      0,
+      'control.Finally is the canonical try/catch/finally step and must be recognised'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `com.provar.plugins.bundled.apis.control.TryCatchFinally` does not exist in Provar — the canonical control-flow step is `com.provar.plugins.bundled.apis.control.Finally` (confirmed against a live Provar project and `provar_test_step_schema.json`).
- The bogus id was published in the reference doc (an MCP resource), whitelisted in the `bestPracticesEngine` `VALID_API_IDS` allow-list, and referenced in the loop authoring prompts — so `API-UNKNOWN-001` never flagged it and agents were steered toward generating a step Provar cannot load.
- Also corrected a doubled `list.ListCompareListCompare` apiId in the schema (the correct id, `list.ListCompare`, was already in the doc and allow-list).

## Jira
https://provartesting.atlassian.net/browse/PDX-512

## Changes
- `src/mcp/tools/bestPracticesEngine.ts`: removed the invalid `control.TryCatchFinally` from `VALID_API_IDS` (the correct `control.Finally` was already present); updated a stale doc comment.
- `docs/PROVAR_TEST_STEP_REFERENCE.md`: normalized all 6 `TryCatchFinally` references to `Finally` — table row, section heading, example `apiId` + `name=`, and the cleanup checklist (kept the descriptive `title="Try/Catch/Finally"`).
- `src/mcp/prompts/loopPrompts.ts`: reworded two prose references from `TryCatchFinally` to "a Finally block (try/catch/finally)".
- `src/mcp/rules/provar_test_step_schema.json`: fixed `ListCompareListCompare` → `ListCompare`.
- `test/unit/mcp/bestPracticesEngine.test.ts`: added a data-driven parity test that extracts **every** apiId documented in `PROVAR_TEST_STEP_REFERENCE.md` and asserts the validator raises no `API-UNKNOWN-001` for any of them — locking the reference doc to the allow-list so the two can never silently drift again — plus explicit regressions that the bogus `TryCatchFinally` is now flagged and that `control.Finally` passes.
- `package.json` + `server.json`: bumped version 1.6.0 → 1.6.1 (kept in sync).

## Test plan
- [x] `yarn compile` passes
- [x] unit tests pass (1482 passing; 3 new PDX-512 tests green)
- [x] `yarn lint` passes
- [x] `mcp-smoke.cjs`: 29/31 PASS — the 2 failures (`provar_automation_compile`, `provar_automation_testrun`) are pre-existing environmental timeouts (require a live Provar runtime + Salesforce org), unrelated to this change

## Public-docs follow-up
`docs/PROVAR_TEST_STEP_REFERENCE.md` is an MCP resource served verbatim to agents. If the customer-facing docs (`provar-mcp-public-docs`, University of Provar course) mirror the TryCatchFinally/ListCompare step references, the Provar team should update those manually.